### PR TITLE
#479@major: Fixes issues with HTML parsing and serialization related …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2545,7 +2545,7 @@
 		"node_modules/@types/form-data": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
-			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+			"integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -3206,7 +3206,7 @@
 		"node_modules/arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3222,7 +3222,7 @@
 		"node_modules/arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3273,7 +3273,7 @@
 		"node_modules/array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3281,7 +3281,7 @@
 		"node_modules/array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3338,7 +3338,7 @@
 		"node_modules/assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3691,7 +3691,7 @@
 		"node_modules/call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+			"integrity": "sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw=="
 		},
 		"node_modules/caller-callsite": {
 			"version": "2.0.0",
@@ -4404,7 +4404,7 @@
 		"node_modules/cpy/node_modules/array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
 			"dependencies": {
 				"array-uniq": "^1.0.1"
 			},
@@ -16015,7 +16015,7 @@
 		"@types/form-data": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
-			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+			"integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -16536,7 +16536,7 @@
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA=="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
@@ -16546,7 +16546,7 @@
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="
 		},
 		"array-differ": {
 			"version": "3.0.0",
@@ -16582,12 +16582,12 @@
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q=="
 		},
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ=="
 		},
 		"array.prototype.flat": {
 			"version": "1.2.5",
@@ -16629,7 +16629,7 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -16905,7 +16905,7 @@
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+			"integrity": "sha512-wCyFsDQkKPwwF8BDwOiWNx/9K45L/hvggQiDbve+viMNMQnWhrlYIuBk09offfwCRtCO9P6XwUttufzU11WCVw=="
 		},
 		"caller-callsite": {
 			"version": "2.0.0",
@@ -17461,7 +17461,7 @@
 				"array-union": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+					"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
 					"requires": {
 						"array-uniq": "^1.0.1"
 					}

--- a/packages/happy-dom/src/config/UnclosedElements.ts
+++ b/packages/happy-dom/src/config/UnclosedElements.ts
@@ -1,1 +1,0 @@
-export default ['meta'];

--- a/packages/happy-dom/src/config/VoidElements.ts
+++ b/packages/happy-dom/src/config/VoidElements.ts
@@ -1,5 +1,4 @@
 export default [
-	// Standard Elements
 	'area',
 	'base',
 	'br',
@@ -14,15 +13,5 @@ export default [
 	'source',
 	'track',
 	'wbr',
-
-	// SVG Elements
-	'circle',
-	'ellipse',
-	'line',
-	'path',
-	'polygon',
-	'polyline',
-	'rect',
-	'stop',
-	'use'
+	'meta'
 ];

--- a/packages/happy-dom/src/xml-serializer/XMLSerializer.ts
+++ b/packages/happy-dom/src/xml-serializer/XMLSerializer.ts
@@ -1,7 +1,6 @@
 import Element from '../nodes/element/Element';
 import Node from '../nodes/node/Node';
-import SelfClosingElements from '../config/SelfClosingElements';
-import UnclosedElements from '../config/UnclosedElements';
+import VoidElements from '../config/VoidElements';
 import DocumentType from '../nodes/document-type/DocumentType';
 import { escape } from 'he';
 import INode from '../nodes/node/INode';
@@ -25,10 +24,8 @@ export default class XMLSerializer {
 				const element = <Element>root;
 				const tagName = element.tagName.toLowerCase();
 
-				if (UnclosedElements.includes(tagName)) {
+				if (VoidElements.includes(tagName)) {
 					return `<${tagName}${this._getAttributes(element)}>`;
-				} else if (SelfClosingElements.includes(tagName)) {
-					return `<${tagName}${this._getAttributes(element)}/>`;
 				}
 
 				let innerHTML = '';

--- a/packages/happy-dom/test/xml-parser/XMLParser.test.ts
+++ b/packages/happy-dom/test/xml-parser/XMLParser.test.ts
@@ -13,7 +13,6 @@ const GET_EXPECTED_HTML = (html: string): string =>
 	html
 		.replace('<?Question mark comment>', '<!--?Question mark comment-->')
 		.replace('<!Exclamation mark comment>', '<!--Exclamation mark comment-->')
-		.replace('<img>', '<img/>')
 		.replace('<self-closing-custom-tag />', '<self-closing-custom-tag></self-closing-custom-tag>')
 		.replace(/[\s]/gm, '');
 
@@ -218,13 +217,13 @@ describe('XMLParser', () => {
 			const circle = svg.children[0];
 
 			expect(div.namespaceURI).toBe(NamespaceURI.html);
-			expect(svg.namespaceURI).toBe(NamespaceURI.html);
-			expect(circle.namespaceURI).toBe(NamespaceURI.html);
+			expect(svg.namespaceURI).toBe(NamespaceURI.svg);
+			expect(circle.namespaceURI).toBe(NamespaceURI.svg);
 
 			// Attributes should be in lower-case now as the namespace is HTML
 			expect(svg.attributes).toEqual({
 				'0': {
-					name: 'viewbox',
+					name: 'viewBox',
 					value: '0 0 300 100',
 					namespaceURI: null,
 					specified: true,
@@ -250,13 +249,13 @@ describe('XMLParser', () => {
 				'3': {
 					name: 'xmlns',
 					value: NamespaceURI.html,
-					namespaceURI: null,
+					namespaceURI: NamespaceURI.html,
 					specified: true,
 					ownerElement: svg,
 					ownerDocument: document
 				},
-				viewbox: {
-					name: 'viewbox',
+				viewBox: {
+					name: 'viewBox',
 					value: '0 0 300 100',
 					namespaceURI: null,
 					specified: true,
@@ -282,7 +281,7 @@ describe('XMLParser', () => {
 				xmlns: {
 					name: 'xmlns',
 					value: NamespaceURI.html,
-					namespaceURI: null,
+					namespaceURI: NamespaceURI.html,
 					specified: true,
 					ownerElement: svg,
 					ownerDocument: document
@@ -293,14 +292,61 @@ describe('XMLParser', () => {
 			expect(root.innerHTML.replace(/[\s]/gm, '')).toBe(
 				`
 				<div>
-					<svg viewbox="0 0 300 100" stroke="red" fill="grey" xmlns="${NamespaceURI.html}">
-						<circle cx="50" cy="50" r="40" />
-						<circle cx="150" cy="50" r="4" />
+					<svg viewBox="0 0 300 100" stroke="red" fill="grey" xmlns="${NamespaceURI.html}">
+						<circle cx="50" cy="50" r="40"></circle>
+						<circle cx="150" cy="50" r="4"></circle>
+					
+						<svg viewBox="0 0 10 10" x="200" width="100">
+							<circle cx="5" cy="5" r="4"></circle>
+						</svg>
+					</svg>
+				</div>
+			`.replace(/[\s]/gm, '')
+			);
+		});
+
+		it('Parses a malformed SVG with "xmlns" set to HTML.', () => {
+			const root = XMLParser.parse(
+				window.document,
+				`
+				<div>
+					<svg viewBox="0 0 300 100" stroke="red" fill="grey" xmlns="${NamespaceURI.html}">
+						<ellipse cx="50" cy="50" r="40">
+						<line cx="50" cy="50" r="40">
+						<path cx="50" cy="50" r="40">
+						<polygon cx="50" cy="50" r="40">
+						<polyline cx="50" cy="50" r="40" />
+						<rect cx="50" cy="50" r="40" />
+						<stop cx="50" cy="50" r="40" />
+						<use cx="50" cy="50" r="40" />
+						<circle cx="150" cy="50" r="4"><test></test></circle>
 					
 						<svg viewBox="0 0 10 10" x="200" width="100">
 							<circle cx="5" cy="5" r="4" />
 						</svg>
 					</svg>
+				</div>
+			`
+			);
+
+			expect(root.innerHTML.replace(/[\s]/gm, '')).toBe(
+				`
+				<div>
+					<svg viewBox="0 0 300 100" stroke="red" fill="grey" xmlns="${NamespaceURI.html}">
+						<ellipse cx="50" cy="50" r="40">
+						<line cx="50" cy="50" r="40">
+						<path cx="50" cy="50" r="40">
+						<polygon cx="50" cy="50" r="40">
+						<polyline cx="50" cy="50" r="40"></polyline>
+						<rect cx="50" cy="50" r="40"></rect>
+						<stop cx="50" cy="50" r="40"></stop>
+						<use cx="50" cy="50" r="40"></use>
+						<circle cx="150" cy="50" r="4"><test></test></circle>
+					
+						<svg viewBox="0 0 10 10" x="200" width="100">
+							<circle cx="5" cy="5" r="4"></circle>
+						</svg>
+					</polygon></path></line></ellipse></svg>
 				</div>
 			`.replace(/[\s]/gm, '')
 			);

--- a/packages/happy-dom/test/xml-serializer/XMLSerializer.test.ts
+++ b/packages/happy-dom/test/xml-serializer/XMLSerializer.test.ts
@@ -39,6 +39,19 @@ describe('XMLSerializer', () => {
 			);
 		});
 
+		it('Serializes void elements elements like img correctly.', () => {
+			const div = document.createElement('div');
+			const img = document.createElement('img');
+
+			img.setAttribute('src', 'https://localhost/img.jpg');
+
+			div.appendChild(img);
+
+			expect(xmlSerializer.serializeToString(div)).toBe(
+				'<div><img src="https://localhost/img.jpg"></div>'
+			);
+		});
+
 		it('Serializes a comment node.', () => {
 			const div = document.createElement('div');
 			const comment = document.createComment('');


### PR DESCRIPTION
…to void and SVG elements. This change can potentially break tests as the serialized HTML may differ from before (e.g. Element.innerHTML) and therefore it is released as a major version.