### PR TITLE
#648@patch: OptionElement.value returns `textContent` as fallback.

### DIFF
--- a/packages/happy-dom/src/nodes/html-option-element/HTMLOptionElement.ts
+++ b/packages/happy-dom/src/nodes/html-option-element/HTMLOptionElement.ts
@@ -109,7 +109,7 @@ export default class HTMLOptionElement extends HTMLElement implements IHTMLOptio
 	 * @returns Value.
 	 */
 	public get value(): string {
-		return this.getAttributeNS(null, 'value') || '';
+		return this.getAttributeNS(null, 'value') || this.textContent;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
@@ -25,6 +25,12 @@ describe('HTMLOptionElement', () => {
 			element.setAttribute('value', 'VALUE');
 			expect(element.value).toBe('VALUE');
 		});
+
+		it('Returns the text IDL value if no attribute is present.', () => {
+			element.removeAttribute('value');
+			element.textContent = 'TEXT VALUE';
+			expect(element.value).toBe('TEXT VALUE');
+		});
 	});
 
 	describe('set value()', () => {


### PR DESCRIPTION
Proposed fix for #648 
