### PR TITLE
#722@minor: Add timeStamp property to Event.

### DIFF
--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -18,7 +18,7 @@ export default class Event {
 	public _propagationStopped = false;
 	public _target: IEventTarget = null;
 	public _currentTarget: IEventTarget = null;
-	public timeStamp: number = Date.now() - performance.timeOrigin;
+	public timeStamp: number = performance.now();
 	public type: string = null;
 
 	/**

--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -4,6 +4,7 @@ import IWindow from '../window/IWindow';
 import IShadowRoot from '../nodes/shadow-root/IShadowRoot';
 import IEventTarget from './IEventTarget';
 import NodeTypeEnum from '../nodes/node/NodeTypeEnum';
+import { performance } from 'perf_hooks';
 
 /**
  * Event.
@@ -17,6 +18,7 @@ export default class Event {
 	public _propagationStopped = false;
 	public _target: IEventTarget = null;
 	public _currentTarget: IEventTarget = null;
+	public timeStamp: number = Date.now() - performance.timeOrigin;
 	public type: string = null;
 
 	/**

--- a/packages/happy-dom/test/event/Event.test.ts
+++ b/packages/happy-dom/test/event/Event.test.ts
@@ -3,6 +3,7 @@ import Window from '../../src/window/Window';
 import IDocument from '../../src/nodes/document/IDocument';
 import Event from '../../src/event/Event';
 import CustomElement from '../CustomElement';
+import { performance } from 'perf_hooks';
 
 describe('Event', () => {
 	let window: IWindow;
@@ -13,6 +14,28 @@ describe('Event', () => {
 		document = window.document;
 
 		window.customElements.define('custom-element', CustomElement);
+	});
+
+	describe('timeStamp', () => {
+		it('Has a timeStamp property.', () => {
+			const event = new Event('click');
+			expect('timeStamp' in event).toBeTruthy();
+		});
+		it('Property is of type number.', () => {
+			const event = new Event('click');
+			expect(typeof event.timeStamp).toBe('number');
+		});
+		it('Has value greater than zero.', () => {
+			const event = new Event('click');
+			expect(event.timeStamp).toBeGreaterThan(0);
+		});
+		it('Returns a value not in the future', () => {
+			const event = new Event('click');
+			const { timeOrigin } = performance;
+			const eventOriginalTime = timeOrigin + event.timeStamp;
+			const now = Date.now();
+			expect(eventOriginalTime).toBeLessThanOrEqual(now);
+		});
 	});
 
 	describe('composedPath()', () => {

--- a/packages/happy-dom/test/event/Event.test.ts
+++ b/packages/happy-dom/test/event/Event.test.ts
@@ -16,25 +16,16 @@ describe('Event', () => {
 		window.customElements.define('custom-element', CustomElement);
 	});
 
-	describe('timeStamp', () => {
-		it('Has a timeStamp property.', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+	
+	describe('get timeStamp()', () => {
+		it('Returns the value returned by performance.now() at the time it was created.', () => {
+		        const performanceNow = 12345;
+		        spyOn(performance, 'now').mockImplementation(() => performanceNow);
 			const event = new Event('click');
-			expect('timeStamp' in event).toBeTruthy();
-		});
-		it('Property is of type number.', () => {
-			const event = new Event('click');
-			expect(typeof event.timeStamp).toBe('number');
-		});
-		it('Has value greater than zero.', () => {
-			const event = new Event('click');
-			expect(event.timeStamp).toBeGreaterThan(0);
-		});
-		it('Returns a value not in the future', () => {
-			const event = new Event('click');
-			const { timeOrigin } = performance;
-			const eventOriginalTime = timeOrigin + event.timeStamp;
-			const now = Date.now();
-			expect(eventOriginalTime).toBeLessThanOrEqual(now);
+			expect(event.timeStamp).toBe(performanceNow);
 		});
 	});
 

--- a/packages/happy-dom/test/event/Event.test.ts
+++ b/packages/happy-dom/test/event/Event.test.ts
@@ -19,11 +19,17 @@ describe('Event', () => {
 	afterEach(() => {
 		jest.restoreAllMocks();
 	});
-	
+
 	describe('get timeStamp()', () => {
 		it('Returns the value returned by performance.now() at the time it was created.', () => {
-		        const performanceNow = 12345;
-		        spyOn(performance, 'now').mockImplementation(() => performanceNow);
+			Object.defineProperty(performance, 'now', {
+				value: jest.fn(),
+				configurable: true,
+				writable: true
+			});
+
+			const performanceNow = 12345;
+			jest.spyOn(performance, 'now').mockImplementation(() => performanceNow);
 			const event = new Event('click');
 			expect(event.timeStamp).toBe(performanceNow);
 		});

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -354,22 +354,18 @@ describe('HTMLElement', () => {
 
 	describe('click()', () => {
 		it('Dispatches "click" event.', () => {
-			let triggeredEvent = null;
+			let triggeredEvent: PointerEvent = null;
 
-			element.addEventListener('click', (event) => {
-				triggeredEvent = event;
-			});
+			element.addEventListener('click', (event: PointerEvent) => (triggeredEvent = event));
 
 			element.click();
 
-			const event = new PointerEvent('click', {
-				bubbles: true,
-				composed: true
-			});
-			event._target = element;
-			event._currentTarget = element;
-
-			expect(triggeredEvent).toEqual(event);
+			expect(triggeredEvent instanceof PointerEvent).toBe(true);
+			expect(triggeredEvent.type).toBe('click');
+			expect(triggeredEvent.bubbles).toBe(true);
+			expect(triggeredEvent.composed).toBe(true);
+			expect(triggeredEvent.target === element).toBe(true);
+			expect(triggeredEvent.currentTarget === element).toBe(true);
 		});
 	});
 
@@ -401,7 +397,7 @@ describe('HTMLElement', () => {
 			expect(triggeredFocusOutEvent.composed).toBe(true);
 			expect(triggeredFocusOutEvent.target === element).toBe(true);
 
-			expect(document.activeElement).toEqual(document.body);
+			expect(document.activeElement === document.body).toBe(true);
 		});
 
 		it('Does not dispatch "blur" event if not connected to the DOM.', () => {
@@ -459,7 +455,7 @@ describe('HTMLElement', () => {
 			expect(triggeredFocusInEvent.composed).toBe(true);
 			expect(triggeredFocusInEvent.target === element).toBe(true);
 
-			expect(document.activeElement).toEqual(element);
+			expect(document.activeElement === element).toBe(true);
 		});
 
 		it('Does not dispatch "focus" event if not connected to the DOM.', () => {

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,19 @@
 		"lint": {
 			"outputs": []
 		},
+		"lint:fix": {
+			"outputs": []
+		},
 		"test": {
+			"outputs": []
+		},
+		"test:watch": {
+			"outputs": []
+		},
+		"version": {
+			"outputs": []
+		},
+		"publish": {
 			"outputs": []
 		}
 	}


### PR DESCRIPTION
Fix #722 by implementing `timeStamp` property on `Event`.



According to specification (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp) and [Spec](https://dom.spec.whatwg.org/#ref-for-dom-event-timestamp%E2%91%A0)) the `timeStamp` property is described as follows:
> _This value is the number of milliseconds elapsed from the beginning of the time origin until the event was created. If the global object is [Window](https://developer.mozilla.org/en-US/docs/Web/API/Window), the time origin is the moment the user clicked on the link, or the script that initiated the loading of the document. In a worker, the time origin is the moment of creation of the worker._

My proposed solution is to use `performance.timeOrigin` as the time origin to resolve the relative Event `timeStamp` value.
