### PR TITLE
#321@patch: `tagName` can be null.

### DIFF
--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -94,7 +94,7 @@ export default class Element extends Node implements IElement {
 	 * @returns Local name.
 	 */
 	public get localName(): string {
-		return this.tagName.toLowerCase();
+		return this.tagName ? this.tagName.toLowerCase() : 'unknown';
 	}
 
 	/**


### PR DESCRIPTION
see https://github.com/vitest-dev/vitest/pull/234

Maybe it is also a problem on `lit` side.

closes #321 