### PR TITLE
#405@patch: Adds support for sending in other values than strings as …

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -630,11 +630,11 @@ export default class Document extends Node implements IDocument {
 		qualifiedName: string,
 		options?: { is?: string }
 	): IElement {
-		const tagName = qualifiedName.toUpperCase();
+		const tagName = String(qualifiedName).toUpperCase();
 
 		let customElementClass;
 		if (this.defaultView && options && options.is) {
-			customElementClass = this.defaultView.customElements.get(options.is);
+			customElementClass = this.defaultView.customElements.get(String(options.is));
 		} else if (this.defaultView) {
 			customElementClass = this.defaultView.customElements.get(tagName);
 		}

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -793,6 +793,11 @@ describe('Document', () => {
 			svg.style.cssText = 'user-select:none;';
 			expect(svg.style.cssText).toBe('user-select: none;');
 		});
+
+		it("Creates an element when tag name isn't a string.", () => {
+			const element = <ISVGElement>document.createElementNS(null, <string>(<unknown>true));
+			expect(element.tagName).toBe('TRUE');
+		});
 	});
 
 	describe('createAttribute()', () => {


### PR DESCRIPTION
…tag name to Document.createElement() and Document.createElementNS().