### PR TITLE
#369@minor: Adds support for HTMLMetaElement.

### DIFF
--- a/packages/happy-dom/src/config/ElementTag.ts
+++ b/packages/happy-dom/src/config/ElementTag.ts
@@ -10,6 +10,7 @@ import HTMLLinkElement from '../nodes/html-link-element/HTMLLinkElement';
 import HTMLStyleElement from '../nodes/html-style-element/HTMLStyleElement';
 import HTMLLabelElement from '../nodes/html-label-element/HTMLLabelElement';
 import HTMLSlotElement from '../nodes/html-slot-element/HTMLSlotElement';
+import HTMLMetaElement from '../nodes/html-meta-element/HTMLMetaElement';
 
 export default {
 	template: HTMLTemplateElement,
@@ -31,5 +32,6 @@ export default {
 	polyline: SVGElement,
 	rect: SVGElement,
 	stop: SVGElement,
-	use: SVGElement
+	use: SVGElement,
+	meta: HTMLMetaElement
 };

--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -74,6 +74,8 @@ import HTMLSlotElement from './nodes/html-slot-element/HTMLSlotElement';
 import IHTMLSlotElement from './nodes/html-slot-element/IHTMLSlotElement';
 import HTMLLabelElement from './nodes/html-label-element/HTMLLabelElement';
 import IHTMLLabelElement from './nodes/html-label-element/IHTMLLabelElement';
+import HTMLMetaElement from './nodes/html-meta-element/HTMLMetaElement';
+import IHTMLMetaElement from './nodes/html-meta-element/IHTMLMetaElement';
 import SVGElement from './nodes/svg-element/SVGElement';
 import ISVGElement from './nodes/svg-element/ISVGElement';
 import SVGGraphicsElement from './nodes/svg-element/SVGGraphicsElement';
@@ -181,6 +183,8 @@ export {
 	IHTMLSlotElement,
 	HTMLLabelElement,
 	IHTMLLabelElement,
+	HTMLMetaElement,
+	IHTMLMetaElement,
 	SVGElement,
 	ISVGElement,
 	SVGGraphicsElement,

--- a/packages/happy-dom/src/nodes/html-meta-element/HTMLMetaElement.ts
+++ b/packages/happy-dom/src/nodes/html-meta-element/HTMLMetaElement.ts
@@ -1,0 +1,81 @@
+import IHTMLMetaElement from './IHTMLMetaElement';
+import HTMLElement from '../html-element/HTMLElement';
+
+/**
+ * HTML Form Element.
+ *
+ * Reference:
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLMetaElement.
+ */
+export default class HTMLMetaElement extends HTMLElement implements IHTMLMetaElement {
+	/**
+	 * Returns content.
+	 *
+	 * @returns Content.
+	 */
+	public get content(): string {
+		return this.getAttributeNS(null, 'content') || '';
+	}
+
+	/**
+	 * Sets content.
+	 *
+	 * @param content Content.
+	 */
+	public set content(content: string) {
+		this.setAttributeNS(null, 'content', content);
+	}
+
+	/**
+	 * Returns httpEquiv.
+	 *
+	 * @returns HttpEquiv.
+	 */
+	public get httpEquiv(): string {
+		return this.getAttributeNS(null, 'httpEquiv') || '';
+	}
+
+	/**
+	 * Sets httpEquiv.
+	 *
+	 * @param httpEquiv HttpEquiv.
+	 */
+	public set httpEquiv(httpEquiv: string) {
+		this.setAttributeNS(null, 'httpEquiv', httpEquiv);
+	}
+
+	/**
+	 * Returns name.
+	 *
+	 * @returns Name.
+	 */
+	public get name(): string {
+		return this.getAttributeNS(null, 'name') || '';
+	}
+
+	/**
+	 * Sets name.
+	 *
+	 * @param name Name.
+	 */
+	public set name(name: string) {
+		this.setAttributeNS(null, 'name', name);
+	}
+	/**
+	 * Returns scheme.
+	 *
+	 * @returns Name.
+	 */
+	public get scheme(): string {
+		return this.getAttributeNS(null, 'scheme') || '';
+	}
+
+	/**
+	 * Sets scheme.
+	 *
+	 * @param scheme Scheme.
+	 */
+	public set scheme(scheme: string) {
+		this.setAttributeNS(null, 'scheme', scheme);
+	}
+}

--- a/packages/happy-dom/src/nodes/html-meta-element/HTMLMetaElement.ts
+++ b/packages/happy-dom/src/nodes/html-meta-element/HTMLMetaElement.ts
@@ -32,7 +32,7 @@ export default class HTMLMetaElement extends HTMLElement implements IHTMLMetaEle
 	 * @returns HttpEquiv.
 	 */
 	public get httpEquiv(): string {
-		return this.getAttributeNS(null, 'httpEquiv') || '';
+		return this.getAttributeNS(null, 'http-equiv') || '';
 	}
 
 	/**
@@ -41,7 +41,7 @@ export default class HTMLMetaElement extends HTMLElement implements IHTMLMetaEle
 	 * @param httpEquiv HttpEquiv.
 	 */
 	public set httpEquiv(httpEquiv: string) {
-		this.setAttributeNS(null, 'httpEquiv', httpEquiv);
+		this.setAttributeNS(null, 'http-equiv', httpEquiv);
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-meta-element/HTMLMetaElement.ts
+++ b/packages/happy-dom/src/nodes/html-meta-element/HTMLMetaElement.ts
@@ -2,7 +2,7 @@ import IHTMLMetaElement from './IHTMLMetaElement';
 import HTMLElement from '../html-element/HTMLElement';
 
 /**
- * HTML Form Element.
+ * HTML Meta Element.
  *
  * Reference:
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLMetaElement.

--- a/packages/happy-dom/src/nodes/html-meta-element/IHTMLMetaElement.ts
+++ b/packages/happy-dom/src/nodes/html-meta-element/IHTMLMetaElement.ts
@@ -1,0 +1,14 @@
+import IHTMLElement from '../html-element/IHTMLElement';
+
+/**
+ * HTML Meta Element.
+ *
+ * Reference:
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLMetaElement.
+ */
+export default interface IHTMLMetaElement extends IHTMLElement {
+	content: string;
+	httpEquiv: string;
+	name: string;
+	scheme: string;
+}

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -17,6 +17,7 @@ import HTMLLinkElement from '../nodes/html-link-element/HTMLLinkElement';
 import HTMLStyleElement from '../nodes/html-style-element/HTMLStyleElement';
 import HTMLSlotElement from '../nodes/html-slot-element/HTMLSlotElement';
 import HTMLLabelElement from '../nodes/html-label-element/HTMLLabelElement';
+import HTMLMetaElement from '../nodes/html-meta-element/HTMLMetaElement';
 import SVGSVGElement from '../nodes/svg-element/SVGSVGElement';
 import SVGElement from '../nodes/svg-element/SVGElement';
 import HTMLScriptElement from '../nodes/html-script-element/HTMLScriptElement';
@@ -92,6 +93,7 @@ export default interface IWindow {
 	readonly HTMLStyleElement: typeof HTMLStyleElement;
 	readonly HTMLSlotElement: typeof HTMLSlotElement;
 	readonly HTMLLabelElement: typeof HTMLLabelElement;
+	readonly HTMLMetaElement: typeof HTMLMetaElement;
 	readonly SVGSVGElement: typeof SVGSVGElement;
 	readonly SVGElement: typeof SVGElement;
 	readonly Image: typeof Image;

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -18,6 +18,7 @@ import HTMLLinkElement from '../nodes/html-link-element/HTMLLinkElement';
 import HTMLStyleElement from '../nodes/html-style-element/HTMLStyleElement';
 import HTMLSlotElement from '../nodes/html-slot-element/HTMLSlotElement';
 import HTMLLabelElement from '../nodes/html-label-element/HTMLLabelElement';
+import HTMLMetaElement from '../nodes/html-meta-element/HTMLMetaElement';
 import SVGSVGElement from '../nodes/svg-element/SVGSVGElement';
 import SVGElement from '../nodes/svg-element/SVGElement';
 import HTMLScriptElement from '../nodes/html-script-element/HTMLScriptElement';
@@ -105,6 +106,7 @@ export default class Window extends EventTarget implements IWindow, NodeJS.Globa
 	public readonly HTMLStyleElement = HTMLStyleElement;
 	public readonly HTMLLabelElement = HTMLLabelElement;
 	public readonly HTMLSlotElement = HTMLSlotElement;
+	public readonly HTMLMetaElement = HTMLMetaElement;
 	public readonly SVGSVGElement = SVGSVGElement;
 	public readonly SVGElement = SVGElement;
 	public readonly Text = Text;

--- a/packages/happy-dom/test/nodes/html-meta-element/HTMLMetaElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-meta-element/HTMLMetaElement.test.ts
@@ -1,0 +1,75 @@
+import Window from '../../../src/window/Window';
+import Document from '../../../src/nodes/document/Document';
+import IHTMLMetaElement from '../../../src/nodes/html-meta-element/IHTMLMetaElement';
+
+describe('HTMLMetaElement', () => {
+	let window: Window;
+	let document: Document;
+	let element: IHTMLMetaElement;
+
+	beforeEach(() => {
+		window = new Window();
+		document = window.document;
+		element = <IHTMLMetaElement>document.createElement('meta');
+	});
+
+	describe('get content()', () => {
+		it('Returns attribute value.', () => {
+			expect(element.content).toBe('');
+			element.setAttribute('content', 'value');
+			expect(element.content).toBe('value');
+		});
+	});
+
+	describe('set content()', () => {
+		it('Sets attribute value.', () => {
+			element.content = 'value';
+			expect(element.getAttribute('content')).toBe('value');
+		});
+	});
+
+	describe('get httpEquiv()', () => {
+		it('Returns attribute value.', () => {
+			expect(element.httpEquiv).toBe('');
+			element.setAttribute('httpEquiv', 'value');
+			expect(element.httpEquiv).toBe('value');
+		});
+	});
+
+	describe('set httpEquiv()', () => {
+		it('Sets attribute value.', () => {
+			element.httpEquiv = 'value';
+			expect(element.getAttribute('httpEquiv')).toBe('value');
+		});
+	});
+
+	describe('get name()', () => {
+		it('Returns attribute value.', () => {
+			expect(element.name).toBe('');
+			element.setAttribute('name', 'value');
+			expect(element.name).toBe('value');
+		});
+	});
+
+	describe('set name()', () => {
+		it('Sets attribute value.', () => {
+			element.name = 'value';
+			expect(element.getAttribute('name')).toBe('value');
+		});
+	});
+
+	describe('get scheme()', () => {
+		it('Returns attribute value.', () => {
+			expect(element.scheme).toBe('');
+			element.setAttribute('scheme', 'value');
+			expect(element.scheme).toBe('value');
+		});
+	});
+
+	describe('set scheme()', () => {
+		it('Sets attribute value.', () => {
+			element.scheme = 'value';
+			expect(element.getAttribute('scheme')).toBe('value');
+		});
+	});
+});

--- a/packages/happy-dom/test/nodes/html-meta-element/HTMLMetaElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-meta-element/HTMLMetaElement.test.ts
@@ -31,7 +31,7 @@ describe('HTMLMetaElement', () => {
 	describe('get httpEquiv()', () => {
 		it('Returns attribute value.', () => {
 			expect(element.httpEquiv).toBe('');
-			element.setAttribute('httpEquiv', 'value');
+			element.setAttribute('http-equiv', 'value');
 			expect(element.httpEquiv).toBe('value');
 		});
 	});
@@ -39,7 +39,7 @@ describe('HTMLMetaElement', () => {
 	describe('set httpEquiv()', () => {
 		it('Sets attribute value.', () => {
 			element.httpEquiv = 'value';
-			expect(element.getAttribute('httpEquiv')).toBe('value');
+			expect(element.getAttribute('http-equiv')).toBe('value');
 		});
 	});
 


### PR DESCRIPTION
test code: 

```javascript
const happy = require("happy-dom")


const window = new happy.Window();
const  document = window.document;

document.write(`
<html>
<head>
<meta name="meta2" http-equiv="Content-Type" content="text/html; charset=utf-8">
</head>
</html>
`)
console.log(document.getElementsByTagName("meta")[0].httpEquiv);
console.log(document.getElementsByTagName("meta")[0].content);
console.log(document.getElementsByTagName("meta")[0].name);
```

before: 

```shell
undefined
undefined
undefined
```

after:

```shell
Content-Type
text/html; charset=utf-8
meta2
```

`npm test` pass: 

![image](https://user-images.githubusercontent.com/60805843/154882453-e710fae9-dfe2-469d-81cf-62b5f0dc25c2.png)
