### PR TITLE
#544@patch: Does not set Event.target and Event.currrentTarget direct…

### DIFF
--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -9,13 +9,13 @@ import IEventTarget from './IEventTarget';
  */
 export default class Event {
 	public composed = false;
-	public currentTarget: IEventTarget = null;
-	public target: IEventTarget = null;
 	public bubbles = false;
 	public cancelable = false;
 	public defaultPrevented = false;
 	public _immediatePropagationStopped = false;
 	public _propagationStopped = false;
+	public _target: IEventTarget = null;
+	public _currentTarget: IEventTarget = null;
 	public type: string = null;
 
 	/**
@@ -32,6 +32,24 @@ export default class Event {
 			this.cancelable = eventInit.cancelable || false;
 			this.composed = eventInit.composed || false;
 		}
+	}
+
+	/**
+	 * Returns target.
+	 *
+	 * @returns Target.
+	 */
+	public get target(): IEventTarget {
+		return this._target;
+	}
+
+	/**
+	 * Returns target.
+	 *
+	 * @returns Target.
+	 */
+	public get currentTarget(): IEventTarget {
+		return this._currentTarget;
 	}
 
 	/**

--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -46,11 +46,11 @@ export default abstract class EventTarget implements IEventTarget {
 	 * @returns The return value is false if event is cancelable and at least one of the event handlers which handled this event called Event.preventDefault().
 	 */
 	public dispatchEvent(event: Event): boolean {
-		if (!event.target) {
-			event.target = this;
+		if (!event._target) {
+			event._target = this;
 		}
 
-		event.currentTarget = this;
+		event._currentTarget = this;
 
 		const onEventName = 'on' + event.type.toLowerCase();
 

--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -359,8 +359,8 @@ export default class HTMLElement extends Element implements IHTMLElement {
 			bubbles: true,
 			composed: true
 		});
-		event.target = this;
-		event.currentTarget = this;
+		event._target = this;
+		event._currentTarget = this;
 		this.dispatchEvent(event);
 	}
 
@@ -379,8 +379,8 @@ export default class HTMLElement extends Element implements IHTMLElement {
 				bubbles: true,
 				composed: true
 			});
-			event.target = this;
-			event.currentTarget = this;
+			event._target = this;
+			event._currentTarget = this;
 			this.dispatchEvent(event);
 		}
 	}
@@ -404,8 +404,8 @@ export default class HTMLElement extends Element implements IHTMLElement {
 				bubbles: true,
 				composed: true
 			});
-			event.target = this;
-			event.currentTarget = this;
+			event._target = this;
+			event._currentTarget = this;
 			this.dispatchEvent(event);
 		}
 	}

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -338,8 +338,8 @@ describe('HTMLElement', () => {
 				bubbles: true,
 				composed: true
 			});
-			event.target = element;
-			event.currentTarget = element;
+			event._target = element;
+			event._currentTarget = element;
 
 			expect(triggeredEvent).toEqual(event);
 		});


### PR DESCRIPTION
…ly to solve a problem with Vitest typechecking the internals of Happy DOM.