### PR TITLE
sets target on event when dispatched

### DIFF
--- a/src/event/EventTarget.ts
+++ b/src/event/EventTarget.ts
@@ -42,8 +42,12 @@ export default abstract class EventTarget {
 		let returnValue = true;
 
 		if (this._listeners[event.type]) {
+			const newTarget = Object.create(event)
+			// @ts-ignore internally the target can be set but it cannot be modified in user code
+			newTarget.target = this
+
 			for (const listener of this._listeners[event.type]) {
-				listener(event);
+				listener(newTarget);
 				if (event.cancelable && event.defaultPrevented) {
 					returnValue = false;
 				}

--- a/src/event/EventTarget.ts
+++ b/src/event/EventTarget.ts
@@ -12,7 +12,7 @@ export default abstract class EventTarget {
 	 * @param {string} type Event type.
 	 * @param {function} listener Listener.
 	 */
-	public addEventListener (type: string, listener: (event: Event) => void): void {
+	public addEventListener(type: string, listener: (event: Event) => void): void {
 		this._listeners[type] = this._listeners[type] || []
 		this._listeners[type].push(listener)
 	}
@@ -23,7 +23,7 @@ export default abstract class EventTarget {
 	 * @param {string} type Event type.
 	 * @param {function} listener Listener.
 	 */
-	public removeEventListener (type: string, listener: (event: Event) => void): void {
+	public removeEventListener(type: string, listener: (event: Event) => void): void {
 		if (this._listeners[type]) {
 			const index = this._listeners[type].indexOf(listener)
 			if (index !== -1) {
@@ -38,12 +38,16 @@ export default abstract class EventTarget {
 	 * @param {Event} event Event.
 	 * @return {boolean} The return value is false if event is cancelable and at least one of the event handlers which handled this event called Event.preventDefault()
 	 */
-	public dispatchEvent (event: Event): boolean {
+	public dispatchEvent(event: Event): boolean {
 		let returnValue = true
 
 		if (this._listeners[event.type]) {
-			// @ts-ignore internally the target can be set but it cannot be modified in user code
-			event.target = this
+			if (!event.target) {
+				// @ts-ignore read-only to user code
+				event.target = this
+			}
+			// @ts-ignore read-only to user code
+			event.currentTarget = this
 
 			for (const listener of this._listeners[event.type]) {
 				listener(event)

--- a/src/event/EventTarget.ts
+++ b/src/event/EventTarget.ts
@@ -1,10 +1,10 @@
-import Event from './Event';
+import Event from './Event'
 
 /**
  * Handles events.
  */
 export default abstract class EventTarget {
-	private readonly _listeners: { [k: string]: ((event: Event) => void)[] } = {};
+	private readonly _listeners: { [k: string]: ((event: Event) => void)[] } = {}
 
 	/**
 	 * Adds an event listener.
@@ -12,9 +12,9 @@ export default abstract class EventTarget {
 	 * @param {string} type Event type.
 	 * @param {function} listener Listener.
 	 */
-	public addEventListener(type: string, listener: (event: Event) => void): void {
-		this._listeners[type] = this._listeners[type] || [];
-		this._listeners[type].push(listener);
+	public addEventListener (type: string, listener: (event: Event) => void): void {
+		this._listeners[type] = this._listeners[type] || []
+		this._listeners[type].push(listener)
 	}
 
 	/**
@@ -23,11 +23,11 @@ export default abstract class EventTarget {
 	 * @param {string} type Event type.
 	 * @param {function} listener Listener.
 	 */
-	public removeEventListener(type: string, listener: (event: Event) => void): void {
+	public removeEventListener (type: string, listener: (event: Event) => void): void {
 		if (this._listeners[type]) {
-			const index = this._listeners[type].indexOf(listener);
+			const index = this._listeners[type].indexOf(listener)
 			if (index !== -1) {
-				this._listeners[type].splice(index);
+				this._listeners[type].splice(index)
 			}
 		}
 	}
@@ -38,25 +38,24 @@ export default abstract class EventTarget {
 	 * @param {Event} event Event.
 	 * @return {boolean} The return value is false if event is cancelable and at least one of the event handlers which handled this event called Event.preventDefault()
 	 */
-	public dispatchEvent(event: Event): boolean {
-		let returnValue = true;
+	public dispatchEvent (event: Event): boolean {
+		let returnValue = true
 
 		if (this._listeners[event.type]) {
-			const newTarget = Object.create(event)
 			// @ts-ignore internally the target can be set but it cannot be modified in user code
-			newTarget.target = this
+			event.target = this
 
 			for (const listener of this._listeners[event.type]) {
-				listener(newTarget);
+				listener(event)
 				if (event.cancelable && event.defaultPrevented) {
-					returnValue = false;
+					returnValue = false
 				}
 				if (event._immediatePropagationStopped) {
-					return returnValue;
+					return returnValue
 				}
 			}
 		}
 
-		return returnValue;
+		return returnValue
 	}
 }

--- a/test/event/EventTarget.test.ts
+++ b/test/event/EventTarget.test.ts
@@ -3,7 +3,7 @@ import Event from '../../lib/event/Event';
 import CustomEvent from '../../lib/event/CustomEvent';
 
 const EVENT_TYPE = 'click';
-class TestEventTarget extends EventTarget {}
+class TestEventTarget extends EventTarget { }
 
 describe('EventTarget', () => {
 	let eventTarget: EventTarget;
@@ -21,7 +21,10 @@ describe('EventTarget', () => {
 			const dispatchedEvent = new Event(EVENT_TYPE);
 			eventTarget.addEventListener(EVENT_TYPE, listener);
 			eventTarget.dispatchEvent(dispatchedEvent);
-			expect(recievedEvent).toBe(dispatchedEvent);
+
+			for (const prop in dispatchedEvent) {
+				expect(recievedEvent[prop]).toEqual(recievedEvent[prop])
+			}
 		});
 
 		test('Triggers a custom event and triggers it when calling dispatchEvent().', () => {
@@ -33,7 +36,11 @@ describe('EventTarget', () => {
 			const dispatchedEvent = new CustomEvent(EVENT_TYPE, { detail: DETAIL });
 			eventTarget.addEventListener(EVENT_TYPE, listener);
 			eventTarget.dispatchEvent(dispatchedEvent);
-			expect(recievedEvent).toBe(dispatchedEvent);
+
+			for (const prop in dispatchedEvent) {
+				expect(recievedEvent[prop]).toEqual(recievedEvent[prop])
+			}
+			expect(recievedEvent.type).toEqual(EVENT_TYPE)
 			expect(recievedEvent.detail).toBe(DETAIL);
 		});
 	});
@@ -49,6 +56,25 @@ describe('EventTarget', () => {
 			eventTarget.removeEventListener(EVENT_TYPE, listener);
 			eventTarget.dispatchEvent(dispatchedEvent);
 			expect(recievedEvent).toBe(null);
+		});
+	});
+
+	describe('dispatchEvent()', () => {
+		test('Sets target to the EventTarget that was asked to dispatch the event.', () => {
+			let recievedEvent: Event = null;
+			const listener = (event: Event): void => {
+				recievedEvent = event;
+			};
+			const dispatchedEvent = new Event(EVENT_TYPE);
+			eventTarget.addEventListener(EVENT_TYPE, listener);
+			eventTarget.dispatchEvent(dispatchedEvent);
+			expect(recievedEvent.target).toBe(eventTarget)
+			for (const prop in dispatchedEvent) {
+				expect(recievedEvent[prop]).toEqual(recievedEvent[prop])
+			}
+
+			// leaves src event untouched
+			expect(dispatchedEvent.target).toBe(null)
 		});
 	});
 });

--- a/test/event/EventTarget.test.ts
+++ b/test/event/EventTarget.test.ts
@@ -1,80 +1,74 @@
-import EventTarget from '../../lib/event/EventTarget';
-import Event from '../../lib/event/Event';
-import CustomEvent from '../../lib/event/CustomEvent';
+import EventTarget from '../../lib/event/EventTarget'
+import Event from '../../lib/event/Event'
+import CustomEvent from '../../lib/event/CustomEvent'
 
-const EVENT_TYPE = 'click';
-class TestEventTarget extends EventTarget { }
+const EVENT_TYPE = 'click'
+class TestEventTarget extends EventTarget {}
 
 describe('EventTarget', () => {
-	let eventTarget: EventTarget;
+	let eventTarget: EventTarget
 
 	beforeEach(() => {
-		eventTarget = new TestEventTarget();
-	});
+		eventTarget = new TestEventTarget()
+	})
 
 	describe('addEventListener()', () => {
 		test('Adds an event listener and triggers it when calling dispatchEvent().', () => {
-			let recievedEvent: Event = null;
+			let recievedEvent: Event = null
 			const listener = (event: Event): void => {
-				recievedEvent = event;
-			};
-			const dispatchedEvent = new Event(EVENT_TYPE);
-			eventTarget.addEventListener(EVENT_TYPE, listener);
-			eventTarget.dispatchEvent(dispatchedEvent);
-
-			for (const prop in dispatchedEvent) {
-				expect(recievedEvent[prop]).toEqual(recievedEvent[prop])
+				recievedEvent = event
 			}
-		});
+			const dispatchedEvent = new Event(EVENT_TYPE)
+			eventTarget.addEventListener(EVENT_TYPE, listener)
+			eventTarget.dispatchEvent(dispatchedEvent)
+
+			expect(recievedEvent).toBe(dispatchedEvent)
+		})
 
 		test('Triggers a custom event and triggers it when calling dispatchEvent().', () => {
-			let recievedEvent: CustomEvent = null;
-			const DETAIL = {};
+			let recievedEvent: CustomEvent = null
+			const DETAIL = {}
 			const listener = (event: CustomEvent): void => {
-				recievedEvent = event;
-			};
-			const dispatchedEvent = new CustomEvent(EVENT_TYPE, { detail: DETAIL });
-			eventTarget.addEventListener(EVENT_TYPE, listener);
-			eventTarget.dispatchEvent(dispatchedEvent);
-
-			for (const prop in dispatchedEvent) {
-				expect(recievedEvent[prop]).toEqual(recievedEvent[prop])
+				recievedEvent = event
 			}
+			const dispatchedEvent = new CustomEvent(EVENT_TYPE, { detail: DETAIL })
+			eventTarget.addEventListener(EVENT_TYPE, listener)
+			eventTarget.dispatchEvent(dispatchedEvent)
+
+			expect(recievedEvent).toBe(dispatchedEvent)
 			expect(recievedEvent.type).toEqual(EVENT_TYPE)
-			expect(recievedEvent.detail).toBe(DETAIL);
-		});
-	});
+			expect(recievedEvent.detail).toBe(DETAIL)
+		})
+	})
 
 	describe('removeEventListener()', () => {
 		test('Removes an event listener and does not call it when calling dispatchEvent().', () => {
-			let recievedEvent: Event = null;
+			let recievedEvent: Event = null
 			const listener = (event: Event): void => {
-				recievedEvent = event;
-			};
-			const dispatchedEvent = new Event(EVENT_TYPE);
-			eventTarget.addEventListener(EVENT_TYPE, listener);
-			eventTarget.removeEventListener(EVENT_TYPE, listener);
-			eventTarget.dispatchEvent(dispatchedEvent);
-			expect(recievedEvent).toBe(null);
-		});
-	});
+				recievedEvent = event
+			}
+			const dispatchedEvent = new Event(EVENT_TYPE)
+			eventTarget.addEventListener(EVENT_TYPE, listener)
+			eventTarget.removeEventListener(EVENT_TYPE, listener)
+			eventTarget.dispatchEvent(dispatchedEvent)
+			expect(recievedEvent).toBe(null)
+		})
+	})
 
 	describe('dispatchEvent()', () => {
 		test('Sets target to the EventTarget that was asked to dispatch the event.', () => {
-			let recievedEvent: Event = null;
+			let recievedEvent: Event = null
 			const listener = (event: Event): void => {
-				recievedEvent = event;
-			};
-			const dispatchedEvent = new Event(EVENT_TYPE);
-			eventTarget.addEventListener(EVENT_TYPE, listener);
-			eventTarget.dispatchEvent(dispatchedEvent);
-			expect(recievedEvent.target).toBe(eventTarget)
-			for (const prop in dispatchedEvent) {
-				expect(recievedEvent[prop]).toEqual(recievedEvent[prop])
+				recievedEvent = event
 			}
+			const dispatchedEvent = new Event(EVENT_TYPE)
+			eventTarget.addEventListener(EVENT_TYPE, listener)
+			eventTarget.dispatchEvent(dispatchedEvent)
+			expect(recievedEvent.target).toBe(eventTarget)
+			expect(recievedEvent).toBe(dispatchedEvent)
 
-			// leaves src event untouched
-			expect(dispatchedEvent.target).toBe(null)
-		});
-	});
-});
+			// directly modifies the dispatched event
+			expect(dispatchedEvent.target).toBe(eventTarget)
+		})
+	})
+})


### PR DESCRIPTION
event.target was always null, but I think it ought to be the EventTarget itself.

Rather than just assign target to the EventTarget on the event, I'm creating a new object using Object.create and assigning target to it.

I'm not sure what the spec says should be done in this case but it felt like modifying the passed argument was not the right thing to do.

If you'd rather I just change the incoming event let me know and I'll strip out the cloning logic (and test modifications for it).