### PR TITLE
#842@trivial: Adds declaration maps.

### DIFF
--- a/packages/global-registrator/tsconfig.json
+++ b/packages/global-registrator/tsconfig.json
@@ -5,6 +5,7 @@
 		"tsBuildInfoFile": "tmp/.tsbuildinfo",
 		"target": "es2020",
 		"declaration": true,
+		"declarationMap": true,
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"esModuleInterop": true,

--- a/packages/happy-dom/tsconfig.json
+++ b/packages/happy-dom/tsconfig.json
@@ -5,6 +5,7 @@
 		"tsBuildInfoFile": "tmp/.tsbuildinfo",
 		"target": "es2020",
 		"declaration": true,
+		"declarationMap": true,
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"esModuleInterop": true,

--- a/packages/jest-environment/tsconfig.json
+++ b/packages/jest-environment/tsconfig.json
@@ -5,6 +5,7 @@
 		"tsBuildInfoFile": "tmp/.tsbuildinfo",
 		"target": "es2020",
 		"declaration": true,
+		"declarationMap": true,
 		"module": "CommonJS",
 		"moduleResolution": "node",
 		"esModuleInterop": true,


### PR DESCRIPTION
this will build and include declaration maps alongside the declarations, allowing "go to definition" to lead to the source instead of a definition file. To see just the types "go to type definition" will still work.