### PR TITLE
#328@minor: Add toggle() to ClassList.

### DIFF
--- a/packages/happy-dom/src/nodes/element/ClassList.ts
+++ b/packages/happy-dom/src/nodes/element/ClassList.ts
@@ -65,4 +65,28 @@ export default class ClassList {
 		const list = attr ? attr.split(' ') : [];
 		return list.includes(className);
 	}
+
+	/**
+	 * Toggle a class name.
+	 *
+	 * @param className A string representing the class name you want to toggle.
+	 * @param force If included, turns the toggle into a one way-only operation. If set to `false`, then class name will only be removed, but not added. If set to `true`, then class name will only be added, but not removed.
+	 * @returns A boolean value, `true` or `false`, indicating whether class name is in the list after the call or not.
+	 */
+	public toggle(className: string, force?: boolean): boolean {
+		let shouldAdd: boolean;
+		if (force !== undefined) {
+			shouldAdd = force;
+		} else {
+			shouldAdd = !this.contains(className);
+		}
+
+		if (shouldAdd) {
+			this.add(className);
+			return true;
+		}
+
+		this.remove(className);
+		return false;
+	}
 }

--- a/packages/happy-dom/test/nodes/element/ClassList.test.ts
+++ b/packages/happy-dom/test/nodes/element/ClassList.test.ts
@@ -43,4 +43,28 @@ describe('ClassList', () => {
 			expect(classList.contains('class')).toBe(true);
 		});
 	});
+
+	describe('toggle()', () => {
+		it('Adds a class from the list when not existing.', () => {
+			expect(classList.toggle('class')).toBe(true);
+			expect(element.className).toBe('class');
+		});
+		it('Adds a class from the list when force is set.', () => {
+			classList.add('classA');
+			expect(classList.toggle('classA', true)).toBe(true);
+			expect(classList.toggle('classB', true)).toBe(true);
+			expect(element.className).toBe('classA classB');
+		});
+		it('Removes a class from the list when existing.', () => {
+			classList.add('class');
+			expect(classList.toggle('class')).toBe(false);
+			expect(element.className).toBe('');
+		});
+		it('Adds a class from the list when force is set.', () => {
+			classList.add('classA');
+			expect(classList.toggle('classA', false)).toBe(false);
+			expect(classList.toggle('classB', false)).toBe(false);
+			expect(element.className).toBe('');
+		});
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/capricorn86/happy-dom/issues/328

Implements `toggle()` on `ClassList` (see https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle)


![image](https://user-images.githubusercontent.com/22725671/149852755-6f0f51d3-ea54-42ce-bf70-a2f4247d7f77.png)
