### PR TITLE
#290@patch: The method window.customElements.get() should return unde…

### DIFF
--- a/packages/happy-dom/src/custom-element/CustomElementRegistry.ts
+++ b/packages/happy-dom/src/custom-element/CustomElementRegistry.ts
@@ -57,7 +57,7 @@ export default class CustomElementRegistry {
 	 */
 	public get(tagName: string): typeof HTMLElement {
 		const name = tagName.toLowerCase();
-		return this._registry[name] ? this._registry[name].elementClass : null;
+		return this._registry[name] ? this._registry[name].elementClass : undefined;
 	}
 
 	/**

--- a/packages/happy-dom/test/custom-element/CustomElementRegistry.test.ts
+++ b/packages/happy-dom/test/custom-element/CustomElementRegistry.test.ts
@@ -41,6 +41,17 @@ describe('CustomElementRegistry', () => {
 		});
 	});
 
+	describe('get()', () => {
+		it('Returns element class if the tag name has been defined..', () => {
+			customElements.define('custom-element', CustomElement);
+			expect(customElements.get('custom-element')).toBe(CustomElement);
+		});
+
+		it('Returns undefined if the tag name has not been defined.', () => {
+			expect(customElements.get('custom-element')).toBe(undefined);
+		});
+	});
+
 	describe('whenDefined()', () => {
 		it('Returns a promise which is fulfilled when an element is defined.', done => {
 			customElements.whenDefined('custom-element').then(done);


### PR DESCRIPTION
…fined when an element tag name has not been defined.