### PR TITLE
Adding support for `Document.adoptNode` method.

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -594,4 +594,20 @@ export default class Document extends Node implements IDocument {
 		(<Document>clone.ownerDocument) = this;
 		return clone;
 	}
+
+	/**
+	 * Adopts a node.
+	 *
+	 * @param node Node to adopt.
+	 * @return Adopted node.
+	 */
+	public adoptNode(node: INode): INode {
+		if (!(node instanceof Node)) {
+			throw new DOMException('Parameter 1 was not of type Node.');
+		}
+
+		const adopted = node.parentNode ? node.parentNode.removeChild(node) : node;
+		(<Document>adopted.ownerDocument) = this;
+		return adopted;
+	}
 }

--- a/packages/happy-dom/src/nodes/document/IDocument.ts
+++ b/packages/happy-dom/src/nodes/document/IDocument.ts
@@ -142,4 +142,12 @@ export default interface IDocument extends IParentNode {
 	 * @return Cloned node.
 	 */
 	cloneNode(deep: boolean): IDocument;
+
+	/**
+	 * Adopts a node.
+	 *
+	 * @param node Node to adopt.
+	 * @return Adopted node.
+	 */
+	adoptNode(node: INode): INode;
 }

--- a/packages/happy-dom/src/nodes/node/INode.ts
+++ b/packages/happy-dom/src/nodes/node/INode.ts
@@ -20,7 +20,7 @@ export default interface INode extends IEventTarget {
 	disconnectedCallback?(): void;
 	cloneNode(deep: boolean): INode;
 	appendChild(node: INode): INode;
-	removeChild(node: INode): void;
+	removeChild(node: INode): INode;
 	insertBefore(newNode: INode, referenceNode?: INode | null): INode;
 	replaceChild(newChild: INode, oldChild: INode): INode;
 	toString(): string;

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -272,8 +272,9 @@ export default class Node extends EventTarget implements INode {
 	 * Remove Child element from childNodes array.
 	 *
 	 * @param node Node to remove
+	 * @return Removed node.
 	 */
-	public removeChild(node: INode): void {
+	public removeChild(node: INode): INode {
 		const index = this.childNodes.indexOf(node);
 
 		if (index === -1) {
@@ -298,6 +299,8 @@ export default class Node extends EventTarget implements INode {
 				}
 			}
 		}
+
+		return node;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -728,4 +728,27 @@ describe('Document', () => {
 			expect(clone2.children[0].outerHTML).toBe('<div class="className"></div>');
 		});
 	});
+
+	describe('adoptNode()', () => {
+		test('Removes node from its original document and sets the ownerDocument to be the current document.', () => {
+			const originalDocument = new Window().document;
+			const node = originalDocument.createElement('div');
+			originalDocument.body.append(node);
+			const adopted = <Element>document.adoptNode(node);
+
+			expect(adopted.tagName).toBe('DIV');
+			expect(adopted instanceof HTMLElement).toBe(true);
+			expect(adopted.ownerDocument).toBe(document);
+			expect(originalDocument.querySelector('div')).toBe(null);
+		});
+
+		test('Just change the ownerDocument of the node to be the current document, if the original document does not have node inside tree.', () => {
+			const node = new Window().document.createElement('div');
+			const adopted = <Element>document.adoptNode(node);
+
+			expect(adopted.tagName).toBe('DIV');
+			expect(adopted instanceof HTMLElement).toBe(true);
+			expect(adopted.ownerDocument).toBe(document);
+		});
+	});
 });

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -311,7 +311,7 @@ describe('Node', () => {
 	});
 
 	describe('removeChild()', () => {
-		test('Removes a child Node from its parent.', () => {
+		test('Removes a child Node from its parent and returns a reference to a removed node.', () => {
 			const child = document.createElement('span');
 			const parent = document.createElement('div');
 
@@ -325,11 +325,12 @@ describe('Node', () => {
 
 			expect(child.isConnected).toBe(true);
 
-			parent.removeChild(child);
+			const removed = parent.removeChild(child);
 
 			expect(child.parentNode).toBe(null);
 			expect(parent.childNodes).toEqual([]);
 			expect(child.isConnected).toBe(false);
+			expect(removed).toEqual(child);
 		});
 	});
 


### PR DESCRIPTION
Hello. At first, thank you for your great work!
I noticed that the `Document` object does not have an `adoptNode` method, so I tried to add it. Also, there is an inconsistency in the `Node.removeChild` method - it should return the removed node.

- [Issue #244]
- [Issue #243 ]

> When I tried to compile the project I got a lot of TS errors. Thus I had no possibility to test it :( So I do not ask for a merging of the pull request, but a review.