### PR TITLE
#771@patch: Don't bubble `focus` and `blur` events through DOM.

### DIFF
--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -383,15 +383,18 @@ export default class HTMLElement extends Element implements IHTMLElement {
 
 		this.ownerDocument['_activeElement'] = null;
 
-		for (const eventType of ['blur', 'focusout']) {
-			const event = new FocusEvent(eventType, {
+		this.dispatchEvent(
+			new FocusEvent('blur', {
+				bubbles: false,
+				composed: true
+			})
+		);
+		this.dispatchEvent(
+			new FocusEvent('focusout', {
 				bubbles: true,
 				composed: true
-			});
-			event._target = this;
-			event._currentTarget = this;
-			this.dispatchEvent(event);
-		}
+			})
+		);
 	}
 
 	/**
@@ -408,15 +411,18 @@ export default class HTMLElement extends Element implements IHTMLElement {
 
 		this.ownerDocument['_activeElement'] = this;
 
-		for (const eventType of ['focus', 'focusin']) {
-			const event = new FocusEvent(eventType, {
+		this.dispatchEvent(
+			new FocusEvent('focus', {
+				bubbles: false,
+				composed: true
+			})
+		);
+		this.dispatchEvent(
+			new FocusEvent('focusin', {
 				bubbles: true,
 				composed: true
-			});
-			event._target = this;
-			event._currentTarget = this;
-			this.dispatchEvent(event);
-		}
+			})
+		);
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -388,7 +388,7 @@ describe('HTMLElement', () => {
 			element.blur();
 
 			expect(triggeredBlurEvent.type).toBe('blur');
-			expect(triggeredBlurEvent.bubbles).toBe(true);
+			expect(triggeredBlurEvent.bubbles).toBe(false);
 			expect(triggeredBlurEvent.composed).toBe(true);
 			expect(triggeredBlurEvent.target === element).toBe(true);
 
@@ -446,7 +446,7 @@ describe('HTMLElement', () => {
 			element.focus();
 
 			expect(triggeredFocusEvent.type).toBe('focus');
-			expect(triggeredFocusEvent.bubbles).toBe(true);
+			expect(triggeredFocusEvent.bubbles).toBe(false);
 			expect(triggeredFocusEvent.composed).toBe(true);
 			expect(triggeredFocusEvent.target === element).toBe(true);
 
@@ -502,7 +502,7 @@ describe('HTMLElement', () => {
 			element.focus();
 
 			expect(triggeredEvent.type).toBe('blur');
-			expect(triggeredEvent.bubbles).toBe(true);
+			expect(triggeredEvent.bubbles).toBe(false);
 			expect(triggeredEvent.composed).toBe(true);
 			expect(triggeredEvent.target === previousElement).toBe(true);
 		});


### PR DESCRIPTION
Fixes #771.

Only updated existing `HTMLElement` tests that expect `bubbles` value of `blur/focus` events to be `false` from now.

Actual event bubbling is still covered by `Node.test.ts`.