### PR TITLE
#582@patch: Window.fetch handles URL and Request objects.

### DIFF
--- a/packages/happy-dom/src/fetch/IRequest.ts
+++ b/packages/happy-dom/src/fetch/IRequest.ts
@@ -1,5 +1,8 @@
 import IHeaders from './IHeaders';
 import IBody from './IBody';
+import URL from './../location/URL';
+
+export type RequestInfo = IRequest | string | URL;
 
 /**
  * Fetch request.

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -87,6 +87,7 @@ import Plugin from '../navigator/Plugin';
 import PluginArray from '../navigator/PluginArray';
 import IResponseInit from '../fetch/IResponseInit';
 import IRequest from '../fetch/IRequest';
+import { RequestInfo } from '../fetch/IRequest';
 import IHeaders from '../fetch/IHeaders';
 import IRequestInit from '../fetch/IRequestInit';
 import IResponse from '../fetch/IResponse';
@@ -328,11 +329,11 @@ export default interface IWindow extends IEventTarget, NodeJS.Global {
 	/**
 	 * This method provides an easy, logical way to fetch resources asynchronously across the network.
 	 *
-	 * @param url URL.
+	 * @param url RequestInfo.
 	 * @param [init] Init.
 	 * @returns Promise.
 	 */
-	fetch(url: string, init?: IRequestInit): Promise<IResponse>;
+	fetch(url: RequestInfo, init?: IRequestInit): Promise<IResponse>;
 
 	/**
 	 * Creates a Base64-encoded ASCII string from a binary string (i.e., a string in which each character in the string is treated as a byte of binary data).

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -80,6 +80,7 @@ import AsyncTaskManager from '../async-task-manager/AsyncTaskManager';
 import IResponse from '../fetch/IResponse';
 import IResponseInit from '../fetch/IResponseInit';
 import IRequest from '../fetch/IRequest';
+import { RequestInfo } from '../fetch/IRequest';
 import IRequestInit from '../fetch/IRequestInit';
 import IHeaders from '../fetch/IHeaders';
 import IHeadersInit from '../fetch/IHeadersInit';
@@ -615,11 +616,11 @@ export default class Window extends EventTarget implements IWindow {
 	 * This method provides an easy, logical way to fetch resources asynchronously across the network.
 	 *
 	 * @override
-	 * @param url URL.
+	 * @param url RequestInfo.
 	 * @param [init] Init.
 	 * @returns Promise.
 	 */
-	public async fetch(url: string, init?: IRequestInit): Promise<IResponse> {
+	public async fetch(url: RequestInfo, init?: IRequestInit): Promise<IResponse> {
 		return await FetchHandler.fetch(this.document, url, init);
 	}
 

--- a/packages/happy-dom/test/setup.js
+++ b/packages/happy-dom/test/setup.js
@@ -5,7 +5,9 @@ global.mockedModules = {
 		options: null
 	},
 	'node-fetch': {
-		url: null,
+		url: {
+			url: Symbol('url')
+		},
 		init: null,
 		error: null,
 		response: {
@@ -53,7 +55,12 @@ class NodeFetchResponse {
 	}
 }
 
-class NodeFetchRequest extends NodeFetchResponse {}
+class NodeFetchRequest extends NodeFetchResponse {
+	constructor(url) {
+		super();
+		this.url = url;
+	}
+}
 class NodeFetchHeaders {}
 
 jest.mock('node-fetch', () => {

--- a/packages/happy-dom/test/window/Window.test.ts
+++ b/packages/happy-dom/test/window/Window.test.ts
@@ -455,7 +455,7 @@ describe('Window', () => {
 				const response = await window.fetch(expectedUrl, expectedOptions);
 				const result = await response[method]();
 
-				expect(MOCKED_NODE_FETCH.url).toBe(expectedUrl);
+				expect(MOCKED_NODE_FETCH.url.url).toBe(expectedUrl);
 				expect(MOCKED_NODE_FETCH.init).toBe(expectedOptions);
 				expect(result).toEqual(MOCKED_NODE_FETCH.response[method]);
 			});
@@ -470,7 +470,47 @@ describe('Window', () => {
 			const response = await window.fetch(expectedPath, expectedOptions);
 			const textResponse = await response.text();
 
-			expect(MOCKED_NODE_FETCH.url).toBe('https://localhost:8080' + expectedPath);
+			expect(MOCKED_NODE_FETCH.url.url).toBe('https://localhost:8080' + expectedPath);
+			expect(MOCKED_NODE_FETCH.init).toBe(expectedOptions);
+			expect(textResponse).toEqual(MOCKED_NODE_FETCH.response.text);
+		});
+
+		it('Handles URL object.', async () => {
+			const expectedUrl = new window.URL('https://localhost:8080/path');
+			const expectedOptions = {};
+
+			const response = await window.fetch(expectedUrl, expectedOptions);
+			const textResponse = await response.text();
+
+			expect(MOCKED_NODE_FETCH.url.url).toBe(expectedUrl);
+			expect(MOCKED_NODE_FETCH.init).toBe(expectedOptions);
+			expect(textResponse).toEqual(MOCKED_NODE_FETCH.response.text);
+		});
+
+		it('Handles Request object.', async () => {
+			const expectedRequest = new window.Request('https://localhost:8080/path', { method: 'GET' });
+			const expectedOptions = {};
+
+			const response = await window.fetch(expectedRequest, expectedOptions);
+			const textResponse = await response.text();
+
+			expect(MOCKED_NODE_FETCH.url.url).toBe(expectedRequest.url);
+			expect(MOCKED_NODE_FETCH.url.method).toBe(expectedRequest.method);
+			expect(MOCKED_NODE_FETCH.init).toBe(expectedOptions);
+			expect(textResponse).toEqual(MOCKED_NODE_FETCH.response.text);
+		});
+
+		it('Handles Request object with relative url.', async () => {
+			const expectedPath = '/path';
+			const expectedRequest = new window.Request(expectedPath);
+			const expectedOptions = {};
+
+			window.location.href = 'https://localhost:8080';
+
+			const response = await window.fetch(expectedRequest, expectedOptions);
+			const textResponse = await response.text();
+
+			expect(MOCKED_NODE_FETCH.url.url).toBe('https://localhost:8080' + expectedPath);
 			expect(MOCKED_NODE_FETCH.init).toBe(expectedOptions);
 			expect(textResponse).toEqual(MOCKED_NODE_FETCH.response.text);
 		});


### PR DESCRIPTION
`window.fetch` can now handle `Request` and `URL` objects as first parameter.
See https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters
