### PR TITLE
Add naive scrollHeight implementation

### DIFF
--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -44,6 +44,7 @@ export default class Element extends Node implements IElement {
 	public shadowRoot: IShadowRoot = null;
 	public prefix: string = null;
 
+	public scrollHeight = 0;
 	public scrollTop = 0;
 	public scrollLeft = 0;
 	public children: IHTMLCollection<IElement> = new HTMLCollection<IElement>();
@@ -369,6 +370,7 @@ export default class Element extends Node implements IElement {
 		(<string>clone.tagName) = this.tagName;
 		clone.scrollLeft = this.scrollLeft;
 		clone.scrollTop = this.scrollTop;
+		clone.scrollHeight = this.scrollHeight;
 		(<string>clone.namespaceURI) = this.namespaceURI;
 
 		return <IElement>clone;

--- a/packages/happy-dom/src/nodes/element/IElement.ts
+++ b/packages/happy-dom/src/nodes/element/IElement.ts
@@ -23,6 +23,7 @@ export default interface IElement extends IChildNode, INonDocumentTypeChildNode,
 	prefix: string | null;
 	scrollTop: number;
 	scrollLeft: number;
+	scrollHeight: number;
 	id: string;
 	className: string;
 	role: string;

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -1512,6 +1512,12 @@ describe('Element', () => {
 		});
 	}
 
+	describe('scrollHeight', () => {
+		it('Returns the scroll height.', () => {
+			expect(element.scrollHeight).toBe(0);
+		});
+	});
+
 	describe('toString()', () => {
 		it('Returns the same as outerHTML.', () => {
 			expect(element.toString()).toBe(element.outerHTML);


### PR DESCRIPTION
Very naive implementation of https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight

To be able to test https://mui.com/material-ui/react-textarea-autosize/ without warnings:

```
Warning: `NaN` is an invalid value for the `height` css style property.
    at textarea
    at TextareaAutosize (node_modules/@mui/base/node/TextareaAutosize/TextareaAutosize.js:41:7)
    at node_modules/@emotion/react/dist/emotion-element-b63ca7c6.cjs.dev.js:43:23
    at div
    at node_modules/@emotion/react/dist/emotion-element-b63ca7c6.cjs.dev.js:43:23
    at InputBase (node_modules/@mui/material/node/InputBase/InputBase.js:224:44)
    at OutlinedInput (node_modules/@mui/material/node/OutlinedInput/OutlinedInput.js:129:44)
    at div
    [...]
```
