### PR TITLE
@fix: remove one event callback at a time

### DIFF
--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -34,7 +34,7 @@ export default abstract class EventTarget implements IEventTarget {
 		if (this._listeners[type]) {
 			const index = this._listeners[type].indexOf(listener);
 			if (index !== -1) {
-				this._listeners[type].splice(index);
+				this._listeners[type].splice(index, 1);
 			}
 		}
 	}


### PR DESCRIPTION
I faced this issue while testing one of my functionality. 

Current code removes all the event listers. This becomes an issue if multiple event listeners are registered for the same type.

Keeping the [deleteCount](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice) as 1 removes one event listener at a time.
