### PR TITLE
#709@patch: Properly detect `ShadowRoot` boundary when constructing `composedPath`

### DIFF
--- a/packages/happy-dom/src/css/declaration/utilities/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/utilities/CSSStyleDeclarationElementStyle.ts
@@ -129,7 +129,10 @@ export default class CSSStyleDeclarationElementStyle {
 				}
 
 				styleAndElement = { element: null, cssTexts: [] };
-			} else if ((<IShadowRoot>styleAndElement.element).host) {
+			} else if (
+				styleAndElement.element.nodeType === NodeTypeEnum.documentFragmentNode &&
+				(<IShadowRoot>styleAndElement.element).host
+			) {
 				const styleSheets = <INodeList<IHTMLStyleElement>>(
 					(<IShadowRoot>styleAndElement.element).querySelectorAll('style,link[rel="stylesheet"]')
 				);

--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -2,8 +2,8 @@ import IEventInit from './IEventInit';
 import INode from '../nodes/node/INode';
 import IWindow from '../window/IWindow';
 import IShadowRoot from '../nodes/shadow-root/IShadowRoot';
-import ShadowRoot from '../nodes/shadow-root/ShadowRoot';
 import IEventTarget from './IEventTarget';
+import NodeTypeEnum from '../nodes/node/NodeTypeEnum';
 
 /**
  * Event.
@@ -70,8 +70,12 @@ export default class Event {
 			composedPath.push(eventTarget);
 
 			if (this.bubbles) {
-				if (this.composed && eventTarget instanceof ShadowRoot && eventTarget.host) {
-					eventTarget = eventTarget.host;
+				if (
+					this.composed &&
+					(<INode>eventTarget).nodeType === NodeTypeEnum.documentFragmentNode &&
+					(<IShadowRoot>eventTarget).host
+				) {
+					eventTarget = (<IShadowRoot>eventTarget).host;
 				} else if ((<INode>(<unknown>this.target)).ownerDocument === eventTarget) {
 					eventTarget = (<INode>(<unknown>this.target)).ownerDocument.defaultView;
 				} else {

--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -2,6 +2,7 @@ import IEventInit from './IEventInit';
 import INode from '../nodes/node/INode';
 import IWindow from '../window/IWindow';
 import IShadowRoot from '../nodes/shadow-root/IShadowRoot';
+import ShadowRoot from '../nodes/shadow-root/ShadowRoot';
 import IEventTarget from './IEventTarget';
 
 /**
@@ -69,8 +70,8 @@ export default class Event {
 			composedPath.push(eventTarget);
 
 			if (this.bubbles) {
-				if (this.composed && (<IShadowRoot>eventTarget).host) {
-					eventTarget = (<IShadowRoot>eventTarget).host;
+				if (this.composed && eventTarget instanceof ShadowRoot && eventTarget.host) {
+					eventTarget = eventTarget.host;
 				} else if ((<INode>(<unknown>this.target)).ownerDocument === eventTarget) {
 					eventTarget = (<INode>(<unknown>this.target)).ownerDocument.defaultView;
 				} else {

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -482,7 +482,7 @@ export default class Node extends EventTarget implements INode {
 			}
 
 			// eslint-disable-next-line
-			if (event.composed && (<any>this).host) {
+			if (event.composed && this.nodeType === NodeTypeEnum.documentFragmentNode && (<any>this).host) {
 				// eslint-disable-next-line
 				return (<any>this).host.dispatchEvent(event);
 			}

--- a/packages/happy-dom/test/event/Event.test.ts
+++ b/packages/happy-dom/test/event/Event.test.ts
@@ -99,5 +99,32 @@ describe('Event', () => {
 				customELement.shadowRoot
 			]);
 		});
+
+		it('Returns correct composed for HTMLAnchorElement event target and composed is set to "true".', () => {
+			const anchor = document.createElement('a');
+			anchor.setAttribute('href', 'https://example.com');
+			let composedPath = null;
+
+			document.body.appendChild(anchor);
+
+			anchor.addEventListener('click', (event: Event) => {
+				composedPath = event.composedPath();
+			});
+
+			anchor.dispatchEvent(
+				new Event('click', {
+					bubbles: true,
+					composed: true
+				})
+			);
+
+			expect(composedPath).toEqual([
+				anchor,
+				document.body,
+				document.documentElement,
+				document,
+				window
+			]);
+		});
 	});
 });


### PR DESCRIPTION
Fixes #709.

Not exactly sure about this `instanceof ShadowRoot` check with an extra import as I couldn't find other similar usages the codebase. Will be happy to update this PR If there's a more desirable pattern.