### PR TITLE
#887@patch: Fix parsing CSS comments with asterisks.

### DIFF
--- a/packages/happy-dom/src/css/CSSParser.ts
+++ b/packages/happy-dom/src/css/CSSParser.ts
@@ -7,7 +7,7 @@ import CSSMediaRule from './rules/CSSMediaRule';
 import CSSContainerRule from './rules/CSSContainerRule';
 import CSSSupportsRule from './rules/CSSSupportsRule';
 
-const COMMENT_REGEXP = /\/\*[^*]*\*\//gm;
+const COMMENT_REGEXP = /\/\*[\s\S]*?\*\//gm;
 
 /**
  * CSS parser.

--- a/packages/happy-dom/test/css/CSSParser.test.ts
+++ b/packages/happy-dom/test/css/CSSParser.test.ts
@@ -14,7 +14,7 @@ describe('CSSParser', () => {
 			const cssStyleSheet = new CSSStyleSheet();
 			const cssRules = CSSParser.parseFromString(cssStyleSheet, CSSParserInput);
 
-			expect(cssRules.length).toBe(8);
+			expect(cssRules.length).toBe(10);
 
 			// CSSStyleRule
 			expect((<CSSStyleRule>cssRules[0]).parentRule).toBe(null);
@@ -187,6 +187,22 @@ describe('CSSParser', () => {
 			expect(children6[0].style[0]).toBe('color');
 			expect(children6[0].style.color).toBe('green');
 			expect(children6[0].cssText).toBe('.container { color: green; }');
+
+			expect((<CSSStyleRule>cssRules[8]).parentRule).toBe(null);
+			expect((<CSSStyleRule>cssRules[8]).parentStyleSheet).toBe(cssStyleSheet);
+			expect((<CSSStyleRule>cssRules[8]).selectorText).toBe(':root');
+			expect((<CSSStyleRule>cssRules[8]).cssText).toBe(':root { --my-var: 10px; }');
+			expect((<CSSStyleRule>cssRules[8]).style.parentRule).toBe(cssRules[8]);
+			expect((<CSSStyleRule>cssRules[8]).style.length).toBe(1);
+			expect((<CSSStyleRule>cssRules[8]).style.cssText).toBe('--my-var: 10px;');
+
+			expect((<CSSStyleRule>cssRules[9]).parentRule).toBe(null);
+			expect((<CSSStyleRule>cssRules[9]).parentStyleSheet).toBe(cssStyleSheet);
+			expect((<CSSStyleRule>cssRules[9]).selectorText).toBe('.foo');
+			expect((<CSSStyleRule>cssRules[9]).cssText).toBe('.foo { color: red; }');
+			expect((<CSSStyleRule>cssRules[9]).style.parentRule).toBe(cssRules[9]);
+			expect((<CSSStyleRule>cssRules[9]).style.length).toBe(1);
+			expect((<CSSStyleRule>cssRules[9]).style.cssText).toBe('color: red;');
 		});
 	});
 });

--- a/packages/happy-dom/test/css/data/CSSParserInput.ts
+++ b/packages/happy-dom/test/css/data/CSSParserInput.ts
@@ -1,4 +1,5 @@
 export default `
+
     :host {
         display: flex;
         overflow: hidden;
@@ -57,4 +58,15 @@ export default `
             color: green;
         }
     }
+
+    /*
+    * Multi-line comment with leading star
+    */
+    :root {
+        --my-var: 10px;
+    }
+
+    /* Single-line comment */
+    .foo { color: red; }
+    
 `.trim();


### PR DESCRIPTION
Fix CSS regex so comment content is a non-greedy "any character or whitespace" instead of the previous "anything but *".