### PR TITLE
#603@patch: Fixes problem in the "global-registrator" package  where unregister only deletes/pops half the registered keys

### DIFF
--- a/packages/global-registrator/src/GlobalRegistrator.ts
+++ b/packages/global-registrator/src/GlobalRegistrator.ts
@@ -31,9 +31,9 @@ export default class GlobalRegistrator {
 				'Failed to unregister. Happy DOM has not previously been globally registered.'
 			);
 		}
-		for (const key of this.registered) {
+		while (this.registered.length) {
+			const key = this.registered.pop();
 			delete global[key];
-			this.registered.pop();
 		}
 	}
 }


### PR DESCRIPTION
fixes #603 