### PR TITLE
docs: fix typo in window settings

### DIFF
--- a/packages/happy-dom/README.md
+++ b/packages/happy-dom/README.md
@@ -262,7 +262,7 @@ const window = new Window({
 		enableFileSystemHttpRequests: true,
         device: {
             mediaType: 'print',
-            prefersColorScheme = 'dark
+            prefersColorScheme: 'dark
         }
 	}
 });


### PR DESCRIPTION
tiny change to fix the syntax in the example here