### PR TITLE
Add support for prepend and append

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -433,9 +433,9 @@
 			"dev": true
 		},
 		"@types/he": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/he/-/he-1.1.0.tgz",
-			"integrity": "sha512-HyiLOiJhclRBPzcbYrNThdi0JOdq7bT4hq9jFBPQk4HGjzkwYVQnMj9IDi7qvYkg9QTly2oZ9kjm4j7d8Ic9eA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/he/-/he-1.1.1.tgz",
+			"integrity": "sha512-jpzrsR1ns0n3kyWt92QfOUQhIuJGQ9+QGa7M62rO6toe98woQjnsnzjdMtsQXCdvjjmqjS2ZBCC7xKw0cdzU+Q==",
 			"dev": true
 		},
 		"@types/istanbul-lib-coverage": {

--- a/src/nodes/basic-types/node/Node.ts
+++ b/src/nodes/basic-types/node/Node.ts
@@ -268,6 +268,23 @@ export default class Node extends EventTarget {
 	}
 
 	/**
+	 * Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
+	 */
+	public prepend(...nodes: (Node | string)[]): void {
+		const originalFirstChild = this.firstChild;
+		nodes.forEach(item =>
+			this.insertBefore(typeof item === 'string' ? this.ownerDocument.createTextNode(item) : item, originalFirstChild)
+		);
+	}
+
+	/**
+	 * Inserts nodes after the last child of node, while replacing strings in nodes with equivalent Text nodes.
+	 */
+	public append(...nodes: (Node | string)[]): void {
+		nodes.forEach(item => this.appendChild(typeof item === 'string' ? this.ownerDocument.createTextNode(item) : item));
+	}
+
+	/**
 	 * Append a child node to childNodes.
 	 *
 	 * @param  {Node} node Node to append.

--- a/test/element/Element.test.ts
+++ b/test/element/Element.test.ts
@@ -1,12 +1,57 @@
-import Element from '../../src/nodes/basic-types/element/Element';
+import Window from '../../lib/Window';
+import Element from '../../lib/nodes/basic-types/element/Element';
 
-describe('HTMLParser', () => {
+describe('Element', () => {
 	describe('hasAttribute', () => {
 		test('Returns true for the existing attribute.', () => {
 			const toTest = new Element();
 			const attributeName = 'test';
 			toTest.setAttribute(attributeName, 'foo');
 			expect(toTest.hasAttribute(attributeName)).toBeTruthy();
+		});
+	});
+
+	describe('prepend', () => {
+		test('should add element at the beginning', () => {
+			// given
+			const document = new Window().document;
+			const baseChild = document.createElement('div');
+			const newChild = document.createElement('p');
+			// system under test
+			const toTest = document.createElement('div');
+			toTest.appendChild(baseChild);
+
+			// when
+			toTest.prepend(newChild, 'txt');
+
+			// then
+			expect(toTest.children).toHaveLength(2);
+			expect(toTest.childNodes).toHaveLength(3);
+			expect(toTest.childNodes[0]).toBe(newChild);
+			expect(toTest.childNodes[1]).toHaveProperty('textContent', 'txt');
+			expect(toTest.childNodes[2]).toBe(baseChild);
+		});
+	});
+
+	describe('append', () => {
+		test('should add elements at the end', () => {
+			// given
+			const document = new Window().document;
+			const baseChild = document.createElement('div');
+			const newChild = document.createElement('p');
+			// system under test
+			const toTest = document.createElement('div');
+			toTest.appendChild(baseChild);
+
+			// when
+			toTest.append(newChild, 'txt');
+
+			// then
+			expect(toTest.children).toHaveLength(2);
+			expect(toTest.childNodes).toHaveLength(3);
+			expect(toTest.childNodes[0]).toBe(baseChild);
+			expect(toTest.childNodes[1]).toBe(newChild);
+			expect(toTest.childNodes[2]).toHaveProperty('textContent', 'txt');
 		});
 	});
 });


### PR DESCRIPTION
[`prepend`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/prepend) and [`append`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append) API for adding multiple nodes and text nodes at once.