### PR TITLE
#945@minor Add support for HTMLInputElement set valueAsNumber

### DIFF
--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputDateUtility.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputDateUtility.ts
@@ -1,0 +1,21 @@
+/**
+ * Return iso-week number from given date
+ *
+ * @param date Date|number.
+ * @returns Iso-week string.
+ */
+export const dateIsoWeek = (date: Date | number): string => {
+	date = new Date(date);
+	const day = (date.getUTCDay() + 6) % 7;
+	date.setUTCDate(date.getUTCDate() - day + 3);
+	const firstThursday = date.getTime();
+	date.setUTCMonth(0, 1);
+	if (date.getDay() !== 4) {
+		date.setUTCMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+	}
+	return (
+		date.getUTCFullYear() +
+		'-W' +
+		String(1 + Math.ceil((firstThursday - date.getTime()) / 604800000)).padStart(2, '0')
+	);
+};

--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
@@ -24,6 +24,28 @@ import NodeList from '../node/NodeList.js';
 import EventPhaseEnum from '../../event/EventPhaseEnum.js';
 
 /**
+ * Return iso-week number from given date
+ *
+ * @param date Date|number.
+ * @returns Iso-week string.
+ */
+export const dateIsoWeek = (date: Date | number): string => {
+	date = new Date(date);
+	const day = (date.getUTCDay() + 6) % 7;
+	date.setUTCDate(date.getUTCDate() - day + 3);
+	const firstThursday = date.getTime();
+	date.setUTCMonth(0, 1);
+	if (date.getDay() !== 4) {
+		date.setUTCMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+	}
+	return (
+		date.getUTCFullYear() +
+		'-W' +
+		String(1 + Math.ceil((firstThursday - date.getTime()) / 604800000)).padStart(2, '0')
+	);
+};
+
+/**
  * HTML Input Element.
  *
  * Reference:
@@ -797,7 +819,104 @@ export default class HTMLInputElement extends HTMLElement implements IHTMLInputE
 	 * @returns Number.
 	 */
 	public get valueAsNumber(): number {
-		return this.value ? parseFloat(this.value) : NaN;
+		const value = this.value;
+		if (!this.type.match(/^(range|number|date|datetime-local|month|time|week)$/) || !value) {
+			return NaN;
+		}
+		switch (this.type) {
+			case 'number':
+				return parseFloat(value);
+			case 'range': {
+				const number = parseFloat(value);
+				const min = parseFloat(this.min) || 0;
+				const max = parseFloat(this.max) || 100;
+				if (isNaN(number)) {
+					return max < min ? min : (min + max) / 2;
+				} else if (number < min) {
+					return min;
+				} else if (number > max) {
+					return max;
+				}
+				return number;
+			}
+			case 'date':
+				return new Date(value).getTime();
+			case 'datetime-local':
+				return new Date(value).getTime() - new Date(value).getTimezoneOffset() * 60000;
+			case 'month':
+				return (new Date(value).getUTCFullYear() - 1970) * 12 + new Date(value).getUTCMonth();
+			case 'time':
+				return (
+					new Date('1970-01-01T' + value).getTime() - new Date('1970-01-01T00:00:00').getTime()
+				);
+			case 'week': {
+				// https://html.spec.whatwg.org/multipage/input.html#week-state-(type=week)
+				const match = value.match(/^(\d{4})-W(\d{2})$/);
+				if (!match) {
+					return NaN;
+				}
+				const d = new Date(Date.UTC(parseInt(match[1], 10), 0));
+				const day = d.getUTCDay();
+				const diff = ((day === 0 ? -6 : 1) - day) * 86400000 + parseInt(match[2], 10) * 604800000;
+				return d.getTime() + diff;
+			}
+		}
+	}
+
+	/**
+	 * Sets value from a number.
+	 *
+	 * @param value number.
+	 */
+	public set valueAsNumber(value: number) {
+		// Specs at https://html.spec.whatwg.org/multipage/input.html
+		switch (this.type) {
+			case 'number':
+			case 'range':
+				// We Rely on HTMLInputElementValueSanitizer
+				this.value = Number(value).toString();
+				break;
+			case 'date':
+			case 'datetime-local': {
+				const d = new Date(Number(value));
+				if (isNaN(d.getTime())) {
+					// Reset to default value
+					this.value = '';
+					break;
+				}
+				if (this.type == 'date') {
+					this.value = d.toISOString().slice(0, 10);
+				} else {
+					this.value = d.toISOString().slice(0, -1);
+				}
+				break;
+			}
+			case 'month':
+				if (!Number.isInteger(value) || value < 0) {
+					this.value = '';
+				} else {
+					this.value = new Date(Date.UTC(1970, Number(value))).toISOString().slice(0, 7);
+				}
+				break;
+			case 'time':
+				if (!Number.isInteger(value) || value < 0) {
+					this.value = '';
+				} else {
+					this.value = new Date(Number(value)).toISOString().slice(11, -1);
+				}
+				break;
+			case 'week':
+			case 'week': {
+				const d = new Date(Number(value));
+				this.value = isNaN(d.getTime()) ? '' : dateIsoWeek(d);
+				break;
+			}
+			default:
+				throw new DOMException(
+					"Failed to set the 'valueAsNumber' property on 'HTMLInputElement': This input element does not support Number values.",
+					DOMExceptionNameEnum.invalidStateError
+				);
+		}
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
@@ -22,28 +22,7 @@ import IDocument from '../document/IDocument.js';
 import IShadowRoot from '../shadow-root/IShadowRoot.js';
 import NodeList from '../node/NodeList.js';
 import EventPhaseEnum from '../../event/EventPhaseEnum.js';
-
-/**
- * Return iso-week number from given date
- *
- * @param date Date|number.
- * @returns Iso-week string.
- */
-export const dateIsoWeek = (date: Date | number): string => {
-	date = new Date(date);
-	const day = (date.getUTCDay() + 6) % 7;
-	date.setUTCDate(date.getUTCDate() - day + 3);
-	const firstThursday = date.getTime();
-	date.setUTCMonth(0, 1);
-	if (date.getDay() !== 4) {
-		date.setUTCMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
-	}
-	return (
-		date.getUTCFullYear() +
-		'-W' +
-		String(1 + Math.ceil((firstThursday - date.getTime()) / 604800000)).padStart(2, '0')
-	);
-};
+import { dateIsoWeek } from './HTMLInputDateUtility.js';
 
 /**
  * HTML Input Element.

--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElementValueSanitizer.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElementValueSanitizer.ts
@@ -1,6 +1,7 @@
 import HTMLInputElement from './HTMLInputElement.js';
 
 const NEW_LINES_REGEXP = /[\n\r]/gm;
+const parseInts = (a: string[]): number[] => a.map((v) => parseInt(v, 10));
 
 /**
  * HTML input element value sanitizer.
@@ -35,7 +36,7 @@ export default class HTMLInputElementValueSanitizer {
 			case 'number':
 				// https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number):value-sanitization-algorithm
 				return !isNaN(Number.parseFloat(value)) ? value : '';
-			case 'range':
+			case 'range': {
 				// https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range):value-sanitization-algorithm
 				const number = Number.parseFloat(value);
 				const min = parseFloat(input.min) || 0;
@@ -50,11 +51,162 @@ export default class HTMLInputElementValueSanitizer {
 				}
 
 				return value;
+			}
 			case 'url':
 				// https://html.spec.whatwg.org/multipage/forms.html#url-state-(type=url):value-sanitization-algorithm
 				return value.trim().replace(NEW_LINES_REGEXP, '');
+			case 'date':
+				// https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date):value-sanitization-algorithm
+				value = this.sanitizeDate(value);
+				return value && this.checkBoundaries(value, input.min, input.max) ? value : '';
+			case 'datetime-local': {
+				// https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local):value-sanitization-algorithm
+				const match = value.match(
+					/^(\d\d\d\d)-(\d\d)-(\d\d)[T ](\d\d):(\d\d)(?::(\d\d)(?:\.(\d{1,3}))?)?$/
+				);
+				if (!match) {
+					return '';
+				}
+				const dateString = this.sanitizeDate(value.slice(0, 10));
+				let timeString = this.sanitizeTime(value.slice(11));
+				if (!(dateString && timeString)) {
+					return '';
+				}
+				// Has seconds so needs to remove trailing zeros
+				if (match[6] !== undefined) {
+					if (timeString.indexOf('.') !== -1) {
+						// Remove unecessary zeros milliseconds
+						timeString = timeString.replace(/(?:\.0*|(\.\d+?)0+)$/, '$1');
+					}
+					timeString = timeString.replace(/(\d\d:\d\d)(:00)$/, '$1');
+				}
+				return dateString + 'T' + timeString;
+			}
+			case 'month':
+				// https://html.spec.whatwg.org/multipage/input.html#month-state-(type=month):value-sanitization-algorithm
+				if (!(value.match(/^(\d\d\d\d)-(\d\d)$/) && this.parseMonthComponent(value))) {
+					return '';
+				}
+				return this.checkBoundaries(value, input.min, input.max) ? value : '';
+			case 'time': {
+				// https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time):value-sanitization-algorithm
+				value = this.sanitizeTime(value);
+				return value && this.checkBoundaries(value, input.min, input.max) ? value : '';
+			}
+			case 'week': {
+				// https://html.spec.whatwg.org/multipage/input.html#week-state-(type=week):value-sanitization-algorithm
+				const match = value.match(/^(\d\d\d\d)-W(\d\d)$/);
+				if (!match) {
+					return '';
+				}
+				const [intY, intW] = parseInts(match.slice(1, 3));
+				if (intY <= 0 || intW < 1 || intW > 53) {
+					return '';
+				}
+				// Check date is valid
+				const lastWeek = this.lastIsoWeekOfYear(intY);
+				if (intW < 1 || intW > 52 + lastWeek) {
+					return '';
+				}
+				if (!this.checkBoundaries(value, input.min, input.max)) {
+					return '';
+				}
+				return value;
+			}
 		}
 
 		return value;
+	}
+	/**
+	 * Checks if a value is within the boundaries of min and max.
+	 *
+	 * @param value
+	 * @param min
+	 * @param max
+	 */
+	private static checkBoundaries<T>(value: T, min: T, max: T): boolean {
+		if (min && min > value) {
+			return false;
+		} else if (max && max < value) {
+			return false;
+		}
+		return true;
+	}
+	/**
+	 * Parses the month component of a date string.
+	 *
+	 * @param value
+	 */
+	private static parseMonthComponent(value: string): string {
+		const [Y, M] = value.split('-');
+		const [intY, intM] = parseInts([Y, M]);
+		if (isNaN(intY) || isNaN(intM) || intY <= 0 || intM < 1 || intM > 12) {
+			return '';
+		}
+		return value;
+	}
+	/**
+	 * Returns the last ISO week of a year.
+	 *
+	 * @param year
+	 */
+	private static lastIsoWeekOfYear = (year: string | number): number => {
+		const date = new Date(+year, 11, 31);
+		const day = (date.getDay() + 6) % 7;
+		date.setDate(date.getDate() - day + 3);
+		const firstThursday = date.getTime();
+		date.setMonth(0, 1);
+		if (date.getDay() !== 4) {
+			date.setMonth(0, 1 + ((4 - date.getDay() + 7) % 7));
+		}
+		return 1 + Math.ceil((firstThursday - date.getTime()) / 604800000);
+	};
+
+	/**
+	 * Sanitizes a date string.
+	 *
+	 * @param value
+	 */
+	private static sanitizeDate(value: string): string {
+		const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+		if (!match) {
+			return '';
+		}
+		const month = this.parseMonthComponent(value.slice(0, 7));
+		if (!month) {
+			return '';
+		}
+		const [intY, intM, intD] = parseInts(match.slice(1, 4));
+		if (intD < 1 || intD > 31) {
+			return '';
+		}
+		// Check date is valid
+		const lastDayOfMonth = new Date(intY, intM, 0).getDate();
+		if (intD > lastDayOfMonth) {
+			return '';
+		}
+		return value;
+	}
+
+	/**
+	 * Sanitizes a time string.
+	 *
+	 * @param value
+	 */
+	private static sanitizeTime(value: string): string {
+		const match = value.match(/^(\d{2}):(\d{2})(?::(\d{2}(?:\.(\d{1,3}))?))?$/);
+		if (!match) {
+			return '';
+		}
+		const [intH, intM] = parseInts(match.slice(1, 3));
+		const ms = parseFloat(match[3] || '0') * 1000;
+		if (intH > 23 || intM > 59 || ms > 59999) {
+			return '';
+		}
+		if (ms === 0) {
+			return `${match[1]}:${match[2]}`;
+		} else {
+			return `${match[1]}:${match[2]}${ms >= 10000 ? `:${ms / 1000}` : `:0${ms / 1000}`}`;
+		}
 	}
 }

