### PR TITLE
#645@patch: Declares type for element.click()

### DIFF
--- a/packages/happy-dom/src/nodes/element/IElement.ts
+++ b/packages/happy-dom/src/nodes/element/IElement.ts
@@ -305,4 +305,9 @@ export default interface IElement extends IChildNode, INonDocumentTypeChildNode,
 	 * @param text String to insert.
 	 */
 	insertAdjacentText(position: TInsertAdjacentPositions, text: string): void;
+
+	/**
+	 * Simulates a click on the element.
+	 */
+	click(): void;
 }


### PR DESCRIPTION
https://github.com/capricorn86/happy-dom/issues/645

This declares `click` on the `IElement` interfact