### PR TITLE
#853@minor: Fix method Range.cloneContents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10119,6 +10119,7 @@
 			"dependencies": {
 				"css.escape": "^1.5.1",
 				"he": "^1.2.0",
+				"iconv-lite": "^0.6.3",
 				"webidl-conversions": "^7.0.0",
 				"whatwg-encoding": "^2.0.0",
 				"whatwg-mimetype": "^3.0.0"
@@ -14069,6 +14070,7 @@
 				"eslint-plugin-prettier": "^4.0.0",
 				"eslint-plugin-turbo": "^0.0.7",
 				"he": "^1.2.0",
+				"iconv-lite": "^0.6.3",
 				"jest": "^29.4.0",
 				"prettier": "^2.6.0",
 				"ts-jest": "^29.0.5",

--- a/packages/happy-dom/src/range/Range.ts
+++ b/packages/happy-dom/src/range/Range.ts
@@ -79,8 +79,6 @@ export default class Range {
 			const length = NodeUtility.getNodeLength(this._start.node);
 			if (this._start.offset > length) {
 				this._start.offset = length;
-			} else if (length === 0) {
-				this._start.offset = 0;
 			}
 		}
 
@@ -98,8 +96,6 @@ export default class Range {
 			const length = NodeUtility.getNodeLength(this._end.node);
 			if (this._end.offset > length) {
 				this._end.offset = length;
-			} else if (length === 0) {
-				this._end.offset = 0;
 			}
 		}
 
@@ -343,8 +339,8 @@ export default class Range {
 			fragment.appendChild(clone);
 
 			const subRange = new Range();
-			subRange._start.node = this._end.node;
-			subRange._start.offset = endOffset;
+			subRange._start.node = this._start.node;
+			subRange._start.offset = startOffset;
 			subRange._end.node = firstPartialContainedChild;
 			subRange._end.offset = NodeUtility.getNodeLength(firstPartialContainedChild);
 

--- a/packages/happy-dom/test/range/Range.test.ts
+++ b/packages/happy-dom/test/range/Range.test.ts
@@ -291,6 +291,22 @@ describe('Range', () => {
 
 			expect(document.body.innerHTML).toBe('ample: <i>italic</i> and <b>bol</b>');
 		});
+
+		// Fix for https://github.com/capricorn86/happy-dom/issues/853.
+		it('Clones multiple child elements inside a paragraph.', () => {
+			const paragraph = document.createElement('p');
+
+			paragraph.innerHTML = 'Example: <i>italic</i> and <b>bold</b>';
+
+			range.setStart(paragraph.querySelector('i').firstChild, 2);
+			range.setEnd(paragraph.querySelector('b').firstChild, 3);
+
+			const documentFragment = range.cloneContents();
+
+			document.body.appendChild(documentFragment);
+
+			expect(document.body.innerHTML).toBe('<i>alic</i> and <b>bol</b>');
+		});
 	});
 
 	describe('cloneRange()', () => {


### PR DESCRIPTION
Seems the method initializes the initial subrange (the first element containing the start of the selection) incorrectly (Range.ts, line 282):
- Currently, the subrange will be created from **end** of current range to end of `firstPartialContainedChild`.
- Obviously, the subrange should clone from **start** of original range to end of `firstPartialContainedChild`.

Minor additional fix: I removed the else-if branches in the `startOffset` and `endOffset` getters. Code would only run into the else-if branch if the `offset` property is already 0 (otherwise the initial if-branch would trigger and reset the `offset` property to 0). Therefore the else-if branch does not have any effect.