--- a/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
@@ -9,6 +9,7 @@ import HTMLInputElementSelectionModeEnum from '../../../src/nodes/html-input-ele
 import HTMLInputElementSelectionDirectionEnum from '../../../src/nodes/html-input-element/HTMLInputElementSelectionDirectionEnum.js';
 import ValidityState from '../../../src/validity-state/ValidityState.js';
 import IHTMLFormElement from '../../../src/nodes/html-form-element/IHTMLFormElement.js';
+import DOMExceptionNameEnum from '../../../src/exception/DOMExceptionNameEnum.js';
 import { beforeEach, describe, it, expect } from 'vitest';
 
 describe('HTMLInputElement', () => {
@@ -199,6 +200,158 @@ describe('HTMLInputElement', () => {
 			element.type = 'url';
 			element.value = '  \n\rhttp://www.test.com\n\r ';
 			expect(element.value).toBe('http://www.test.com');
+		});
+	});
+
+	describe('get valueAsNumber()', () => {
+		describe('Should return NaN for non-numeric input type', () => {
+			for (const type of [
+				'button',
+				'checkbox',
+				'color',
+				'email',
+				'file',
+				'hidden',
+				'image',
+				'password',
+				'radio',
+				'reset',
+				'search',
+				'submit',
+				'tel',
+				'text',
+				'url'
+			]) {
+				it(`"${type}"`, () => {
+					element.setAttribute('type', type);
+					if (type === 'file') {
+						element.value = '';
+					} else {
+						element.value = '0';
+					}
+					expect(element.valueAsNumber).toBeNaN();
+				});
+			}
+		});
+		describe('with default value', () => {
+			for (const type of ['date', 'datetime-local', 'month', 'number', 'time', 'week']) {
+				it(`Should return NaN for type ${type}.`, () => {
+					element.type = type;
+					element.value = '';
+					expect(element.valueAsNumber).toBeNaN();
+				});
+			}
+			it(`Should return middle range value for type "range".`, () => {
+				element.type = 'range';
+				element.value = '';
+				const min = element.min ? parseFloat(element.min) : 0;
+				const max = element.max ? parseFloat(element.max) : 100;
+				expect(element.valueAsNumber).toBe((max - min) / 2);
+			});
+		});
+
+		describe('With valid value', () => {
+			const testData: { type: string; value: string; want: number }[] = [
+				{ type: 'number', value: '123', want: 123 },
+				{ type: 'number', value: '1.23', want: 1.23 },
+				{ type: 'range', value: '75', want: 75 },
+				{ type: 'range', value: '12.5', want: 12.5 },
+				{ type: 'date', value: '2019-01-01', want: new Date('2019-01-01').getTime() },
+				{
+					type: 'datetime-local',
+					value: '2019-01-01T00:00',
+					want:
+						new Date('2019-01-01T00:00').getTime() -
+						new Date('2019-01-01T00:00').getTimezoneOffset() * 60000
+				},
+				{ type: 'month', value: '2019-01', want: 588 },
+				{ type: 'time', value: '00:00', want: 0 },
+				{ type: 'time', value: '12:00', want: 43200000 },
+				{ type: 'time', value: '18:55', want: 68100000 },
+				{ type: 'week', value: '2023-W22', want: 1685318400000 }
+			];
+			it.each(testData)(`Should return valid number for type $type`, ({ type, value, want }) => {
+				element.type = type;
+				element.value = value;
+				expect(element.valueAsNumber).toEqual(want);
+			});
+		});
+	});
+	describe('set valueAsNumber()', () => {
+		describe('Should throw exception for non-numeric input', () => {
+			it.each([
+				'button',
+				'checkbox',
+				'color',
+				'email',
+				'file',
+				'hidden',
+				'image',
+				'password',
+				'radio',
+				'reset',
+				'search',
+				'submit',
+				'tel',
+				'text',
+				'url'
+			])('Of type %s.', (type) => {
+				element.type = type;
+				expect(() => (element.valueAsNumber = 0)).toThrowError(
+					new DOMException(
+						"Failed to set the 'valueAsNumber' property on 'HTMLInputElement': This input element does not support Number values.",
+						DOMExceptionNameEnum.invalidStateError
+					)
+				);
+			});
+		});
+
+		describe('With invalid value for', () => {
+			it.each(['number', 'date', 'datetime-local', 'month', 'time', 'week'])(
+				'Type "%s" should set default empty value.',
+				(type) => {
+					element.type = type;
+					expect(() => {
+						// @ts-ignore
+						element.valueAsNumber = 'x';
+					}).not.toThrow();
+					expect(element.value).toBe('');
+				}
+			);
+			it(`Type "range" should set default middle range value.`, () => {
+				element.type = 'range';
+				expect(() => {
+					// @ts-ignore
+					element.valueAsNumber = 'x';
+				}).not.toThrow();
+				expect(element.value).toBe('50');
+			});
+		});
+
+		describe('With valid value for', () => {
+			const testCases = [
+				{ type: 'number', value: 123, want: '123' },
+				{ type: 'number', value: 1.23, want: '1.23' },
+				{ type: 'range', value: 75, want: '75' },
+				{ type: 'range', value: 12.5, want: '12.5' },
+				{ type: 'date', value: new Date('2019-01-01').getTime(), want: '2019-01-01' },
+				{ type: 'datetime-local', value: 1546300800000, want: '2019-01-01T00:00' },
+				{ type: 'month', value: 588, want: '2019-01' },
+				{ type: 'time', value: 0, want: '00:00' },
+				{ type: 'time', value: 43200000, want: '12:00' },
+				{ type: 'time', value: 68100000, want: '18:55' },
+				{ type: 'time', value: 83709010, want: '23:15:09.01' },
+				{ type: 'week', value: 1685318400000, want: '2023-W22' },
+				{ type: 'week', value: 1672531200000, want: '2022-W52' }
+			];
+			it.each(testCases)(
+				`Type "$type" should set a corresponding value`,
+				({ type, value, want }) => {
+					element.type = type;
+					element.valueAsNumber = value;
+					expect(element.value).toEqual(want);
+				}
+			);
 		});
 	});
 

