### PR TITLE
Exclude source files from package

### DIFF
--- a/packages/global-registrator/package.json
+++ b/packages/global-registrator/package.json
@@ -6,6 +6,7 @@
 	"repository": "https://github.com/capricorn86/happy-dom",
 	"author": "David Ortner",
 	"description": "Use Happy DOM globally in a Node.js environment for testing.",
+	"files": ["lib"],
 	"main": "lib/index.js",
 	"keywords": [
 		"jsdom",

--- a/packages/happy-dom/package.json
+++ b/packages/happy-dom/package.json
@@ -6,6 +6,7 @@
 	"repository": "https://github.com/capricorn86/happy-dom",
 	"author": "David Ortner",
 	"description": "Happy DOM is a JavaScript implementation of a web browser without its graphical user interface. It includes many web standards from WHATWG DOM and HTML.",
+	"files": ["lib"],
 	"main": "lib/index.js",
 	"keywords": [
 		"jsdom",

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -6,6 +6,7 @@
 	"repository": "https://github.com/capricorn86/happy-dom",
 	"author": "David Ortner",
 	"description": "Use Happy DOM as environment in Jest.",
+	"files": ["lib"],
 	"main": "lib/index.js",
 	"keywords": [
 		"jest",


### PR DESCRIPTION
Currently the `happy-dom` package is shipping all the source files, which accounts for a quarter of the size:

```shellsession
$ du -sh node_modules/happy-dom/* | sort -h | tail -n2
1.2M    node_modules/happy-dom/src
3.3M    node_modules/happy-dom/lib
```

This pull request excludes them from the package by only publishing the compiled `lib` directory.