### PR TITLE
#313@minor: Adds support for EventTarget.attachEvent. Adds support fo…

### DIFF
--- a/packages/happy-dom/package.json
+++ b/packages/happy-dom/package.json
@@ -27,7 +27,7 @@
 		"watch": "tsc -w --preserveWatchOutput",
 		"lint": "eslint --ignore-path .gitignore --max-warnings 0 .",
 		"lint:fix": "eslint --ignore-path .gitignore --max-warnings 0 --fix .",
-		"test": "jest",
+		"test": "jest --runInBand",
 		"test:coverage": "jest --collectCoverage",
 		"test:watch": "jest --watch",
 		"test:update-snapshot": "jest --updateSnapshot",

--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -67,4 +67,16 @@ export default abstract class EventTarget implements IEventTarget {
 
 		return !(event.cancelable && event.defaultPrevented);
 	}
+
+	/**
+	 * Adds an event listener.
+	 *
+	 * This is only supported by IE8- and Opera, but for some reason React uses it and calls it, so therefore we will keep support for it until they stop using it.
+	 *
+	 * @param type Event type.
+	 * @param listener Listener.
+	 */
+	public attachEvent(type: string, listener: ((event: Event) => void) | IEventListener): void {
+		this.addEventListener(type.replace('on', ''), listener);
+	}
 }

