### PR TITLE
#501@patch: allow proxy keys besides strings

### DIFF
--- a/packages/happy-dom/src/nodes/html-element/DatasetUtility.ts
+++ b/packages/happy-dom/src/nodes/html-element/DatasetUtility.ts
@@ -23,6 +23,8 @@ export default class DatasetUtility {
 	 * @returns Kebab cased string.
 	 */
 	public static camelCaseToKebab(text: string): string {
-		return text.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase());
+		return text
+			.toString()
+			.replace(/[A-Z]+(?![a-z])|[A-Z]/g, ($, ofs) => (ofs ? '-' : '') + $.toLowerCase());
 	}
 }


### PR DESCRIPTION
fixes #501 

Simplest solution was to add the toString method.

I did try to change types and write a wrapper function the proxy handler uses, but major blocking point of that was a type error I couldn't resolve. Mainly `type symbol can not be used as an index` which since version [4.4](https://github.com/Microsoft/TypeScript/issues/24587#issuecomment-890314169) of typescript is completely valid. Couldn't figure out why it wouldn't allow it in this specific repo, as I wasn't having issues with my other ones.