### PR TITLE
#530@minor: Broader support for HTMLLabelElement `control`.

### DIFF
--- a/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElement.ts
+++ b/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElement.ts
@@ -42,12 +42,9 @@ export default class HTMLLabelElement extends HTMLElement implements IHTMLLabelE
 		if (htmlFor) {
 			return <IHTMLElement>this.ownerDocument.getElementById(htmlFor);
 		}
-		for (const child of this.children) {
-			if (child.tagName === 'INPUT') {
-				return <IHTMLElement>child;
-			}
-		}
-		return null;
+		return <IHTMLElement>(
+			this.querySelector('button,input:not([type="hidden"]),meter,output,progress,select,textarea')
+		);
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
@@ -50,6 +50,21 @@ describe('HTMLLabelElement', () => {
 			element.appendChild(input);
 			expect(element.control === input).toBe(true);
 		});
+
+		it('Returns a descendent input if "for" attribute is not defined.', () => {
+			const input = document.createElement('input');
+			const span = document.createElement('span');
+			span.appendChild(input);
+			element.appendChild(span);
+			expect(element.control === input).toBe(true);
+		});
+
+		it('Does not return hidden inputs.', () => {
+			const input = document.createElement('input');
+			input.setAttribute('type', 'hidden');
+			element.appendChild(input);
+			expect(element.control).toBe(null);
+		});
 	});
 
 	describe('get form()', () => {


### PR DESCRIPTION
This supports nested / descendent input elements for HTMLLabelElement's `control` property and also supports other labelable elements, as described in the spec:

https://html.spec.whatwg.org/multipage/forms.html#category-label

To be fully spec-compliant, the `control` getter would ignore `for` element(s) that aren't labelable elements, and labelable elements would also include form-associated custom elements.

I'm using a CSS selector for this, because that seemed like the most convenient approach, but if another approach would be better (e.g., for performance?), please let me know.

Fixes #530.