### PR TITLE
#982@patch: Fixes problem where lit-html is using special characters …

### DIFF
--- a/packages/global-registrator/package.json
+++ b/packages/global-registrator/package.json
@@ -74,7 +74,7 @@
 		"test:debug": "tsc --project ./test && node --inspect-brk ./tmp/react/React.test.js"
 	},
 	"dependencies": {
-		"happy-dom": "^0.0.0"
+		"happy-dom": "0.0.0"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.16.0",

--- a/packages/happy-dom/src/nodes/document-fragment/IDocumentFragment.ts
+++ b/packages/happy-dom/src/nodes/document-fragment/IDocumentFragment.ts
@@ -28,7 +28,7 @@ export default interface IDocumentFragment extends INode {
 	 * @param selector CSS selector.
 	 * @returns Matching element.
 	 */
-	querySelector(selector: string): IElement;
+	querySelector(selector: string): IElement | null;
 
 	/**
 	 * Query CSS selector to find matching nodes.

--- a/packages/happy-dom/src/nodes/parent-node/IParentNode.ts
+++ b/packages/happy-dom/src/nodes/parent-node/IParentNode.ts
@@ -29,7 +29,7 @@ export default interface IParentNode extends INode {
 	 * @param selector CSS selector.
 	 * @returns Matching element.
 	 */
-	querySelector(selector: string): IElement;
+	querySelector(selector: string): IElement | null;
 
 	/**
 	 * Query CSS selector to find matching nodes.

--- a/packages/happy-dom/src/xml-parser/XMLParser.ts
+++ b/packages/happy-dom/src/xml-parser/XMLParser.ts
@@ -40,7 +40,7 @@ const MARKUP_REGEXP =
  * Group 9: Attribute name when the attribute has no value (e.g. "disabled" in "<div disabled>").
  */
 const ATTRIBUTE_REGEXP =
-	/\s*([a-zA-Z0-9-_:]+) *= *("{0,1})([^"]*)("{0,1})|\s*([a-zA-Z0-9-_:]+) *= *('{0,1})([^']*)('{0,1})|\s*([a-zA-Z0-9-_:]+)/gm;
+	/\s*([a-zA-Z0-9-_:.$@]+) *= *("{0,1})([^"]*)("{0,1})|\s*([a-zA-Z0-9-_:.$@]+) *= *('{0,1})([^']*)('{0,1})|\s*([a-zA-Z0-9-_:.$@]+)/gm;
 
 enum MarkupReadStateEnum {
 	startOrEndTag = 'startOrEndTag',

--- a/packages/happy-dom/test/xml-parser/XMLParser.test.ts
+++ b/packages/happy-dom/test/xml-parser/XMLParser.test.ts
@@ -639,5 +639,21 @@ describe('XMLParser', () => {
 			expect(root.children[8].attributes[0].name).toBe('key1');
 			expect(root.children[8].attributes[0].value).toBe('value1 /> value2');
 		});
+
+		it('Parses attributes with characters that lit-html is using (".", "$", "@").', () => {
+			const root = XMLParser.parse(
+				document,
+				`
+                <img key1="value1" key2/>
+                <img key1="value1"/>
+                <span .key$lit$="{{lit-11111}}"></span>
+                <div @event="{{lit-22222}}"></div>
+                <img key1="value1" key2/>
+                `
+			);
+
+			expect(root.querySelector('span')?.getAttribute('.key$lit$')).toBe('{{lit-11111}}');
+			expect(root.querySelector('div')?.getAttribute('@event')).toBe('{{lit-22222}}');
+		});
 	});
 });

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -54,7 +54,7 @@
 		"@jest/types": "^29.4.0",
 		"jest-mock": "^29.4.0",
 		"jest-util": "^29.4.0",
-		"happy-dom": "^0.0.0"
+		"happy-dom": "0.0.0"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.16.0",


### PR DESCRIPTION
…in attributes, causing the XMLParser not to be able to parse the attribute correctly.