### PR TITLE
fix: HTMLStyleElement should cache the created CSSStyleSheet

### DIFF
--- a/packages/happy-dom/src/nodes/html-style-element/HTMLStyleElement.ts
+++ b/packages/happy-dom/src/nodes/html-style-element/HTMLStyleElement.ts
@@ -9,6 +9,8 @@ import IHTMLStyleElement from './IHTMLStyleElement';
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement.
  */
 export default class HTMLStyleElement extends HTMLElement implements IHTMLStyleElement {
+	private _styleSheet: CSSStyleSheet | null = null;
+
 	/**
 	 * Returns CSS style sheet.
 	 *
@@ -18,9 +20,11 @@ export default class HTMLStyleElement extends HTMLElement implements IHTMLStyleE
 		if (!this.isConnected) {
 			return null;
 		}
-		const styleSheet = new CSSStyleSheet();
-		styleSheet.replaceSync(this.innerText);
-		return styleSheet;
+		if (!this._styleSheet) {
+			this._styleSheet = new CSSStyleSheet();
+			this._styleSheet.replaceSync(this.innerText);
+		}
+		return this._styleSheet
 	}
 
 	/**


### PR DESCRIPTION
Without this change every time one calls `styleElement.sheet` a new CSSStyleSheet is returned.