### PR TITLE
feat(dom): add support for animation frames

### DIFF
--- a/src/Window.ts
+++ b/src/Window.ts
@@ -105,4 +105,20 @@ export default class Window extends EventTarget {
 	 * Disposes the window.
 	 */
 	public dispose(): void {}
+
+	/**
+	 * Mock animation frames with timeouts
+	 */
+	public requestAnimationFrame(callback: (time: number) => void): number {
+		setTimeout(callback, 0);
+
+		return 2;
+	}
+
+	/**
+	 * Mock animation frames with timeouts
+	 */
+	public cancelAnimationFrame(handle): void {
+		return clearTimeout(handle);
+	}
 }

--- a/test/dom-implementation/DOMImplementation.test.ts
+++ b/test/dom-implementation/DOMImplementation.test.ts
@@ -17,4 +17,19 @@ describe('DOMImplementation', () => {
 			expect(document.defaultView).toBe(window);
 		});
 	});
+
+	describe('requestAnimationFrame()', () => {
+		test('Requesting an animation frame', () => {
+			const frame = window.requestAnimationFrame(() => 'Frame');
+			expect(Number.isInteger(frame)).toBeTruthy();
+			expect(frame).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe('cancelAnimationFrame()', () => {
+		test('Cancel an animation frame', () => {
+			const res = window.cancelAnimationFrame(2);
+			expect(res).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
This adds animation frame support adding `requestAnimationFrame` and `cancelAnimationFrame` functions to the window

ref #9