### PR TITLE
#131@patch: Removes white space trimming in XMLParser. It was not pos…

### DIFF
--- a/packages/happy-dom/src/nodes/basic/document/Document.ts
+++ b/packages/happy-dom/src/nodes/basic/document/Document.ts
@@ -549,13 +549,14 @@ export default class Document extends Node implements IDocument {
 	 * Imports a node.
 	 *
 	 * @param node Node to import.
+	 * @param [deep=false] Set to "true" if the clone should be deep.
 	 * @param Imported node.
 	 */
-	public importNode(node: Node): Node {
+	public importNode(node: Node, deep = false): Node {
 		if (!(node instanceof Node)) {
 			throw new Error('Parameter 1 was not of type Node.');
 		}
-		const clone = node.cloneNode(true);
+		const clone = node.cloneNode(deep);
 		// @ts-ignore
 		clone.ownerDocument = this;
 		return clone;

--- a/packages/happy-dom/src/nodes/basic/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/basic/html-element/HTMLElement.ts
@@ -8,17 +8,35 @@ import CSSStyleDeclarationFactory from '../../../css/CSSStyleDeclarationFactory'
  * HTMLElement.
  */
 export default class HTMLElement extends Element implements IHTMLElement {
-	public tabIndex = -1;
-	public offsetHeight = 0;
-	public offsetWidth = 0;
-	public offsetLeft = 0;
-	public offsetTop = 0;
-	public clientHeight = 0;
-	public clientWidth = 0;
+	public readonly offsetHeight = 0;
+	public readonly offsetWidth = 0;
+	public readonly offsetLeft = 0;
+	public readonly offsetTop = 0;
+	public readonly clientHeight = 0;
+	public readonly clientWidth = 0;
 	private _style: {
 		cssText: string;
 		cssStyleDeclaration: CSSStyleDeclaration;
 	} = null;
+
+	/**
+	 * Returns tab index.
+	 *
+	 * @return Tab index.
+	 */
+	public get tabIndex(): number {
+		const tabIndex = this.getAttribute('tabindex');
+		return tabIndex !== null ? Number(tabIndex) : -1;
+	}
+
+	/**
+	 * Returns tab index.
+	 *
+	 * @param tabIndex Tab index.
+	 */
+	public set tabIndex(tabIndex: number) {
+		this.setAttribute('tabindex', String(tabIndex));
+	}
 
 	/**
 	 * Returns inner text.
@@ -91,26 +109,5 @@ export default class HTMLElement extends Element implements IHTMLElement {
 		event.target = this;
 		event.currentTarget = this;
 		this.dispatchEvent(event);
-	}
-
-	/**
-	 * Clones a node.
-	 *
-	 * @override
-	 * @param [deep=false] "true" to clone deep.
-	 * @return Cloned node.
-	 */
-	public cloneNode(deep = false): HTMLElement {
-		const clone = <HTMLElement>super.cloneNode(deep);
-
-		clone.tabIndex = this.tabIndex;
-		clone.offsetHeight = this.offsetHeight;
-		clone.offsetWidth = this.offsetWidth;
-		clone.offsetLeft = this.offsetLeft;
-		clone.offsetTop = this.offsetTop;
-		clone.clientHeight = this.clientHeight;
-		clone.clientWidth = this.clientWidth;
-
-		return clone;
 	}
 }

--- a/packages/happy-dom/src/xml-parser/XMLParser.ts
+++ b/packages/happy-dom/src/xml-parser/XMLParser.ts
@@ -33,9 +33,7 @@ export default class XMLParser {
 		let lastTextIndex = 0;
 		let match: RegExpExecArray;
 
-		data = data.trim();
-
-		while ((match = markupRegexp.exec(data.trim()))) {
+		while ((match = markupRegexp.exec(data))) {
 			const tagName = match[2].toLowerCase();
 			const isStartTag = !match[1];
 


### PR DESCRIPTION
…sible to set the deep parameter to Document.importNode(). The properties tabIndex, offsetHeight, offsetWidth, offsetLeft, offsetTop, clientHeight, clientWidth should not be cloned HTMLElement.cloneNode().