### PR TITLE
#478@major: Fixes issues with HTML serialization of the is value.

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -662,6 +662,9 @@ export default class Document extends Node implements IDocument {
 		element.tagName = tagName;
 		element.ownerDocument = this;
 		element.namespaceURI = namespaceURI;
+		if (element instanceof Element && options && options.is) {
+			element._isValue = String(options.is);
+		}
 
 		return element;
 	}

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -48,6 +48,7 @@ export default class Element extends Node implements IElement {
 	public _attributes: { [k: string]: Attr } = {};
 
 	private _classList: DOMTokenList = null;
+	public _isValue?: string;
 
 	/**
 	 * Returns class list.

--- a/packages/happy-dom/src/xml-serializer/XMLSerializer.ts
+++ b/packages/happy-dom/src/xml-serializer/XMLSerializer.ts
@@ -75,6 +75,11 @@ export default class XMLSerializer {
 	 */
 	private _getAttributes(element: IElement): string {
 		let attributeString = '';
+
+		if (!(<Element>element)._attributes.is && (<Element>element)._isValue) {
+			attributeString += ' is="' + escape((<Element>element)._isValue) + '"';
+		}
+
 		for (const attribute of Object.values((<Element>element)._attributes)) {
 			if (attribute.value !== null) {
 				attributeString += ' ' + attribute.name + '="' + escape(attribute.value) + '"';

--- a/packages/happy-dom/test/xml-serializer/XMLSerializer.test.ts
+++ b/packages/happy-dom/test/xml-serializer/XMLSerializer.test.ts
@@ -194,5 +194,18 @@ describe('XMLSerializer', () => {
 				'<div attr1="Hello \u{2068}John\u{2069}" attr2="&lt;span&gt; test" attr3=""></div>'
 			);
 		});
+
+		it('Serializes the is value.', () => {
+			const div = document.createElement('div', { is: 'custom-element' });
+
+			expect(xmlSerializer.serializeToString(div)).toBe('<div is="custom-element"></div>');
+		});
+
+		it('Ignores the is value if the is attribute is present.', () => {
+			const div = document.createElement('div', { is: 'custom-element' });
+			div.setAttribute('is', 'custom-replacement');
+
+			expect(xmlSerializer.serializeToString(div)).toBe('<div is="custom-replacement"></div>');
+		});
 	});
 });


### PR DESCRIPTION
This change can potentially break tests as the serialized HTML may differ from before (e.g. Element.innerHTML) and therefore it is released as a major version.