### PR TITLE
#857@patch: Throw DOMException from Text.splitText.

### DIFF
--- a/packages/happy-dom/src/nodes/text/Text.ts
+++ b/packages/happy-dom/src/nodes/text/Text.ts
@@ -43,15 +43,14 @@ export default class Text extends CharacterData implements IText {
 	 * Breaks the Text node into two nodes at the specified offset, keeping both nodes in the tree as siblings.
 	 *
 	 * @see https://dom.spec.whatwg.org/#dom-text-splittext
-	 * @see https://dom.spec.whatwg.org/#dom-text-splittext
 	 * @param offset Offset.
 	 * @returns New text node.
 	 */
 	public splitText(offset: number): IText {
 		const length = this._data.length;
 
-		if (offset > length) {
-			new DOMException(
+		if (offset < 0 || offset > length) {
+			throw new DOMException(
 				'The index is not in the allowed range.',
 				DOMExceptionNameEnum.indexSizeError
 			);

--- a/packages/happy-dom/test/nodes/text/Text.test.ts
+++ b/packages/happy-dom/test/nodes/text/Text.test.ts
@@ -1,5 +1,7 @@
 import Window from '../../../src/window/Window';
 import Document from '../../../src/nodes/document/Document';
+import DOMException from '../../../src/exception/DOMException';
+import Text from '../../../src/nodes/text/Text';
 
 describe('Text', () => {
 	let window: Window;
@@ -17,6 +19,7 @@ describe('Text', () => {
 	describe('get nodeName()', () => {
 		it('Returns "#text".', () => {
 			const node = document.createTextNode('test');
+			expect(node).toBeInstanceOf(Text);
 			expect(node.nodeName).toBe('#text');
 		});
 	});
@@ -33,6 +36,24 @@ describe('Text', () => {
 			const node = document.createTextNode('test');
 			const clone = node.cloneNode();
 			expect(clone.data).toBe(node.data);
+		});
+	});
+
+	describe('splitText()', () => {
+		it('Splits the text node.', () => {
+			const node = document.createTextNode('test');
+			document.body.append(node);
+			const result = node.splitText(2);
+			expect(node.textContent).toBe('te');
+			expect(result).toBeInstanceOf(Text);
+			expect(result.textContent).toBe('st');
+			expect(node.nextSibling).toBe(result);
+			expect(result.previousSibling).toBe(node);
+		});
+		it('Throws on invalid index.', () => {
+			const node = document.createTextNode('test');
+			expect(() => node.splitText(-1)).toThrow(DOMException);
+			expect(() => node.splitText(5)).toThrow(DOMException);
 		});
 	});
 });


### PR DESCRIPTION
fix #857 and unit tests for `Text.splittext`:
- the DOMException needs to be actually thrown
- missing check for negative index
- added unit test