### PR TITLE
#330@minor: Add document.location.

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -33,6 +33,7 @@ import IHTMLLinkElement from '../html-link-element/IHTMLLinkElement';
 import IHTMLStyleElement from '../html-style-element/IHTMLStyleElement';
 import DocumentReadyStateEnum from './DocumentReadyStateEnum';
 import DocumentReadyStateManager from './DocumentReadyStateManager';
+import Location from '../../location/Location';
 
 /**
  * Document.
@@ -217,6 +218,15 @@ export default class Document extends Node implements IDocument {
 	 */
 	public get activeElement(): IHTMLElement {
 		return this._activeElement || this.body || this.documentElement || null;
+	}
+
+	/**
+	 * Returns location.
+	 *
+	 * @returns Location.
+	 */
+	public get location(): Location {
+		return this._defaultView.location;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -274,6 +274,12 @@ describe('Document', () => {
 		});
 	});
 
+	describe('get location()', () => {
+		it('Returns the current location', () => {
+			expect(document.location === window.location).toBe(true);
+		});
+	});
+
 	describe('append()', () => {
 		it('Inserts a set of Node objects or DOMString objects after the last child of the ParentNode. DOMString objects are inserted as equivalent Text nodes.', () => {
 			const node1 = document.createComment('test1');


### PR DESCRIPTION
Fixes https://github.com/capricorn86/happy-dom/issues/330

I used a getter instead of a static property for 3 reasons:
- we want to have the exact same object as `window.location` so that changes made in one will also impact the other (so I didn't use `new Location()`)
- the document has a view `this._defaultView` that can be updated, so `document.location` should always be up-to-date with the linked view
- it won't be overridable 

I also added a test that passes `npm test`

![image](https://user-images.githubusercontent.com/22725671/149851846-827c34b3-6dff-4f5e-9138-58ca2ff60cba.png)


--- 

Note: this is my first PR to the project, so I'm not sure I followed every guideline