--- a/packages/happy-dom/src/event/NonImplementedEventTypes.ts
+++ b/packages/happy-dom/src/event/NonImplementedEventTypes.ts
@@ -25,7 +25,6 @@ export default [
 	'OverconstrainedError',
 	'PageTransitionEvent',
 	'PaymentRequestUpdateEvent',
-	'PointerEvent',
 	'PopStateEvent',
 	'ProgressEvent',
 	'RelatedEvent',

--- a/packages/happy-dom/src/event/events/IPointerEventInit.ts
+++ b/packages/happy-dom/src/event/events/IPointerEventInit.ts
@@ -1,0 +1,14 @@
+import IMouseEventInit from './IMouseEventInit';
+
+export default interface IPointerEventInit extends IMouseEventInit {
+	pointerId?: number;
+	width?: number;
+	height?: number;
+	pressure?: number;
+	tangentialPressure?: number;
+	tiltX?: number;
+	tiltY?: number;
+	twist?: number;
+	pointerType?: string;
+	isPrimary?: boolean;
+}

--- a/packages/happy-dom/src/event/events/PointerEvent.ts
+++ b/packages/happy-dom/src/event/events/PointerEvent.ts
@@ -1,0 +1,42 @@
+import MouseEvent from './MouseEvent';
+import IPointerEventInit from './IPointerEventInit';
+
+/**
+ *
+ */
+export default class PointerEvent extends MouseEvent {
+	public readonly pointerId: number = 0;
+	public readonly width: number = 0;
+	public readonly height: number = 0;
+	public readonly pressure: number = 0;
+	public readonly tangentialPressure: number = 0;
+	public readonly tiltX: number = 0;
+	public readonly tiltY: number = 0;
+	public readonly twist: number = 0;
+	public readonly pointerType: string = '';
+	public readonly isPrimary: boolean = false;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type Event type.
+	 * @param [eventInit] Event init.
+	 */
+	constructor(type: string, eventInit: IPointerEventInit = null) {
+		super(type, eventInit);
+
+		if (eventInit) {
+			this.pointerId = eventInit.pointerId !== undefined ? eventInit.pointerId : 0;
+			this.width = eventInit.width !== undefined ? eventInit.width : 0;
+			this.height = eventInit.height !== undefined ? eventInit.height : 0;
+			this.pressure = eventInit.pressure !== undefined ? eventInit.pressure : 0;
+			this.tangentialPressure =
+				eventInit.tangentialPressure !== undefined ? eventInit.tangentialPressure : 0;
+			this.tiltX = eventInit.tiltX !== undefined ? eventInit.tiltX : 0;
+			this.tiltY = eventInit.tiltY !== undefined ? eventInit.tiltY : 0;
+			this.twist = eventInit.twist !== undefined ? eventInit.twist : 0;
+			this.pointerType = eventInit.pointerType !== undefined ? eventInit.pointerType : '';
+			this.isPrimary = eventInit.isPrimary || eventInit.isPrimary;
+		}
+	}
+}

--- a/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
+++ b/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
@@ -13,6 +13,7 @@ import HTMLCollectionFactory from '../element/HTMLCollectionFactory';
 export default class DocumentFragment extends Node implements IDocumentFragment {
 	public nodeType = Node.DOCUMENT_FRAGMENT_NODE;
 	public readonly children: IHTMLCollection<IElement> = HTMLCollectionFactory.create();
+	public _rootNode: INode = this;
 
 	/**
 	 * Last element child.

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -44,8 +44,9 @@ export default class Document extends Node implements IDocument {
 	public implementation: DOMImplementation;
 	public readonly children: IHTMLCollection<IElement> = HTMLCollectionFactory.create();
 	public readonly readyState = DocumentReadyStateEnum.interactive;
+	public readonly isConnected: boolean = true;
 	public _readyStateManager: DocumentReadyStateManager = null;
-	protected _isConnected = true;
+	public _activeElement: IHTMLElement = null;
 	protected _isFirstWrite = true;
 	protected _isFirstWriteAfterOpen = false;
 	private _defaultView: Window = null;
@@ -207,6 +208,15 @@ export default class Document extends Node implements IDocument {
 			}
 		}
 		return styleSheets;
+	}
+
+	/**
+	 * Returns active element.
+	 *
+	 * @returns Active element.
+	 */
+	public get activeElement(): IHTMLElement {
+		return this._activeElement || this.body || this.documentElement || null;
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/document/IDocument.ts
+++ b/packages/happy-dom/src/nodes/document/IDocument.ts
@@ -23,6 +23,7 @@ export default interface IDocument extends IParentNode {
 	readonly doctype: IDocumentType;
 	readonly body: IHTMLElement;
 	readonly head: IHTMLElement;
+	readonly activeElement: IHTMLElement;
 
 	/**
 	 * Replaces the document HTML with new HTML.

--- a/packages/happy-dom/src/nodes/element/IElement.ts
+++ b/packages/happy-dom/src/nodes/element/IElement.ts
@@ -153,6 +153,14 @@ export default interface IElement extends IChildNode, INonDocumentTypeChildNode,
 	matches(selector: string): boolean;
 
 	/**
+	 * Traverses the Element and its parents (heading toward the document root) until it finds a node that matches the provided selector string.
+	 *
+	 * @param selector Selector.
+	 * @returns Closest matching element.
+	 */
+	closest(selector: string): IElement;
+
+	/**
 	 * The setAttributeNode() method adds a new Attr node to the specified element.
 	 *
 	 * @param attribute Attribute.

--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -1,8 +1,9 @@
 import Element from '../element/Element';
-import Event from '../../event/Event';
 import IHTMLElement from './IHTMLElement';
 import CSSStyleDeclaration from '../../css/CSSStyleDeclaration';
 import Attr from '../../attribute/Attr';
+import FocusEvent from '../../event/events/FocusEvent';
+import PointerEvent from '../../event/events/PointerEvent';
 
 /**
  * HTML Element.
@@ -172,7 +173,7 @@ export default class HTMLElement extends Element implements IHTMLElement {
 	 * Triggers a click event.
 	 */
 	public click(): void {
-		const event = new Event('click', {
+		const event = new PointerEvent('click', {
 			bubbles: true,
 			composed: true
 		});
@@ -185,8 +186,14 @@ export default class HTMLElement extends Element implements IHTMLElement {
 	 * Triggers a blur event.
 	 */
 	public blur(): void {
+		if (this.ownerDocument['_activeElement'] !== this || !this.isConnected) {
+			return;
+		}
+
+		this.ownerDocument['_activeElement'] = null;
+
 		for (const eventType of ['blur', 'focusout']) {
-			const event = new Event(eventType, {
+			const event = new FocusEvent(eventType, {
 				bubbles: true,
 				composed: true
 			});
@@ -200,8 +207,18 @@ export default class HTMLElement extends Element implements IHTMLElement {
 	 * Triggers a focus event.
 	 */
 	public focus(): void {
+		if (this.ownerDocument['_activeElement'] === this || !this.isConnected) {
+			return;
+		}
+
+		if (this.ownerDocument['_activeElement'] !== null) {
+			this.ownerDocument['_activeElement'].blur();
+		}
+
+		this.ownerDocument['_activeElement'] = this;
+
 		for (const eventType of ['focus', 'focusin']) {
-			const event = new Event(eventType, {
+			const event = new FocusEvent(eventType, {
 				bubbles: true,
 				composed: true
 			});

--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
@@ -37,9 +37,6 @@ export default class HTMLInputElement extends HTMLElement implements IHTMLInputE
 	// Type specific: file
 	public files: File[] = [];
 
-	// Not categorized
-	public defaultValue = '';
-
 	// Type specific: text/password/search/tel/url/week/month
 	private _selectionStart = null;
 	private _selectionEnd = null;
@@ -384,21 +381,21 @@ export default class HTMLInputElement extends HTMLElement implements IHTMLInputE
 	}
 
 	/**
-	 * Returns defaultvalue.
+	 * Returns defaultValue.
 	 *
 	 * @returns Defaultvalue.
 	 */
-	public get defaultvalue(): string {
+	public get defaultValue(): string {
 		return this.getAttributeNS(null, 'defaultvalue') || '';
 	}
 
 	/**
-	 * Sets defaultvalue.
+	 * Sets defaultValue.
 	 *
-	 * @param defaultvalue Defaultvalue.
+	 * @param defaultValue Defaultvalue.
 	 */
-	public set defaultvalue(defaultvalue: string) {
-		this.setAttributeNS(null, 'defaultvalue', defaultvalue);
+	public set defaultValue(defaultValue: string) {
+		this.setAttributeNS(null, 'defaultvalue', defaultValue);
 	}
 
 	/**
@@ -778,6 +775,21 @@ export default class HTMLInputElement extends HTMLElement implements IHTMLInputE
 	 */
 	public get valueAsNumber(): number {
 		return this.value ? parseFloat(this.value) : NaN;
+	}
+
+	/**
+	 * Selects the text.
+	 */
+	public select(): void {
+		if (!this._isSelectionSupported()) {
+			return null;
+		}
+
+		this._selectionStart = 0;
+		this._selectionEnd = this.value.length;
+		this._selectionDirection = HTMLInputElementSelectionDirectionEnum.none;
+
+		this.dispatchEvent(new Event('select', { bubbles: true, cancelable: true }));
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-input-element/IHTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/IHTMLInputElement.ts
@@ -35,7 +35,6 @@ export default interface IHTMLInputElement extends IHTMLElement {
 	allowdirs: string;
 	autocomplete: string;
 	src: string;
-	defaultvalue: string;
 	readOnly: boolean;
 	disabled: boolean;
 	autofocus: boolean;

--- a/packages/happy-dom/src/nodes/html-style-element/HTMLStyleElement.ts
+++ b/packages/happy-dom/src/nodes/html-style-element/HTMLStyleElement.ts
@@ -15,7 +15,7 @@ export default class HTMLStyleElement extends HTMLElement implements IHTMLStyleE
 	 * @returns CSS style sheet.
 	 */
 	public get sheet(): CSSStyleSheet {
-		if (!this._isConnected) {
+		if (!this.isConnected) {
 			return null;
 		}
 		const styleSheet = new CSSStyleSheet();

--- a/packages/happy-dom/src/nodes/node/INode.ts
+++ b/packages/happy-dom/src/nodes/node/INode.ts
@@ -8,7 +8,7 @@ export default interface INode extends IEventTarget {
 	readonly parentElement: IElement;
 	readonly nodeType: number;
 	readonly childNodes: INode[];
-	isConnected: boolean;
+	readonly isConnected: boolean;
 	readonly nodeValue: string;
 	readonly nodeName: string;
 	readonly previousSibling: INode;

--- a/packages/happy-dom/src/nodes/shadow-root/ShadowRoot.ts
+++ b/packages/happy-dom/src/nodes/shadow-root/ShadowRoot.ts
@@ -4,6 +4,7 @@ import XMLSerializer from '../../xml-serializer/XMLSerializer';
 import IElement from '../element/IElement';
 import CSSStyleSheet from '../../css/CSSStyleSheet';
 import IShadowRoot from './IShadowRoot';
+import IHTMLElement from '../../nodes/html-element/IHTMLElement';
 
 /**
  * ShadowRoot.
@@ -40,6 +41,19 @@ export default class ShadowRoot extends DocumentFragment implements IShadowRoot 
 		for (const node of XMLParser.parse(this.ownerDocument, html).childNodes.slice()) {
 			this.appendChild(node);
 		}
+	}
+
+	/**
+	 * Returns active element.
+	 *
+	 * @returns Active element.
+	 */
+	public get activeElement(): IHTMLElement {
+		const activeElement: IHTMLElement = this.ownerDocument['_activeElement'];
+		if (activeElement && activeElement.getRootNode() === this) {
+			return activeElement;
+		}
+		return null;
 	}
 
 	/**

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -42,6 +42,7 @@ import FileReader from '../file/FileReader';
 import History from '../history/History';
 import CSSStyleDeclaration from '../css/CSSStyleDeclaration';
 import MouseEvent from '../event/events/MouseEvent';
+import PointerEvent from '../event/events/PointerEvent';
 import FocusEvent from '../event/events/FocusEvent';
 import WheelEvent from '../event/events/WheelEvent';
 import DataTransfer from '../event/DataTransfer';
@@ -111,6 +112,7 @@ export default class Window extends EventTarget implements IWindow, NodeJS.Globa
 	public readonly AnimationEvent = AnimationEvent;
 	public readonly KeyboardEvent = KeyboardEvent;
 	public readonly MouseEvent = MouseEvent;
+	public readonly PointerEvent = PointerEvent;
 	public readonly FocusEvent = FocusEvent;
 	public readonly WheelEvent = WheelEvent;
 	public readonly InputEvent = InputEvent;

--- a/packages/happy-dom/test/nodes/document-fragment/DocumentFragment.test.ts
+++ b/packages/happy-dom/test/nodes/document-fragment/DocumentFragment.test.ts
@@ -279,8 +279,10 @@ describe('DocumentFragment', () => {
 
 			const clone = documentFragment.cloneNode(false);
 
-			expect(clone).toEqual({ ...documentFragment, childNodes: [], children: [] });
-			expect(documentFragment !== clone).toBe(true);
+			expect(clone.nodeType).toBe(Node.DOCUMENT_FRAGMENT_NODE);
+			expect(clone._rootNode).toBe(clone);
+			expect(clone.childNodes.length).toBe(0);
+			expect(clone.children.length).toBe(0);
 		});
 
 		it('Makes a deep clone of the document fragment.', () => {
@@ -294,7 +296,8 @@ describe('DocumentFragment', () => {
 
 			const clone = documentFragment.cloneNode(true);
 
-			expect(clone).toEqual(documentFragment);
+			expect(clone.nodeType).toBe(Node.DOCUMENT_FRAGMENT_NODE);
+			expect(clone._rootNode).toBe(clone);
 			expect(clone.childNodes.length).toBe(3);
 			expect(clone.children).toEqual(
 				clone.childNodes.filter(node => node.nodeType === Node.ELEMENT_NODE)

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -19,7 +19,8 @@ import HTMLTemplateElement from '../../../src/nodes/html-template-element/HTMLTe
 import IHTMLCollection from '../../../src/nodes/element/IHTMLCollection';
 import IElement from '../../../src/nodes/element/IElement';
 import INodeList from '../../../src/nodes/node/INodeList';
-import { IHTMLLinkElement } from '../../../src';
+import IHTMLElement from '../../../src/nodes/html-element/IHTMLElement';
+import IHTMLLinkElement from '../../../src/nodes/html-link-element/IHTMLLinkElement';
 import IResponse from '../../../src/window/IResponse';
 import ResourceFetcher from '../../../src/fetch/ResourceFetcher';
 import IHTMLScriptElement from '../../../src/nodes/html-script-element/IHTMLScriptElement';
@@ -245,6 +246,30 @@ describe('Document', () => {
 
 				done();
 			}, 0);
+		});
+	});
+
+	describe('get activeElement()', () => {
+		it('Returns the currently active element.', () => {
+			const div = <IHTMLElement>document.createElement('div');
+			const span = <IHTMLElement>document.createElement('span');
+
+			document.appendChild(div);
+			document.appendChild(span);
+
+			expect(document.activeElement === document.body).toBe(true);
+
+			div.focus();
+
+			expect(document.activeElement === div).toBe(true);
+
+			span.focus();
+
+			expect(document.activeElement === span).toBe(true);
+
+			span.blur();
+
+			expect(document.activeElement === document.body).toBe(true);
 		});
 	});
 

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -609,6 +609,56 @@ describe('Element', () => {
 
 			expect(element.matches('.container.active')).toBe(true);
 		});
+
+		it('Checks if the element matches any selector in a string separated by comma.', () => {
+			const element = document.createElement('div');
+
+			element.className = 'container active';
+
+			expect(element.matches('.container, .active')).toBe(true);
+		});
+	});
+
+	describe('closest()', () => {
+		it('Finds the closest matching element when connected to DOM.', () => {
+			const div = document.createElement('div');
+			const span = document.createElement('span');
+			const article = document.createElement('article');
+			const b = document.createElement('b');
+
+			span.className = 'span';
+
+			article.appendChild(b);
+			span.appendChild(article);
+			div.appendChild(span);
+
+			document.body.appendChild(div);
+
+			expect(b.closest('div') === div).toBe(true);
+			expect(b.closest('div span') === span).toBe(true);
+			expect(b.closest('div .span') === span).toBe(true);
+			expect(b.closest('div .span b') === b).toBe(true);
+			expect(b.closest('div .span article b') === b).toBe(true);
+		});
+
+		it('Finds the closest matching element when not connected to DOM.', () => {
+			const div = document.createElement('div');
+			const span = document.createElement('span');
+			const article = document.createElement('article');
+			const b = document.createElement('b');
+
+			span.className = 'span';
+
+			article.appendChild(b);
+			span.appendChild(article);
+			div.appendChild(span);
+
+			expect(b.closest('div') === div).toBe(true);
+			expect(b.closest('div span') === span).toBe(true);
+			expect(b.closest('div .span') === span).toBe(true);
+			expect(b.closest('div .span b') === b).toBe(true);
+			expect(b.closest('div .span article b') === b).toBe(true);
+		});
 	});
 
 	describe('querySelectorAll()', () => {

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -94,23 +94,6 @@ describe('Node', () => {
 		});
 	});
 
-	describe('set isConnected()', () => {
-		it('Sets an element and all its children to be connected.', () => {
-			const div = document.createElement('div');
-			const span = document.createElement('span');
-			const text = document.createTextNode('text');
-
-			div.appendChild(span);
-			span.appendChild(text);
-
-			div.isConnected = true;
-
-			expect(div.isConnected).toBe(true);
-			expect(span.isConnected).toBe(true);
-			expect(text.isConnected).toBe(true);
-		});
-	});
-
 	describe('get nodeValue()', () => {
 		it('Returns null.', () => {
 			expect(new Node().nodeValue).toBe(null);
@@ -261,7 +244,7 @@ describe('Node', () => {
 
 			const rootNode = customElement.shadowRoot.querySelector('span').getRootNode();
 
-			expect(rootNode).toBe(customElement.shadowRoot);
+			expect(rootNode === customElement.shadowRoot).toBe(true);
 		});
 
 		it('Returns Document when used on a node inside a ShadowRoot and the option "composed" is set to "true".', () => {
@@ -273,7 +256,7 @@ describe('Node', () => {
 				.querySelector('span')
 				.getRootNode({ composed: true });
 
-			expect(rootNode).toBe(document);
+			expect(rootNode === document).toBe(true);
 		});
 
 		it('Returns Document when the node is not inside a ShadowRoot.', () => {
@@ -285,7 +268,7 @@ describe('Node', () => {
 
 			const rootNode = spanElement.getRootNode();
 
-			expect(rootNode).toBe(document);
+			expect(rootNode === document).toBe(true);
 		});
 	});
 

--- a/packages/happy-dom/test/nodes/shadow-root/ShadowRoot.test.ts
+++ b/packages/happy-dom/test/nodes/shadow-root/ShadowRoot.test.ts
@@ -1,3 +1,4 @@
+import IHTMLElement from '../../../src/nodes/html-element/IHTMLElement';
 import Window from '../../../src/window/Window';
 import CustomElement from '../../CustomElement';
 
@@ -32,6 +33,40 @@ describe('ShadowRoot', () => {
 			const shadowRoot = document.createElement('custom-element').shadowRoot;
 			shadowRoot.innerHTML = html;
 			expect(shadowRoot.innerHTML).toBe(html);
+		});
+	});
+
+	describe('get activeElement()', () => {
+		it('Returns the currently active element within the ShadowRoot.', () => {
+			const customElement = document.createElement('custom-element');
+			const shadowRoot = customElement.shadowRoot;
+			const div = <IHTMLElement>document.createElement('div');
+			const span = <IHTMLElement>document.createElement('span');
+
+			document.body.appendChild(customElement);
+
+			shadowRoot.appendChild(div);
+			shadowRoot.appendChild(span);
+
+			expect(shadowRoot.activeElement === null).toBe(true);
+
+			div.focus();
+
+			expect(shadowRoot.activeElement === div).toBe(true);
+
+			span.focus();
+
+			expect(shadowRoot.activeElement === span).toBe(true);
+
+			span.blur();
+
+			expect(shadowRoot.activeElement === null).toBe(true);
+
+			document.body.appendChild(span);
+
+			span.focus();
+
+			expect(shadowRoot.activeElement === null).toBe(true);
 		});
 	});
 

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -350,6 +350,15 @@ describe('QuerySelector', () => {
 			expect(elements[4]).toBe(container.children[1].children[0]);
 		});
 
+		it('Returns all elements matching "span:not([type=hidden])".', () => {
+			const container = document.createElement('div');
+			container.innerHTML = QuerySelectorHTML;
+			const elements = container.querySelectorAll('span:not([type=hidden])');
+
+			expect(elements.length).toBe(1);
+			expect(elements[0]).toBe(container.children[0].children[1].children[1]);
+		});
+
 		it('Returns all span elements matching span:nth-child(1) or span:nth-child(2).', () => {
 			const container = document.createElement('div');
 			container.innerHTML = QuerySelectorHTML;

--- a/packages/happy-dom/test/query-selector/data/QuerySelectorHTML.ts
+++ b/packages/happy-dom/test/query-selector/data/QuerySelectorHTML.ts
@@ -4,7 +4,7 @@ export default `
 		<h1>Heading1</h1>
 		<!-- Comment 2 !-->
 		<div class="class1 class2">
-			<span class="class1 class2" attr1="value1" attr2="word1 word2" attr3="bracket[]bracket">Span1</span>
+			<span class="class1 class2" attr1="value1" attr2="word1 word2" attr3="bracket[]bracket" type="hidden">Span1</span>
 			<span class="class1 class2" attr1="value1">Span2</span>
 		</div>
 	</div>


### PR DESCRIPTION
…r PointerEvent. Adds support for Document.activeElement. Adds support for ShadowRoot.activeElemnet. Improves performance of Node.getRootNode(). Adds support for Element.closest(). Adds support for checking against multiple selectors divided by comma to Element.matches(). Fixes issue with composed events not bubbling through ShadowRoot. Corrects event types in HTMLElement.click(), HTMLElement.focus(), HTMLElement.blur(). Fixes issue with HTMLInputElement.defaultValue being undefined. Fixes issue with query selectors not supporting the :not() pseudo selector.