### PR TITLE
#519@patch: Fixes XMLParser Bug.

### DIFF
--- a/packages/happy-dom/src/xml-parser/XMLParser.ts
+++ b/packages/happy-dom/src/xml-parser/XMLParser.ts
@@ -68,10 +68,10 @@ export default class XMLParser {
 							isStartTag &&
 							(condCommMatch = condCommRegexp.exec(text)) &&
 							condCommMatch[0] &&
-							(condCommEndMatch = condCommEndRegexp.exec(data)) &&
+							(condCommEndMatch = condCommEndRegexp.exec(data.substring(markupRegexp.lastIndex))) &&
 							condCommEndMatch[0]
 						) {
-							markupRegexp.lastIndex = condCommEndRegexp.lastIndex;
+							markupRegexp.lastIndex += condCommEndRegexp.lastIndex;
 							continue;
 						} else {
 							this.appendTextAndCommentNodes(document, parent, text);

--- a/packages/happy-dom/src/xml-parser/XMLParser.ts
+++ b/packages/happy-dom/src/xml-parser/XMLParser.ts
@@ -61,24 +61,18 @@ export default class XMLParser {
 					} else {
 						let condCommMatch;
 						let condCommEndMatch;
-						let needRewrite = false;
 						const condCommRegexp = new RegExp(CONDITION_COMMENT_REGEXP, 'gi');
 						const condCommEndRegexp = new RegExp(CONDITION_COMMENT_END_REGEXP, 'gi');
 						// @Refer: https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/?redirectedfrom=MSDN
-						if (isStartTag && (condCommMatch = condCommRegexp.exec(text)) && condCommMatch[0]) {
-							// Compatible with IE
-							while ((condCommEndMatch = condCommEndRegexp.exec(data))) {
-								if (condCommEndMatch[0]) {
-									needRewrite = true;
-									break;
-								} else {
-									throw new Error('conditional comments unclosed.');
-								}
-							}
-							if (needRewrite) {
-								markupRegexp.lastIndex = condCommEndRegexp.lastIndex;
-								continue; // Re parse.
-							}
+						if (
+							isStartTag &&
+							(condCommMatch = condCommRegexp.exec(text)) &&
+							condCommMatch[0] &&
+							(condCommEndMatch = condCommEndRegexp.exec(data)) &&
+							condCommEndMatch[0]
+						) {
+							markupRegexp.lastIndex = condCommEndRegexp.lastIndex;
+							continue;
 						} else {
 							this.appendTextAndCommentNodes(document, parent, text);
 						}

--- a/packages/happy-dom/test/xml-parser/XMLParser.test.ts
+++ b/packages/happy-dom/test/xml-parser/XMLParser.test.ts
@@ -434,7 +434,28 @@ describe('XMLParser', () => {
 
 				'<!--[if lt Contoso 2]>\n' +
 					'<p>Your version of the Contoso control is out of date; Please update to the latest.</p>\n' +
-					'<![endif]-->'
+					'<![endif]-->',
+
+				'<!DOCTYPE html><html lang="en">\n' +
+				'<head>\n' +
+				'    <meta charset="UTF-8">\n' +
+				'    <title>Title</title>\n' +
+				'</head>\n' +
+				'<body>\n' +
+				'<!--[if lt IE 9]>\n' +
+				'<script>window.location = \'browser.htm\';</script>\n' +
+				'<![endif]-->\n' +
+				'\n' +
+				'\n' +
+				'<script>\n' +
+				'    const node = document.createElement(\'a\');\n' +
+				'    node.href = \'http://www.google.com\';\n' +
+				'    node.target = \'_blank\';\n' +
+				'    node.innerHTML = \'google\';\n' +
+				'    window.document.body.appendChild(node);\n' +
+				'</script>\n' +
+				'</body>\n' +
+				'</html>\n'
 			];
 
 			for (const html of testHTML) {

--- a/packages/happy-dom/test/xml-parser/XMLParser.test.ts
+++ b/packages/happy-dom/test/xml-parser/XMLParser.test.ts
@@ -410,5 +410,37 @@ describe('XMLParser', () => {
 			const root4 = XMLParser.parse(window.document, <string>(<unknown>false));
 			expect(new XMLSerializer().serializeToString(root4)).toBe('false');
 		});
+
+		it('Parses conditional comments', () => {
+			const testHTML = [
+				'<!--[if IE 8]>\n' + '<p>Welcome to Internet Explorer 8.</p>\n' + '<![endif]-->',
+
+				'<!--[if gte IE 7]>\n' +
+					'<script>\n' +
+					'  alert("Congratulations! You are running Internet Explorer 7 or a later version of Internet Explorer.");\n' +
+					'</script>\n' +
+					'<p>Thank you for closing the message box.</p>\n' +
+					'<![endif]-->',
+
+				'<!--[if IE 5]>\n' +
+					'<p>Welcome to any incremental version of Internet Explorer 5!</p>\n' +
+					'<![endif]-->',
+
+				'<!--[if IE 5.0000]>\n' + '<p>Welcome to Internet Explorer 5.0!</p>\n' + '<![endif]-->',
+
+				'<!--[if WindowsEdition 1]>\n' +
+					'<p>You are using Windows Ultimate Edition.</p>\n' +
+					'<![endif]-->',
+
+				'<!--[if lt Contoso 2]>\n' +
+					'<p>Your version of the Contoso control is out of date; Please update to the latest.</p>\n' +
+					'<![endif]-->'
+			];
+
+			for (const html of testHTML) {
+				const root = XMLParser.parse(window.document, html);
+				expect(new XMLSerializer().serializeToString(root)).toBe(html);
+			}
+		});
 	});
 });

--- a/packages/happy-dom/test/xml-parser/XMLParser.test.ts
+++ b/packages/happy-dom/test/xml-parser/XMLParser.test.ts
@@ -437,25 +437,25 @@ describe('XMLParser', () => {
 					'<![endif]-->',
 
 				'<!DOCTYPE html><html lang="en">\n' +
-				'<head>\n' +
-				'    <meta charset="UTF-8">\n' +
-				'    <title>Title</title>\n' +
-				'</head>\n' +
-				'<body>\n' +
-				'<!--[if lt IE 9]>\n' +
-				'<script>window.location = \'browser.htm\';</script>\n' +
-				'<![endif]-->\n' +
-				'\n' +
-				'\n' +
-				'<script>\n' +
-				'    const node = document.createElement(\'a\');\n' +
-				'    node.href = \'http://www.google.com\';\n' +
-				'    node.target = \'_blank\';\n' +
-				'    node.innerHTML = \'google\';\n' +
-				'    window.document.body.appendChild(node);\n' +
-				'</script>\n' +
-				'</body>\n' +
-				'</html>\n'
+					'<head>\n' +
+					'    <meta charset="UTF-8">\n' +
+					'    <title>Title</title>\n' +
+					'</head>\n' +
+					'<body>\n' +
+					'<!--[if lt IE 9]>\n' +
+					"<script>window.location = 'browser.htm';</script>\n" +
+					'<![endif]-->\n' +
+					'\n' +
+					'\n' +
+					'<script>\n' +
+					"    const node = document.createElement('a');\n" +
+					"    node.href = 'http://www.google.com';\n" +
+					"    node.target = '_blank';\n" +
+					"    node.innerHTML = 'google';\n" +
+					'    window.document.body.appendChild(node);\n' +
+					'</script>\n' +
+					'</body>\n' +
+					'</html>\n'
 			];
 
 			for (const html of testHTML) {


### PR DESCRIPTION
Fix #519

e.g.

```javascript
const window = new Window(), document = window.document;

const html = `<html>
<!--[if lt IE 9]>
    <script>window.location = 'browser.htm';</script>
<![endif]-->
</html>`;
document.write(html);

const source = new window.XMLSerializer().serializeToString(document);
console.assert(source === html);
console.log(window.location);

// Location {
// 	href: 'about:blank',
// 		origin: 'null',
// 		protocol: 'about:',
// 		username: '',
// 		password: '',
// 		host: '',
// 		hostname: '',
// 		port: '',
// 		pathname: 'blank',
// 		search: '',
// 		searchParams: URLSearchParams {},
// 	hash: ''
// }
```