### PR TITLE
#338@minor: Adds support for the deprecated method CustomEvent.initCu…

### DIFF
--- a/packages/happy-dom/src/event/events/CustomEvent.ts
+++ b/packages/happy-dom/src/event/events/CustomEvent.ts
@@ -20,4 +20,25 @@ export default class CustomEvent extends Event {
 			this.detail = eventInit.detail || null;
 		}
 	}
+
+	/**
+	 * Init event.
+	 *
+	 * @deprecated
+	 * @param type Type.
+	 * @param [bubbles=false] "true" if it bubbles.
+	 * @param [cancelable=false] "true" if it cancelable.
+	 * @param [detail=null] Custom event detail.
+	 */
+	public initCustomEvent(
+		type: string,
+		bubbles = false,
+		cancelable = false,
+		detail: object = null
+	): void {
+		this.type = type;
+		this.bubbles = bubbles;
+		this.cancelable = cancelable;
+		this.detail = detail;
+	}
 }

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -620,10 +620,13 @@ export default class Document extends Node implements IDocument {
 	 * Creates an event.
 	 *
 	 * @deprecated
-	 * @param _type Type.
+	 * @param type Type.
 	 * @returns Event.
 	 */
-	public createEvent(_type: string): Event {
+	public createEvent(type: string): Event {
+		if (this.defaultView[type]) {
+			return new this.defaultView[type]('init');
+		}
 		return new Event('init');
 	}
 

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -25,7 +25,8 @@ import IResponse from '../../../src/window/IResponse';
 import ResourceFetcher from '../../../src/fetch/ResourceFetcher';
 import IHTMLScriptElement from '../../../src/nodes/html-script-element/IHTMLScriptElement';
 import DocumentReadyStateEnum from '../../../src/nodes/document/DocumentReadyStateEnum';
-import { ISVGElement } from '../../../src';
+import ISVGElement from '../../../src/nodes/svg-element/ISVGElement';
+import CustomEvent from '../../../src/event/events/CustomEvent';
 
 describe('Document', () => {
 	let window: Window;
@@ -793,6 +794,17 @@ describe('Document', () => {
 			expect(event.bubbles).toBe(true);
 			expect(event.cancelable).toBe(true);
 			expect(event instanceof Event).toBe(true);
+		});
+
+		it('Creates a legacy custom event.', () => {
+			const event = <CustomEvent>document.createEvent('CustomEvent');
+			const detail = {};
+			event.initCustomEvent('click', true, true, detail);
+			expect(event.type).toBe('click');
+			expect(event.bubbles).toBe(true);
+			expect(event.cancelable).toBe(true);
+			expect(event.detail).toBe(detail);
+			expect(event instanceof CustomEvent).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
…stomEvent() which is used by Svelte.