--- a/packages/happy-dom/test/nodes/html-input-element/HTMLInputElementValueSanitizer.test.ts
+++ b/packages/happy-dom/test/nodes/html-input-element/HTMLInputElementValueSanitizer.test.ts
@@ -1,0 +1,115 @@
+import Window from '../../../src/window/Window.js';
+import IWindow from '../../../src/window/IWindow.js';
+import IDocument from '../../../src/nodes/document/IDocument.js';
+import IHTMLInputElement from '../../../src/nodes/html-input-element/IHTMLInputElement.js';
+import HTMLInputElementValueSanitizer from '../../../src/nodes/html-input-element/HTMLInputElementValueSanitizer.js';
+import HTMLInputElement from '../../../src/nodes/html-input-element/HTMLInputElement.js';
+import { beforeEach, describe, it, expect } from 'vitest';
+
+describe('HTMLInputElementValueSanitizer', () => {
+	describe('sanitize', () => {
+		let window: IWindow;
+		let document: IDocument;
+		let input: IHTMLInputElement;
+
+		beforeEach(() => {
+			window = new Window();
+			document = window.document;
+			input = <IHTMLInputElement>document.createElement('input');
+		});
+
+		type TestCase = {
+			value: string;
+			want: string;
+			attributes?: { [key: string]: string };
+		};
+
+		const testCases: Record<string, TestCase[]> = {
+			number: [
+				{ value: '1.25', want: '1.25' },
+				{ value: 'not a number', want: '' },
+				{ value: 'NaN', want: '' }
+			],
+			range: [
+				{ value: '25', want: '25' },
+				{ value: 'NaN', want: '50' },
+				{ value: '-1', want: '0' },
+				{ value: '101', want: '100' }
+			],
+			date: [
+				{ value: '2020-01-01', want: '2020-01-01' },
+				{ value: 'NaN', want: '' },
+				{ value: '2020-01-00', want: '' },
+				{ value: '2020-02-31', want: '' },
+				{ value: '2020-13-01', want: '' },
+				{ value: '2020-01-1', want: '' },
+				{ value: '2020-01-01', want: '', attributes: { min: '2020-01-02' } },
+				{ value: '2020-01-01', want: '', attributes: { max: '2019-12-31' } }
+			],
+			'datetime-local': [
+				{ value: '2020-01-01T00:00', want: '2020-01-01T00:00' },
+				{ value: 'unknown', want: '' },
+				{ value: '2020-01-01 01:00', want: '2020-01-01T01:00' },
+				{ value: '2020-01-01T00:00:59', want: '2020-01-01T00:00:59' },
+				{ value: '2020-01-01T00:00:59.1', want: '2020-01-01T00:00:59.1' },
+				{ value: '2020-01-01T00:00:59.123', want: '2020-01-01T00:00:59.123' },
+				{ value: '2020-01-01T00:00:59.1234', want: '' },
+				{ value: '2020-01-01T00:00:01.000', want: '2020-01-01T00:00:01' },
+				{ value: '2020-01-01T00:00:00.010', want: '2020-01-01T00:00:00.01' },
+				{ value: '2020-01-01T00:00:00.100', want: '2020-01-01T00:00:00.1' },
+				{ value: '2020-01-01T00:00:00.000', want: '2020-01-01T00:00' },
+				{ value: '2020-01-01T00:00:00', want: '2020-01-01T00:00' }
+			],
+			month: [
+				{ value: '2020-01', want: '2020-01' },
+				{ value: 'NaN', want: '' },
+				{ value: '0000-01', want: '' },
+				{ value: '2020-13', want: '' },
+				{ value: '2020-00', want: '' },
+				{ value: '2020-01', want: '', attributes: { min: '2020-02' } },
+				{ value: '2020-01', want: '', attributes: { max: '2019-12' } }
+			],
+			time: [
+				{ value: '00:00', want: '00:00' },
+				{ value: '00:00:00.000', want: '00:00' },
+				{ value: '00:00:09.000', want: '00:00:09' },
+				{ value: '00:00:10.000', want: '00:00:10' },
+				{ value: '00:00:59', want: '00:00:59' },
+				{ value: '00:00:59.1', want: '00:00:59.1' },
+				{ value: '00:00:59.123', want: '00:00:59.123' },
+				{ value: '13:00', want: '13:00' },
+				{ value: 'NaN', want: '' },
+				{ value: '24:00', want: '' },
+				{ value: '00:60', want: '' },
+				{ value: '00:00:60', want: '' },
+				{ value: '00:00:', want: '' },
+				{ value: '00:00:00.1234', want: '' }
+			],
+			week: [
+				{ value: '2020-W01', want: '2020-W01' },
+				{ value: 'NaN', want: '' },
+				{ value: '2020-W00', want: '' },
+				{ value: '2020-W54', want: '' },
+				{ value: '2020-W01', want: '', attributes: { min: '2020-W02' } },
+				{ value: '2020-W01', want: '', attributes: { max: '2019-W53' } }
+			]
+		};
+
+		Object.keys(testCases).forEach((type) => {
+			describe(`For input type ${type}`, () => {
+				it.each(testCases[type])(
+					`Should return "$want" for value "$value"`,
+					({ value, want, attributes }) => {
+						input.type = type;
+						if (attributes) {
+							Object.entries(attributes).forEach(([attr, val]) => input.setAttribute(attr, val));
+						}
+						expect(HTMLInputElementValueSanitizer.sanitize(<HTMLInputElement>input, value)).toBe(
+							want
+						);
+					}
+				);
+			});
+		});
+	});
+});


### PR DESCRIPTION
- Enhance HTMLInputElementValueSanitizer to be more compliant with specs at https://html.spec.whatwg.org/multipage/input.html (breaking change)
- Change HTMLInputElement get valueAsNumber to be more compliant with specs at https://html.spec.whatwg.org/multipage/input.html (breaking change)
- Add support for HTMLInputElement set valueAsNumber based on specs at https://html.spec.whatwg.org/multipage/input.html

This is come as a replacement of PR#946 