### PR TITLE
#271@patch: Element.observedAttributes should not be a getter initial…

### DIFF
--- a/packages/happy-dom/src/custom-element/CustomElementRegistry.ts
+++ b/packages/happy-dom/src/custom-element/CustomElementRegistry.ts
@@ -35,8 +35,9 @@ export default class CustomElementRegistry {
 			extends: options && options.extends ? options.extends.toLowerCase() : null
 		};
 
+		// observedAttributes should only be called once by CustomElementRegistry (see #117)
 		if (elementClass.prototype.attributeChangedCallback) {
-			elementClass._observedAttributes = elementClass.observedAttributes || null;
+			elementClass._observedAttributes = elementClass.observedAttributes;
 		}
 
 		if (this._callbacks[name]) {

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -38,16 +38,10 @@ export default class Element extends Node implements IElement {
 	public children: IHTMLCollection<IElement> = HTMLCollectionFactory.create();
 	public _attributes: { [k: string]: Attr } = {};
 	public readonly namespaceURI: string = null;
-	public static _observedAttributes: string[] = null;
-
-	/**
-	 * Returns a list of observed attributes.
-	 *
-	 * @return Observered attributes.
-	 */
-	public static get observedAttributes(): string[] {
-		return undefined;
-	}
+	// observedAttributes should only be called once by CustomElementRegistry (see #117)
+	// CustomElementRegistry will therefore populate _observedAttributes when CustomElementRegistry.define() is called
+	public static _observedAttributes: string[];
+	public static observedAttributes: string[];
 
 	/**
 	 * Returns ID.


### PR DESCRIPTION
…ly. It should be defined by classes implementing Element. This caused an issue in Stencil that defines this property in a different way compared to other frameworks.