### PR TITLE
Indicate new jest default environment in README

### DIFF
--- a/packages/jest-environment/README.md
+++ b/packages/jest-environment/README.md
@@ -56,7 +56,7 @@ npm install @happy-dom/jest-environment --save-dev
 
 # Setup
 
-Jest uses [JSDOM](https://github.com/jsdom/jsdom) as test environment by default. In order to tell Jest to use a different environment we will either have to set a CLI attribute, define it in "package.json" or add a property to your Jest config file.
+Jest uses `node` as test environment by default. In order to tell Jest to use a different environment we will either have to set a CLI attribute, define it in "package.json" or add a property to your Jest config file.
 
 
 


### PR DESCRIPTION
`node` is the new default environment since [Jest 27](https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults).