### PR TITLE
#923@patch: Fixes issue where attribute selectors with an operator an…

### DIFF
--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -142,7 +142,7 @@ export default class SelectorParser {
 						operator: match[11] || null,
 						value: match[12],
 						modifier: null,
-						regExp: this.getAttributeRegExp({ operator: match[7], value: match[8] })
+						regExp: this.getAttributeRegExp({ operator: match[11], value: match[12] })
 					});
 				} else if (match[13] && match[14]) {
 					currentSelectorItem.pseudos = currentSelectorItem.pseudos || [];

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -473,6 +473,19 @@ describe('QuerySelector', () => {
 			expect(elements[4] === container.children[0].children[1].children[2]).toBe(true);
 		});
 
+		it('Returns all elements with an attribute value that begins with a specified value using "[class^=cl]".', () => {
+			const container = document.createElement('div');
+			container.innerHTML = QuerySelectorHTML;
+			const elements = container.querySelectorAll('[class^=cl]');
+
+			expect(elements.length).toBe(5);
+			expect(elements[0] === container.children[0]).toBe(true);
+			expect(elements[1] === container.children[0].children[1]).toBe(true);
+			expect(elements[2] === container.children[0].children[1].children[0]).toBe(true);
+			expect(elements[3] === container.children[0].children[1].children[1]).toBe(true);
+			expect(elements[4] === container.children[0].children[1].children[2]).toBe(true);
+		});
+
 		it('Returns all elements with an attribute value that ends with a specified value using "[class$="ss2"]".', () => {
 			const container = document.createElement('div');
 			container.innerHTML = QuerySelectorHTML;


### PR DESCRIPTION
…d with a value without quatation marks no longer worked (e.g. "[attr^=value]").