### PR TITLE
#524@minor: Add support for Node.compareDocumentPosition().

### DIFF
--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -120,6 +120,10 @@ import Selection from './selection/Selection';
 import Range from './range/Range';
 import HTMLDialogElement from './nodes/html-dialog-element/HTMLDialogElement';
 import IHTMLDialogElement from './nodes/html-dialog-element/IHTMLDialogElement';
+import Attr from './nodes/attr/Attr';
+import IAttr from './nodes/attr/IAttr';
+import ProcessingInstruction from './nodes/processing-instruction/ProcessingInstruction';
+import IProcessingInstruction from './nodes/processing-instruction/IProcessingInstruction';
 
 export {
 	GlobalWindow,
@@ -243,5 +247,9 @@ export {
 	Selection,
 	Range,
 	HTMLDialogElement,
-	IHTMLDialogElement
+	IHTMLDialogElement,
+	Attr,
+	IAttr,
+	ProcessingInstruction,
+	IProcessingInstruction
 };

--- a/packages/happy-dom/src/nodes/attr/Attr.ts
+++ b/packages/happy-dom/src/nodes/attr/Attr.ts
@@ -8,6 +8,7 @@ import IAttr from './IAttr';
  * Reference: https://developer.mozilla.org/en-US/docs/Web/API/Attr.
  */
 export default class Attr extends Node implements IAttr {
+	public readonly nodeType = Node.ATTRIBUTE_NODE;
 	public value: string = null;
 	public name: string = null;
 	public namespaceURI: string = null;

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -44,6 +44,8 @@ import IAttr from '../attr/IAttr';
 import IProcessingInstruction from '../processing-instruction/IProcessingInstruction';
 import ProcessingInstruction from '../processing-instruction/ProcessingInstruction';
 
+const PROCESSING_INSTRUCTION_TARGET_REGEXP = /^[a-z][a-z0-9-]+$/;
+
 /**
  * Document.
  */
@@ -835,8 +837,15 @@ export default class Document extends Node implements IDocument {
 	 * @param data
 	 */
 	public createProcessingInstruction(target: string, data: string): IProcessingInstruction {
+		if (!target || !PROCESSING_INSTRUCTION_TARGET_REGEXP.test(target)) {
+			throw new DOMException(
+				`Failed to execute 'createProcessingInstruction' on 'Document': The target provided ('${target}') is not a valid name.`
+			);
+		}
 		if (data.includes('?>')) {
-			throw new DOMException('InvalidCharacterError');
+			throw new DOMException(
+				`Failed to execute 'createProcessingInstruction' on 'Document': The data provided ('?>') contains '?>'`
+			);
 		}
 		ProcessingInstruction._ownerDocument = this;
 		const processingInstruction = new ProcessingInstruction(data);

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -41,6 +41,8 @@ import IShadowRoot from '../shadow-root/IShadowRoot';
 import Range from '../../range/Range';
 import IHTMLBaseElement from '../html-base-element/IHTMLBaseElement';
 import IAttr from '../attr/IAttr';
+import IProcessingInstruction from '../processing-instruction/IProcessingInstruction';
+import ProcessingInstruction from '../processing-instruction/ProcessingInstruction';
 
 /**
  * Document.
@@ -823,5 +825,22 @@ export default class Document extends Node implements IDocument {
 			this.dispatchEvent(new Event('readystatechange'));
 			this.dispatchEvent(new Event('load', { bubbles: true }));
 		});
+	}
+
+	/**
+	 * Creates a Processing Instruction node.
+	 *
+	 * @returns IProcessingInstruction.
+	 * @param target
+	 * @param data
+	 */
+	public createProcessingInstruction(target: string, data: string): IProcessingInstruction {
+		if (data.includes('?>')) {
+			throw new DOMException('InvalidCharacterError');
+		}
+		ProcessingInstruction._ownerDocument = this;
+		const processingInstruction = new ProcessingInstruction(data);
+		processingInstruction.target = target;
+		return processingInstruction;
 	}
 }

--- a/packages/happy-dom/src/nodes/document/IDocument.ts
+++ b/packages/happy-dom/src/nodes/document/IDocument.ts
@@ -19,6 +19,7 @@ import Location from '../../location/Location';
 import DocumentReadyStateEnum from './DocumentReadyStateEnum';
 import INodeList from '../node/INodeList';
 import Range from '../../range/Range';
+import IProcessingInstruction from '../processing-instruction/IProcessingInstruction';
 
 /**
  * Document.
@@ -197,4 +198,13 @@ export default interface IDocument extends IParentNode {
 	 * @returns "true" if the document has focus.
 	 */
 	hasFocus(): boolean;
+
+	/**
+	 * Creates a Processing Instruction node.
+	 *
+	 * @returns IProcessingInstruction.
+	 * @param target
+	 * @param data
+	 */
+	createProcessingInstruction(target: string, data: string): IProcessingInstruction;
 }

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -39,6 +39,7 @@ export default class Element extends Node implements IElement {
 	public tagName: string = null;
 	public nodeType = Node.ELEMENT_NODE;
 	public shadowRoot: IShadowRoot = null;
+	public prefix: string = null;
 
 	public scrollTop = 0;
 	public scrollLeft = 0;

--- a/packages/happy-dom/src/nodes/element/IElement.ts
+++ b/packages/happy-dom/src/nodes/element/IElement.ts
@@ -18,6 +18,7 @@ export default interface IElement extends IChildNode, INonDocumentTypeChildNode,
 	readonly shadowRoot: IShadowRoot;
 	readonly classList: IDOMTokenList;
 	readonly namespaceURI: string;
+	prefix: string | null;
 	scrollTop: number;
 	scrollLeft: number;
 	id: string;

--- a/packages/happy-dom/src/nodes/node/INode.ts
+++ b/packages/happy-dom/src/nodes/node/INode.ts
@@ -3,6 +3,7 @@ import IDocument from '../document/IDocument';
 import IElement from '../element/IElement';
 import INodeList from './INodeList';
 import NodeTypeEnum from './NodeTypeEnum';
+import NodeDocumentPositionEnum from './NodeDocumentPositionEnum';
 
 export default interface INode extends IEventTarget {
 	readonly ELEMENT_NODE: NodeTypeEnum;
@@ -14,6 +15,12 @@ export default interface INode extends IEventTarget {
 	readonly DOCUMENT_TYPE_NODE: NodeTypeEnum;
 	readonly DOCUMENT_FRAGMENT_NODE: NodeTypeEnum;
 	readonly PROCESSING_INSTRUCTION_NODE: NodeTypeEnum;
+	readonly DOCUMENT_POSITION_DISCONNECTED: NodeDocumentPositionEnum;
+	readonly DOCUMENT_POSITION_PRECEDING: NodeDocumentPositionEnum;
+	readonly DOCUMENT_POSITION_FOLLOWING: NodeDocumentPositionEnum;
+	readonly DOCUMENT_POSITION_CONTAINS: NodeDocumentPositionEnum;
+	readonly DOCUMENT_POSITION_CONTAINED_BY: NodeDocumentPositionEnum;
+	readonly DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: NodeDocumentPositionEnum;
 	readonly ownerDocument: IDocument;
 	readonly parentNode: INode;
 	readonly parentElement: IElement;
@@ -39,4 +46,5 @@ export default interface INode extends IEventTarget {
 	insertBefore(newNode: INode, referenceNode?: INode | null): INode;
 	replaceChild(newChild: INode, oldChild: INode): INode;
 	toString(): string;
+	compareDocumentPosition(otherNode: INode): number;
 }

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -11,6 +11,9 @@ import IHTMLBaseElement from '../html-base-element/IHTMLBaseElement';
 import INodeList from './INodeList';
 import NodeListFactory from './NodeListFactory';
 import NodeTypeEnum from './NodeTypeEnum';
+import NodeDocumentPositionEnum from './NodeDocumentPositionEnum';
+import NodeUtility from './NodeUtility';
+import IAttr from '../attr/IAttr';
 
 /**
  * Node.
@@ -29,6 +32,13 @@ export default class Node extends EventTarget implements INode {
 	public static readonly DOCUMENT_TYPE_NODE = NodeTypeEnum.documentTypeNode;
 	public static readonly DOCUMENT_FRAGMENT_NODE = NodeTypeEnum.documentFragmentNode;
 	public static readonly PROCESSING_INSTRUCTION_NODE = NodeTypeEnum.processingInstructionNode;
+	public static readonly DOCUMENT_POSITION_CONTAINED_BY = NodeDocumentPositionEnum.containedBy;
+	public static readonly DOCUMENT_POSITION_CONTAINS = NodeDocumentPositionEnum.contains;
+	public static readonly DOCUMENT_POSITION_DISCONNECTED = NodeDocumentPositionEnum.disconnect;
+	public static readonly DOCUMENT_POSITION_FOLLOWING = NodeDocumentPositionEnum.following;
+	public static readonly DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC =
+		NodeDocumentPositionEnum.implementationSpecific;
+	public static readonly DOCUMENT_POSITION_PRECEDING = NodeDocumentPositionEnum.preceding;
 	public readonly ELEMENT_NODE = NodeTypeEnum.elementNode;
 	public readonly ATTRIBUTE_NODE = NodeTypeEnum.attributeNode;
 	public readonly TEXT_NODE = NodeTypeEnum.textNode;
@@ -38,6 +48,13 @@ export default class Node extends EventTarget implements INode {
 	public readonly DOCUMENT_TYPE_NODE = NodeTypeEnum.documentTypeNode;
 	public readonly DOCUMENT_FRAGMENT_NODE = NodeTypeEnum.documentFragmentNode;
 	public readonly PROCESSING_INSTRUCTION_NODE = NodeTypeEnum.processingInstructionNode;
+	public readonly DOCUMENT_POSITION_CONTAINED_BY = NodeDocumentPositionEnum.containedBy;
+	public readonly DOCUMENT_POSITION_CONTAINS = NodeDocumentPositionEnum.contains;
+	public readonly DOCUMENT_POSITION_DISCONNECTED = NodeDocumentPositionEnum.disconnect;
+	public readonly DOCUMENT_POSITION_FOLLOWING = NodeDocumentPositionEnum.following;
+	public readonly DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC =
+		NodeDocumentPositionEnum.implementationSpecific;
+	public readonly DOCUMENT_POSITION_PRECEDING = NodeDocumentPositionEnum.preceding;
 	public readonly ownerDocument: IDocument = null;
 	public readonly parentNode: INode = null;
 	public readonly nodeType: number;
@@ -444,7 +461,7 @@ export default class Node extends EventTarget implements INode {
 			}
 
 			// eslint-disable-next-line
-			if(event.composed && (<any>this).host) {
+			if (event.composed && (<any>this).host) {
 				// eslint-disable-next-line
 				return (<any>this).host.dispatchEvent(event);
 			}
@@ -527,5 +544,178 @@ export default class Node extends EventTarget implements INode {
 				(<any>this)._shadowRoot._connectToNode(this);
 			}
 		}
+	}
+
+	/**
+	 * Reports the position of its argument node relative to the node on which it is called.
+	 * Reference: https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
+	 *
+	 * @param otherNode
+	 */
+	public compareDocumentPosition(otherNode: INode): number {
+		/**
+		 * 1. If this is other, then return zero.
+		 */
+		if (this === otherNode) {
+			return 0;
+		}
+
+		/**
+		 * 2. Let node1 be other and node2 be this.
+		 */
+		let node1: INode = otherNode;
+		let node2: INode = this;
+
+		/**
+		 * 3. Let attr1 and attr2 be null.
+		 */
+		let attr1 = null;
+		let attr2 = null;
+
+		/**
+		 * 4. If node1 is an attribute, then set attr1 to node1 and node1 to attr1’s element.
+		 */
+		if (node1.nodeType === Node.ATTRIBUTE_NODE) {
+			attr1 = node1;
+			node1 = (<IAttr>attr1).ownerElement;
+		}
+
+		/**
+		 * 5. If node2 is an attribute, then:
+		 * 5.1. Set attr2 to node2 and node2 to attr2’s element.
+		 */
+		if (node2.nodeType === Node.ATTRIBUTE_NODE) {
+			attr2 = node2;
+			node2 = (<IAttr>attr2).ownerElement;
+
+			/**
+			 * 5.2. If attr1 and node1 are non-null, and node2 is node1, then:
+			 */
+			if (attr1 !== null && node1 !== null && node2 === node1) {
+				/**
+				 * 5.2.1. For each attr in node2’s attribute list:
+				 */
+				for (const attr of Object.values((<IElement>node2).attributes)) {
+					/**
+					 * 5.2.1.1. If attr equals attr1, then return the result of adding DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC and DOCUMENT_POSITION_PRECEDING.
+					 */
+					if (NodeUtility.nodeEquals(<IAttr>attr, attr1)) {
+						return (
+							Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC | Node.DOCUMENT_POSITION_PRECEDING
+						);
+					}
+
+					/**
+					 * 5.2.1.2. If attr equals attr2, then return the result of adding DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC and DOCUMENT_POSITION_FOLLOWING.
+					 */
+					if (NodeUtility.nodeEquals(<IAttr>attr, attr2)) {
+						return (
+							Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC | Node.DOCUMENT_POSITION_FOLLOWING
+						);
+					}
+				}
+			}
+		}
+
+		const node2Ancestors: INode[] = [];
+		let node2Ancestor: INode = node2;
+
+		while (node2Ancestor) {
+			/**
+			 * 7. If node1 is an ancestor of node2 […] then return the result of adding DOCUMENT_POSITION_CONTAINS to DOCUMENT_POSITION_PRECEDING.
+			 */
+			if (node2Ancestor === node1) {
+				return Node.DOCUMENT_POSITION_CONTAINS | Node.DOCUMENT_POSITION_PRECEDING;
+			}
+
+			node2Ancestors.push(node2Ancestor);
+			node2Ancestor = node2Ancestor.parentNode;
+		}
+
+		const node1Ancestors: INode[] = [];
+		let node1Ancestor: INode = node1;
+
+		while (node1Ancestor) {
+			/**
+			 * 8. If node1 is a descendant of node2 […] then return the result of adding DOCUMENT_POSITION_CONTAINED_BY to DOCUMENT_POSITION_FOLLOWING.
+			 */
+			if (node1Ancestor === node2) {
+				return Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING;
+			}
+
+			node1Ancestors.push(node1Ancestor);
+			node1Ancestor = node1Ancestor.parentNode;
+		}
+
+		const reverseArrayIndex = (array: INode[], reverseIndex: number): INode => {
+			return array[array.length - 1 - reverseIndex];
+		};
+
+		const root = reverseArrayIndex(node2Ancestors, 0);
+
+		/**
+		 * 6. If node1 or node2 is null, or node1’s root is not node2’s root, then return the result of adding
+		 * DOCUMENT_POSITION_DISCONNECTED, DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC, and either
+		 * DOCUMENT_POSITION_PRECEDING or DOCUMENT_POSITION_FOLLOWING, with the constraint that this is to be consistent, together.
+		 */
+		if (!root || root !== reverseArrayIndex(node1Ancestors, 0)) {
+			return (
+				Node.DOCUMENT_POSITION_DISCONNECTED |
+				Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC |
+				Node.DOCUMENT_POSITION_FOLLOWING
+			);
+		}
+
+		// Find the lowest common ancestor
+		let commonAncestorIndex = 0;
+		const ancestorsMinLength = Math.min(node2Ancestors.length, node1Ancestors.length);
+
+		for (let i = 0; i < ancestorsMinLength; ++i) {
+			const node2Ancestor = reverseArrayIndex(node2Ancestors, i);
+			const node1Ancestor = reverseArrayIndex(node1Ancestors, i);
+
+			if (node2Ancestor !== node1Ancestor) {
+				break;
+			}
+
+			commonAncestorIndex = i;
+		}
+
+		const commonAncestor = reverseArrayIndex(node2Ancestors, commonAncestorIndex);
+
+		// Indexes within the common ancestor
+		let indexes = 0;
+		let node2Index = -1;
+		let node1Index = -1;
+		const node2Node = reverseArrayIndex(node2Ancestors, commonAncestorIndex + 1);
+		const node1Node = reverseArrayIndex(node1Ancestors, commonAncestorIndex + 1);
+
+		const computeNodeIndexes = (nodes: INode[]): void => {
+			for (const childNode of nodes) {
+				computeNodeIndexes(childNode.childNodes);
+
+				if (childNode === node2Node) {
+					node2Index = indexes;
+				} else if (childNode === node1Node) {
+					node1Index = indexes;
+				}
+
+				if (node2Index !== -1 && node1Index !== -1) {
+					break;
+				}
+
+				indexes++;
+			}
+		};
+
+		computeNodeIndexes(commonAncestor.childNodes);
+
+		/**
+		 * 9. If node1 is preceding node2, then return DOCUMENT_POSITION_PRECEDING.
+		 * 10. Return DOCUMENT_POSITION_FOLLOWING.
+		 */
+		return node1Index < node2Index
+			? Node.DOCUMENT_POSITION_PRECEDING
+			: Node.DOCUMENT_POSITION_FOLLOWING;
 	}
 }

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -548,9 +548,9 @@ export default class Node extends EventTarget implements INode {
 
 	/**
 	 * Reports the position of its argument node relative to the node on which it is called.
-	 * Reference: https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
 	 *
-	 * @param otherNode
+	 * @see https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
+	 * @param otherNode Other node.
 	 */
 	public compareDocumentPosition(otherNode: INode): number {
 		/**

--- a/packages/happy-dom/src/nodes/node/NodeDocumentPositionEnum.ts
+++ b/packages/happy-dom/src/nodes/node/NodeDocumentPositionEnum.ts
@@ -1,0 +1,10 @@
+enum NodeDocumentPositionEnum {
+	disconnect = 0x01,
+	preceding = 0x02,
+	following = 0x04,
+	contains = 0x08,
+	containedBy = 0x10,
+	implementationSpecific = 0x20
+}
+
+export default NodeDocumentPositionEnum;

--- a/packages/happy-dom/src/nodes/node/NodeUtility.ts
+++ b/packages/happy-dom/src/nodes/node/NodeUtility.ts
@@ -2,6 +2,10 @@ import IText from '../text/IText';
 import IComment from '../comment/IComment';
 import INode from './INode';
 import NodeTypeEnum from './NodeTypeEnum';
+import IElement from '../element/IElement';
+import IDocumentType from '../document-type/IDocumentType';
+import IAttr from '../attr/IAttr';
+import IProcessingInstruction from '../processing-instruction/IProcessingInstruction';
 
 /**
  * Node utility.
@@ -135,5 +139,138 @@ export default class NodeUtility {
 		}
 
 		return node.nextSibling;
+	}
+
+	/**
+	 * Needed by https://dom.spec.whatwg.org/#concept-node-equals
+	 *
+	 * @param elementA
+	 * @param elementB
+	 */
+	public static attributeListsEqual(elementA: IElement, elementB: IElement): boolean {
+		const listA = Object.values(elementA.attributes);
+		const listB = Object.values(elementB.attributes);
+
+		const lengthA = listA.length;
+		const lengthB = listB.length;
+
+		if (lengthA !== lengthB) {
+			return false;
+		}
+
+		for (let i = 0; i < lengthA; ++i) {
+			const attrA = listA[i];
+
+			if (
+				!listB.some((attrB) => {
+					return (
+						(typeof attrA === 'number' && typeof attrB === 'number' && attrA === attrB) ||
+						(typeof attrA === 'object' &&
+							typeof attrB === 'object' &&
+							NodeUtility.nodeEquals(attrA, attrB))
+					);
+				})
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if node a equals node b.
+	 * Reference: https://dom.spec.whatwg.org/#concept-node-equals
+	 *
+	 * @param a
+	 * @param b
+	 */
+	public static nodeEquals(a: INode, b: INode): boolean {
+		if (a.nodeType !== b.nodeType) {
+			return false;
+		}
+
+		switch (a.nodeType) {
+			case NodeTypeEnum.documentTypeNode:
+				const documentTypeA = <IDocumentType>a;
+				const documentTypeB = <IDocumentType>b;
+
+				if (
+					documentTypeA.name !== documentTypeB.name ||
+					documentTypeA.publicId !== documentTypeB.publicId ||
+					documentTypeA.systemId !== documentTypeB.systemId
+				) {
+					return false;
+				}
+				break;
+			case NodeTypeEnum.elementNode:
+				const elementA = <IElement>a;
+				const elementB = <IElement>b;
+
+				if (
+					elementA.namespaceURI !== elementB.namespaceURI ||
+					elementA.prefix !== elementB.prefix ||
+					elementA.localName !== elementB.localName ||
+					elementA.attributes.length !== elementB.attributes.length
+				) {
+					return false;
+				}
+				break;
+			case NodeTypeEnum.attributeNode:
+				const attributeA = <IAttr>a;
+				const attributeB = <IAttr>b;
+
+				if (
+					attributeA.namespaceURI !== attributeB.namespaceURI ||
+					attributeA.localName !== attributeB.localName ||
+					attributeA.value !== attributeB.value
+				) {
+					return false;
+				}
+				break;
+			case NodeTypeEnum.processingInstructionNode:
+				const processingInstructionA = <IProcessingInstruction>a;
+				const processingInstructionB = <IProcessingInstruction>b;
+
+				if (
+					processingInstructionA.target !== processingInstructionB.target ||
+					processingInstructionA.data !== processingInstructionB.data
+				) {
+					return false;
+				}
+				break;
+			case NodeTypeEnum.textNode:
+			case NodeTypeEnum.commentNode:
+				type TextOrComment = IText | IComment;
+				const textOrCommentA = <TextOrComment>a;
+				const textOrCommentB = <TextOrComment>b;
+
+				if (textOrCommentA.data !== textOrCommentB.data) {
+					return false;
+				}
+				break;
+		}
+
+		if (
+			a.nodeType === NodeTypeEnum.elementNode &&
+			!NodeUtility.attributeListsEqual(<IElement>a, <IElement>b)
+		) {
+			return false;
+		}
+
+		if (a.childNodes.length !== b.childNodes.length) {
+			return false;
+		}
+
+		for (let i = 0; i < a.childNodes.length; i++) {
+			const nodeA = a.childNodes[i];
+			const nodeB = b.childNodes[i];
+
+			if (!NodeUtility.nodeEquals(nodeA, nodeB)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/packages/happy-dom/src/nodes/node/NodeUtility.ts
+++ b/packages/happy-dom/src/nodes/node/NodeUtility.ts
@@ -179,21 +179,21 @@ export default class NodeUtility {
 	}
 
 	/**
-	 * Check if node a equals node b.
+	 * Check if node nodeA equals node nodeB.
 	 * Reference: https://dom.spec.whatwg.org/#concept-node-equals
 	 *
-	 * @param a
-	 * @param b
+	 * @param nodeA Node A.
+	 * @param nodeB Node B.
 	 */
-	public static nodeEquals(a: INode, b: INode): boolean {
-		if (a.nodeType !== b.nodeType) {
+	public static nodeEquals(nodeA: INode, nodeB: INode): boolean {
+		if (nodeA.nodeType !== nodeB.nodeType) {
 			return false;
 		}
 
-		switch (a.nodeType) {
+		switch (nodeA.nodeType) {
 			case NodeTypeEnum.documentTypeNode:
-				const documentTypeA = <IDocumentType>a;
-				const documentTypeB = <IDocumentType>b;
+				const documentTypeA = <IDocumentType>nodeA;
+				const documentTypeB = <IDocumentType>nodeB;
 
 				if (
 					documentTypeA.name !== documentTypeB.name ||
@@ -204,8 +204,8 @@ export default class NodeUtility {
 				}
 				break;
 			case NodeTypeEnum.elementNode:
-				const elementA = <IElement>a;
-				const elementB = <IElement>b;
+				const elementA = <IElement>nodeA;
+				const elementB = <IElement>nodeB;
 
 				if (
 					elementA.namespaceURI !== elementB.namespaceURI ||
@@ -217,8 +217,8 @@ export default class NodeUtility {
 				}
 				break;
 			case NodeTypeEnum.attributeNode:
-				const attributeA = <IAttr>a;
-				const attributeB = <IAttr>b;
+				const attributeA = <IAttr>nodeA;
+				const attributeB = <IAttr>nodeB;
 
 				if (
 					attributeA.namespaceURI !== attributeB.namespaceURI ||
@@ -229,8 +229,8 @@ export default class NodeUtility {
 				}
 				break;
 			case NodeTypeEnum.processingInstructionNode:
-				const processingInstructionA = <IProcessingInstruction>a;
-				const processingInstructionB = <IProcessingInstruction>b;
+				const processingInstructionA = <IProcessingInstruction>nodeA;
+				const processingInstructionB = <IProcessingInstruction>nodeB;
 
 				if (
 					processingInstructionA.target !== processingInstructionB.target ||
@@ -242,8 +242,8 @@ export default class NodeUtility {
 			case NodeTypeEnum.textNode:
 			case NodeTypeEnum.commentNode:
 				type TextOrComment = IText | IComment;
-				const textOrCommentA = <TextOrComment>a;
-				const textOrCommentB = <TextOrComment>b;
+				const textOrCommentA = <TextOrComment>nodeA;
+				const textOrCommentB = <TextOrComment>nodeB;
 
 				if (textOrCommentA.data !== textOrCommentB.data) {
 					return false;
@@ -252,21 +252,21 @@ export default class NodeUtility {
 		}
 
 		if (
-			a.nodeType === NodeTypeEnum.elementNode &&
-			!NodeUtility.attributeListsEqual(<IElement>a, <IElement>b)
+			nodeA.nodeType === NodeTypeEnum.elementNode &&
+			!NodeUtility.attributeListsEqual(<IElement>nodeA, <IElement>nodeB)
 		) {
 			return false;
 		}
 
-		if (a.childNodes.length !== b.childNodes.length) {
+		if (nodeA.childNodes.length !== nodeB.childNodes.length) {
 			return false;
 		}
 
-		for (let i = 0; i < a.childNodes.length; i++) {
-			const nodeA = a.childNodes[i];
-			const nodeB = b.childNodes[i];
+		for (let i = 0; i < nodeA.childNodes.length; i++) {
+			const childNodeA = nodeA.childNodes[i];
+			const childNodeB = nodeB.childNodes[i];
 
-			if (!NodeUtility.nodeEquals(nodeA, nodeB)) {
+			if (!NodeUtility.nodeEquals(childNodeA, childNodeB)) {
 				return false;
 			}
 		}

--- a/packages/happy-dom/src/nodes/processing-instruction/IProcessingInstruction.ts
+++ b/packages/happy-dom/src/nodes/processing-instruction/IProcessingInstruction.ts
@@ -1,0 +1,5 @@
+import ICharacterData from '../character-data/ICharacterData';
+
+export default interface IProcessingInstruction extends ICharacterData {
+	target: string;
+}

--- a/packages/happy-dom/src/nodes/processing-instruction/ProcessingInstruction.ts
+++ b/packages/happy-dom/src/nodes/processing-instruction/ProcessingInstruction.ts
@@ -1,6 +1,6 @@
 import IProcessingInstruction from './IProcessingInstruction';
 import CharacterData from '../character-data/CharacterData';
-import Node from '../node/Node';
+import NodeTypeEnum from '../node/NodeTypeEnum';
 
 /**
  * Processing instruction node interface.
@@ -8,7 +8,6 @@ import Node from '../node/Node';
  * Reference: https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction.
  */
 export default class ProcessingInstruction extends CharacterData implements IProcessingInstruction {
-	public readonly nodeType = Node.PROCESSING_INSTRUCTION_NODE;
-
+	public readonly nodeType = NodeTypeEnum.processingInstructionNode;
 	public target: string;
 }

--- a/packages/happy-dom/src/nodes/processing-instruction/ProcessingInstruction.ts
+++ b/packages/happy-dom/src/nodes/processing-instruction/ProcessingInstruction.ts
@@ -1,0 +1,14 @@
+import IProcessingInstruction from './IProcessingInstruction';
+import CharacterData from '../character-data/CharacterData';
+import Node from '../node/Node';
+
+/**
+ * Processing instruction node interface.
+ *
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction.
+ */
+export default class ProcessingInstruction extends CharacterData implements IProcessingInstruction {
+	public readonly nodeType = Node.PROCESSING_INSTRUCTION_NODE;
+
+	public target: string;
+}

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -98,6 +98,7 @@ import Attr from '../nodes/attr/Attr';
 import { URLSearchParams } from 'url';
 import { Performance } from 'perf_hooks';
 import IElement from '../nodes/element/IElement';
+import ProcessingInstruction from '../nodes/processing-instruction/ProcessingInstruction';
 
 /**
  * Window without dependencies to server side specific packages.
@@ -142,6 +143,7 @@ export default interface IWindow extends IEventTarget, NodeJS.Global {
 	readonly Element: typeof Element;
 	readonly DocumentFragment: typeof DocumentFragment;
 	readonly CharacterData: typeof CharacterData;
+	readonly ProcessingInstruction: typeof ProcessingInstruction;
 	readonly NodeFilter: typeof NodeFilter;
 	readonly TreeWalker: typeof TreeWalker;
 	readonly DOMParser: typeof DOMParser;

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -109,6 +109,7 @@ import Base64 from '../base64/Base64';
 import IDocument from '../nodes/document/IDocument';
 import Attr from '../nodes/attr/Attr';
 import IElement from '../nodes/element/IElement';
+import ProcessingInstruction from '../nodes/processing-instruction/ProcessingInstruction';
 
 const ORIGINAL_SET_TIMEOUT = setTimeout;
 const ORIGINAL_CLEAR_TIMEOUT = clearTimeout;
@@ -171,6 +172,7 @@ export default class Window extends EventTarget implements IWindow {
 	public readonly Text = Text;
 	public readonly Comment = Comment;
 	public readonly ShadowRoot = ShadowRoot;
+	public readonly ProcessingInstruction = ProcessingInstruction;
 	public readonly Element = Element;
 	public readonly DocumentFragment = DocumentFragment;
 	public readonly CharacterData = CharacterData;

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -30,6 +30,8 @@ import ISVGElement from '../../../src/nodes/svg-element/ISVGElement';
 import CustomEvent from '../../../src/event/events/CustomEvent';
 import Selection from '../../../src/selection/Selection';
 import Range from '../../../src/range/Range';
+import ProcessingInstruction from '../../../src/nodes/processing-instruction/ProcessingInstruction';
+import DOMException from '../../../src/exception/DOMException';
 
 /* eslint-disable jsdoc/require-jsdoc */
 
@@ -1132,6 +1134,29 @@ describe('Document', () => {
 			document.dispatchEvent(event);
 
 			expect(emittedEvent).toBe(event);
+		});
+	});
+
+	describe('createProcessingInstruction()', () => {
+		it('Creates a Processing Instruction node with target & data.', () => {
+			const instruction = document.createProcessingInstruction('foo', 'bar');
+			expect(instruction instanceof ProcessingInstruction).toBe(true);
+			expect(instruction).toEqual(
+				expect.objectContaining({
+					target: 'foo',
+					data: 'bar',
+					ownerDocument: document
+				})
+			);
+		});
+
+		it('Throws an exception if data contains "?>".', () => {
+			expect.assertions(1);
+			try {
+				document.createProcessingInstruction('foo', 'bar?>');
+			} catch (e) {
+				expect(e).toEqual(new DOMException('InvalidCharacterError'));
+			}
 		});
 	});
 });

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1150,12 +1150,29 @@ describe('Document', () => {
 			);
 		});
 
+		it('Throws an exception if target is invalid".', () => {
+			expect.assertions(1);
+			try {
+				document.createProcessingInstruction('-foo', 'bar');
+			} catch (e) {
+				expect(e).toEqual(
+					new DOMException(
+						`Failed to execute 'createProcessingInstruction' on 'Document': The target provided ('-foo') is not a valid name.`
+					)
+				);
+			}
+		});
+
 		it('Throws an exception if data contains "?>".', () => {
 			expect.assertions(1);
 			try {
 				document.createProcessingInstruction('foo', 'bar?>');
 			} catch (e) {
-				expect(e).toEqual(new DOMException('InvalidCharacterError'));
+				expect(e).toEqual(
+					new DOMException(
+						`Failed to execute 'createProcessingInstruction' on 'Document': The data provided ('?>') contains '?>'`
+					)
+				);
 			}
 		});
 	});

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -624,4 +624,81 @@ describe('Node', () => {
 			expect(parentEvent).toBe(event);
 		});
 	});
+
+	describe('compareDocumentPosition()', () => {
+		it('Returns 0 if b is a', () => {
+			const div = document.createElement('div');
+			div.id = 'element';
+
+			document.body.appendChild(div);
+
+			expect(
+				document
+					.getElementById('element')
+					.compareDocumentPosition(document.getElementById('element'))
+			).toEqual(0);
+		});
+
+		it('Returns 4 if b is following a', () => {
+			const div = document.createElement('div');
+			const span1 = document.createElement('span');
+			span1.id = 'span1';
+			const span2 = document.createElement('span');
+			span2.id = 'span2';
+
+			div.appendChild(span1);
+			div.appendChild(span2);
+			document.body.appendChild(div);
+
+			expect(
+				document.getElementById('span1').compareDocumentPosition(document.getElementById('span2'))
+			).toEqual(4);
+		});
+
+		it('Returns 2 if b is preceding a', () => {
+			const div = document.createElement('div');
+			const span1 = document.createElement('span');
+			span1.id = 'span1';
+			const span2 = document.createElement('span');
+			span2.id = 'span2';
+
+			div.appendChild(span1);
+			div.appendChild(span2);
+			document.body.appendChild(div);
+
+			expect(
+				document.getElementById('span2').compareDocumentPosition(document.getElementById('span1'))
+			).toEqual(2);
+		});
+
+		it('Returns 20 if b is contained by a', () => {
+			const div = document.createElement('div');
+			div.id = 'parent';
+			const span = document.createElement('span');
+			span.id = 'child';
+
+			div.appendChild(span);
+			document.body.appendChild(div);
+
+			const position = document
+				.getElementById('parent')
+				.compareDocumentPosition(document.getElementById('child'));
+			expect(position).toEqual(20);
+		});
+
+		it('Returns 10 if b contains a', () => {
+			const div = document.createElement('div');
+			div.id = 'parent';
+			const span = document.createElement('span');
+			span.id = 'child';
+
+			div.appendChild(span);
+			document.body.appendChild(div);
+
+			const position = document
+				.getElementById('child')
+				.compareDocumentPosition(document.getElementById('parent'));
+			expect(position).toEqual(10);
+		});
+	});
 });

--- a/packages/happy-dom/test/nodes/node/NodeUtility.test.ts
+++ b/packages/happy-dom/test/nodes/node/NodeUtility.test.ts
@@ -2,6 +2,8 @@ import Window from '../../../src/window/Window';
 import Document from '../../../src/nodes/document/Document';
 import NodeUtility from '../../../src/nodes/node/NodeUtility';
 import NodeTypeEnum from '../../../src/nodes/node/NodeTypeEnum';
+import DOMImplementation from '../../../src/dom-implementation/DOMImplementation';
+import IDocument from '../../../src/nodes/document/IDocument';
 
 describe('NodeUtility', () => {
 	let window: Window;
@@ -101,6 +103,265 @@ describe('NodeUtility', () => {
 			div.appendChild(text3);
 
 			expect(NodeUtility.getNodeLength(div)).toBe(3);
+		});
+	});
+
+	describe('attributeListsEqual()', () => {
+		it('Returns false if lists does not have same length', () => {
+			const element1 = document.createElement('div');
+			const element2 = document.createElement('div');
+			const attrFoo = document.createAttribute('data-foo');
+			const attrBar = document.createAttribute('data-bar');
+
+			element1.setAttributeNode(attrFoo);
+			element2.setAttributeNode(attrFoo);
+			element1.setAttributeNode(attrBar);
+
+			expect(NodeUtility.attributeListsEqual(element1, element2)).toEqual(false);
+		});
+
+		it('Returns false if lists are not equal', () => {
+			const element1 = document.createElement('div');
+			const element2 = document.createElement('div');
+			const attrFoo = document.createAttribute('data-foo');
+			const attrBar = document.createAttribute('data-bar');
+			const attrLorem = document.createAttribute('data-lorem');
+
+			element1.setAttributeNode(attrFoo);
+			element1.setAttributeNode(attrBar);
+			element2.setAttributeNode(attrFoo);
+			element2.setAttributeNode(attrLorem);
+
+			expect(NodeUtility.attributeListsEqual(element1, element2)).toEqual(false);
+		});
+
+		it('Returns true if attribute lists are equal', () => {
+			const element1 = document.createElement('div');
+			const element2 = document.createElement('div');
+			const attrFoo = document.createAttribute('data-foo');
+
+			element1.setAttributeNode(attrFoo);
+			element2.setAttributeNode(attrFoo);
+
+			expect(NodeUtility.attributeListsEqual(element1, element2)).toEqual(true);
+		});
+	});
+
+	describe('nodeEquals()', () => {
+		it('Returns false if element are not of same node type', () => {
+			const element = document.createElement('div');
+			const comment = document.createComment('foo');
+
+			expect(NodeUtility.nodeEquals(element, comment)).toEqual(false);
+		});
+
+		describe('w/ document type node', () => {
+			let document: IDocument;
+			let implementation: DOMImplementation;
+
+			beforeEach(() => {
+				document = new Document();
+				implementation = new DOMImplementation(document);
+			});
+
+			it('Returns false if name are different', () => {
+				const doctype1 = implementation.createDocumentType('html1', 'foo', 'bar');
+				const doctype2 = implementation.createDocumentType('html2', 'foo', 'bar');
+
+				expect(NodeUtility.nodeEquals(doctype1, doctype2)).toEqual(false);
+			});
+
+			it('Returns false if public id are different', () => {
+				const doctype1 = implementation.createDocumentType('html', 'foo1', 'bar');
+				const doctype2 = implementation.createDocumentType('html', 'foo2', 'bar');
+
+				expect(NodeUtility.nodeEquals(doctype1, doctype2)).toEqual(false);
+			});
+
+			it('Returns false if system id are different', () => {
+				const doctype1 = implementation.createDocumentType('html', 'foo', 'bar1');
+				const doctype2 = implementation.createDocumentType('html', 'foo', 'bar2');
+
+				expect(NodeUtility.nodeEquals(doctype1, doctype2)).toEqual(false);
+			});
+
+			it('Returns true if doctype are equals', () => {
+				const doctype1 = implementation.createDocumentType('html', 'foo', 'bar');
+				const doctype2 = implementation.createDocumentType('html', 'foo', 'bar');
+
+				expect(NodeUtility.nodeEquals(doctype1, doctype2)).toEqual(true);
+			});
+		});
+
+		describe('w/ element node', () => {
+			it('Returns false if local name are different', () => {
+				const element1 = document.createElement('span');
+				const element2 = document.createElement('div');
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+
+			it('Returns false if namespace URI are different', () => {
+				const element1 = document.createElementNS('ns1', 'span');
+				const element2 = document.createElementNS('ns2', 'span');
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+
+			it('Returns false if prefix are different', () => {
+				const element1 = document.createElement('span');
+				const element2 = document.createElement('span');
+
+				element1.prefix = 'prefix1';
+				element2.prefix = 'prefix2';
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+
+			it('Returns false if attributes list length are different', () => {
+				const element1 = document.createElement('span');
+				const element2 = document.createElement('span');
+				const attrFoo = document.createAttribute('data-foo');
+
+				element1.setAttributeNode(attrFoo);
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+
+			it('Returns false if element attributes are not equal', () => {
+				const element1 = document.createElementNS('ns1', 'span');
+				const element2 = document.createElementNS('ns1', 'span');
+				element1.prefix = 'prefix1';
+				element2.prefix = 'prefix1';
+				const attrFoo = document.createAttribute('data-foo');
+				const attrBar = document.createAttribute('data-bar');
+				element1.setAttributeNode(attrFoo);
+				element2.setAttributeNode(attrBar);
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+
+			it('Returns false if element does not have same amount of children', () => {
+				const element1 = document.createElement('span');
+				const element2 = document.createElement('span');
+
+				const child1 = document.createElement('span');
+				const child2 = document.createElement('span');
+				const child3 = document.createElement('span');
+
+				element1.appendChild(child1);
+				element1.appendChild(child2);
+				element2.appendChild(child3);
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+
+			it("Returns false if element's children are not equals", () => {
+				const element1 = document.createElement('div');
+				const element2 = document.createElement('div');
+
+				const child1 = document.createElement('span');
+				const child2 = document.createElement('span');
+				const child3 = document.createElement('span');
+				const child4 = document.createElement('div');
+
+				element1.appendChild(child1);
+				element1.appendChild(child2);
+				element2.appendChild(child3);
+				element2.appendChild(child4);
+
+				expect(NodeUtility.nodeEquals(element1, element2)).toEqual(false);
+			});
+		});
+
+		describe('w/ attribute node', () => {
+			it('Returns false if local name are different', () => {
+				const attr1 = document.createAttribute('foo1');
+				const attr2 = document.createAttribute('foo2');
+
+				expect(NodeUtility.nodeEquals(attr1, attr2)).toEqual(false);
+			});
+
+			it('Returns false if namespace URI are different', () => {
+				const attr1 = document.createAttributeNS('ns1', 'foo');
+				const attr2 = document.createAttributeNS('ns2', 'foo');
+
+				expect(NodeUtility.nodeEquals(attr1, attr2)).toEqual(false);
+			});
+
+			it('Returns false if value are different', () => {
+				const attr1 = document.createAttribute('foo');
+				const attr2 = document.createAttribute('foo');
+
+				attr1.value = 'bar1';
+				attr2.value = 'bar2';
+
+				expect(NodeUtility.nodeEquals(attr1, attr2)).toEqual(false);
+			});
+
+			it('Returns true if elements are equal', () => {
+				const attr1 = document.createAttributeNS('ns', 'foo');
+				const attr2 = document.createAttributeNS('ns', 'foo');
+				attr1.value = 'bar';
+				attr2.value = 'bar';
+
+				expect(NodeUtility.nodeEquals(attr1, attr2)).toEqual(true);
+			});
+		});
+
+		describe('w/ processing instruction node', () => {
+			it('Returns false if target are different', () => {
+				const instruction1 = document.createProcessingInstruction('target1', 'foo');
+				const instruction2 = document.createProcessingInstruction('target2', 'foo');
+
+				expect(NodeUtility.nodeEquals(instruction1, instruction2)).toEqual(false);
+			});
+
+			it('Returns false if data are different', () => {
+				const instruction1 = document.createProcessingInstruction('target', 'foo1');
+				const instruction2 = document.createProcessingInstruction('target', 'foo2');
+
+				expect(NodeUtility.nodeEquals(instruction1, instruction2)).toEqual(false);
+			});
+
+			it('Returns true if processing instructions are equal', () => {
+				const instruction1 = document.createProcessingInstruction('target', 'foo');
+				const instruction2 = document.createProcessingInstruction('target', 'foo');
+
+				expect(NodeUtility.nodeEquals(instruction1, instruction2)).toEqual(true);
+			});
+		});
+
+		describe('w/ comment node', () => {
+			it('Returns false if data are different', () => {
+				const comment1 = document.createComment('foo1');
+				const comment2 = document.createComment('foo2');
+
+				expect(NodeUtility.nodeEquals(comment1, comment2)).toEqual(false);
+			});
+
+			it('Returns true if comments are equal', () => {
+				const comment1 = document.createComment('foo');
+				const comment2 = document.createComment('foo');
+
+				expect(NodeUtility.nodeEquals(comment1, comment2)).toEqual(true);
+			});
+		});
+
+		describe('w/ text node', () => {
+			it('Returns false if data are different', () => {
+				const textNode1 = document.createTextNode('foo1');
+				const textNode2 = document.createTextNode('foo2');
+
+				expect(NodeUtility.nodeEquals(textNode1, textNode2)).toEqual(false);
+			});
+
+			it('Returns true if text nodes are equal', () => {
+				const textNode1 = document.createTextNode('foo');
+				const textNode2 = document.createTextNode('foo');
+
+				expect(NodeUtility.nodeEquals(textNode1, textNode2)).toEqual(true);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Resolves #524 

Hello there 👋🏻 

I've tried to implement `compareDocumentPosition` into the code base. I hope I've done the job correctly. Feel free to send me some feedback if needed 🙏🏻 I'll be happy to learn from you guys.

Notable changes:
- Added `nodeType` in `Attr` (of type `ATTRIBUTE_NODE`)
- Added `ProcessingInstruction` node & `IProcessingInstruction` interface
- Added `createProcessingInstruction` in `Document` (required to properly test `nodeEquals` method)
- Added `NodeDocumentPositionEnum` enum

References:
- https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
- https://dom.spec.whatwg.org/#attr
- https://dom.spec.whatwg.org/#dom-node-attribute_node
- https://dom.spec.whatwg.org/#concept-node-equals
- https://dom.spec.whatwg.org/#processinginstruction
- https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
- https://github.com/jsdom/jsdom