### PR TITLE
#540@patch: Add toStringTag in Element class to handle Object.prototype.toString.call

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -74,6 +74,15 @@ export default class Node extends EventTarget implements INode {
 	}
 
 	/**
+	 * Returns `Symbol.toStringTag`.
+	 *
+	 * @returns `Symbol.toStringTag`.
+	 */
+	public get [Symbol.toStringTag](): string {
+		return this.constructor.name;
+	}
+
+	/**
 	 * Get text value of children.
 	 *
 	 * @returns Text content.

--- a/packages/happy-dom/src/nodes/node/NodeList.ts
+++ b/packages/happy-dom/src/nodes/node/NodeList.ts
@@ -6,6 +6,15 @@ import INode from './INode';
  */
 export default class NodeList extends Array implements INodeList<INode> {
 	/**
+	 * Returns `Symbol.toStringTag`.
+	 *
+	 * @returns `Symbol.toStringTag`.
+	 */
+	public get [Symbol.toStringTag](): string {
+		return this.constructor.name;
+	}
+
+	/**
 	 * Returns item by index.
 	 *
 	 * @param index Index.

--- a/packages/happy-dom/test/nodes/html-button-element/HTMLButtonElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-button-element/HTMLButtonElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLButtonElement', () => {
 		element = <HTMLButtonElement>document.createElement('button');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLButtonElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLButtonElement]');
+		});
+	});
+
 	describe('get value()', () => {
 		it(`Returns the attribute "value".`, () => {
 			element.setAttribute('value', 'VALUE');

--- a/packages/happy-dom/test/nodes/html-dialog-element/HTMLDialogElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-dialog-element/HTMLDialogElement.test.ts
@@ -15,6 +15,12 @@ describe('HTMLDialogElement', () => {
 		element = <IHTMLDialogElement>document.createElement('dialog');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLDialogElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLDialogElement]');
+		});
+	});
+
 	describe('get open()', () => {
 		it('Should be closed by default', () => {
 			expect(element.open).toBe(false);

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -20,6 +20,12 @@ describe('HTMLElement', () => {
 		jest.restoreAllMocks();
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLElement]');
+		});
+	});
+
 	for (const property of ['accessKey', 'accessKeyLabel']) {
 		describe(`${property}`, () => {
 			it('Returns "".', () => {

--- a/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLFormElement', () => {
 		element = <HTMLFormElement>document.createElement('form');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLFormElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLFormElement]');
+		});
+	});
+
 	for (const property of [
 		'name',
 		'target',

--- a/packages/happy-dom/test/nodes/html-image-element/HTMLImageElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-image-element/HTMLImageElement.test.ts
@@ -11,6 +11,13 @@ describe('HTMLImageElement', () => {
 		document = window.document;
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLImageElement]`', () => {
+			const element = document.createElement('img');
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLImageElement]');
+		});
+	});
+
 	for (const property of ['alt', 'referrerPolicy', 'sizes', 'src', 'srcset', 'useMap']) {
 		describe(`get ${property}()`, () => {
 			it(`Returns the "${property}" attribute.`, () => {

--- a/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
@@ -18,6 +18,12 @@ describe('HTMLInputElement', () => {
 		element = <HTMLInputElement>document.createElement('input');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLInputElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLInputElement]');
+		});
+	});
+
 	describe('get value()', () => {
 		for (const type of ['hidden', 'submit', 'image', 'reset', 'button']) {
 			it(`Returns the attribute "value" if type is "${type}".`, () => {

--- a/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLLabelElement', () => {
 		element = <IHTMLLabelElement>document.createElement('label');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLLabelElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLLabelElement]');
+		});
+	});
+
 	describe('get htmlFor()', () => {
 		it('Returns attribute value.', () => {
 			expect(element.htmlFor).toBe('');

--- a/packages/happy-dom/test/nodes/html-link-element/HTMLLinkElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-link-element/HTMLLinkElement.test.ts
@@ -17,6 +17,13 @@ describe('HTMLLinkElement', () => {
 		jest.restoreAllMocks();
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLLinkElement]`', () => {
+			const element = <IHTMLLinkElement>document.createElement('link');
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLLinkElement]');
+		});
+	});
+
 	for (const property of [
 		'as',
 		'crossOrigin',

--- a/packages/happy-dom/test/nodes/html-media-element/HTMLMediaElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-media-element/HTMLMediaElement.test.ts
@@ -21,6 +21,12 @@ describe('HTMLMediaElement', () => {
 		jest.restoreAllMocks();
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLAudioElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLAudioElement]');
+		});
+	});
+
 	for (const property of ['autoplay', 'controls', 'loop']) {
 		describe(`get ${property}()`, () => {
 			it('Returns attribute value.', () => {

--- a/packages/happy-dom/test/nodes/html-meta-element/HTMLMetaElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-meta-element/HTMLMetaElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLMetaElement', () => {
 		element = <IHTMLMetaElement>document.createElement('meta');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLMetaElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLMetaElement]');
+		});
+	});
+
 	describe('get content()', () => {
 		it('Returns attribute value.', () => {
 			expect(element.content).toBe('');

--- a/packages/happy-dom/test/nodes/html-opt-group-element/HTMLOptGroupElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-opt-group-element/HTMLOptGroupElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLOptGroupElement', () => {
 		element = <HTMLOptGroupElement>document.createElement('optgroup');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLOptGroupElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLOptGroupElement]');
+		});
+	});
+
 	describe(`get disabled()`, () => {
 		it('Returns attribute value.', () => {
 			expect(element.disabled).toBe(false);

--- a/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLOptionElement', () => {
 		element = <HTMLOptionElement>document.createElement('option');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLOptionElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLOptionElement]');
+		});
+	});
+
 	describe('get value()', () => {
 		it('Returns the attribute "value".', () => {
 			element.setAttribute('value', 'VALUE');

--- a/packages/happy-dom/test/nodes/html-script-element/HTMLScriptElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-script-element/HTMLScriptElement.test.ts
@@ -16,6 +16,13 @@ describe('HTMLScriptElement', () => {
 		jest.restoreAllMocks();
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLScriptElement]`', () => {
+			const element = document.createElement('script');
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLScriptElement]');
+		});
+	});
+
 	for (const property of ['type', 'charset', 'lang']) {
 		describe(`get ${property}()`, () => {
 			it(`Returns the "${property}" attribute.`, () => {

--- a/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
@@ -13,6 +13,12 @@ describe('HTMLSelectElement', () => {
 		element = <HTMLSelectElement>document.createElement('select');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLSelectElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLSelectElement]');
+		});
+	});
+
 	describe('get value()', () => {
 		it('Returns the attribute "value".', () => {});
 	});

--- a/packages/happy-dom/test/nodes/html-style-element/HTMLStyleElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-style-element/HTMLStyleElement.test.ts
@@ -17,6 +17,12 @@ describe('HTMLStyleElement', () => {
 		jest.restoreAllMocks();
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLStyleElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLStyleElement]');
+		});
+	});
+
 	for (const property of ['media', 'type']) {
 		describe(`get ${property}()`, () => {
 			it(`Returns the "${property}" attribute.`, () => {

--- a/packages/happy-dom/test/nodes/html-template-element/HTMLTemplateElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-template-element/HTMLTemplateElement.test.ts
@@ -18,6 +18,12 @@ describe('HTMLTemplateElement', () => {
 		jest.restoreAllMocks();
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLTemplateElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLTemplateElement]');
+		});
+	});
+
 	describe('get innerHTML()', () => {
 		it('Returns inner HTML of the "content" node.', () => {
 			const div = document.createElement('div');

--- a/packages/happy-dom/test/nodes/html-text-area-element/HTMLTextAreaElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-text-area-element/HTMLTextAreaElement.test.ts
@@ -15,6 +15,12 @@ describe('HTMLTextAreaElement', () => {
 		element = <HTMLTextAreaElement>document.createElement('textarea');
 	});
 
+	describe('Object.prototype.toString', () => {
+		it('Returns `[object HTMLTextAreaElement]`', () => {
+			expect(Object.prototype.toString.call(element)).toBe('[object HTMLTextAreaElement]');
+		});
+	});
+
 	describe('get value()', () => {
 		it('Returns the attribute "value" if it has not been set using the property.', () => {
 			element.setAttribute('value', 'TEST_VALUE');


### PR DESCRIPTION
Hi, this PR fixes #540 by adding `Symbol.toStringTag` to `Node` and `NodeList` classes.