### PR TITLE
#953@minor: Add missing the movement values into MouseEvent.

### DIFF
--- a/packages/happy-dom/src/event/events/IMouseEventInit.ts
+++ b/packages/happy-dom/src/event/events/IMouseEventInit.ts
@@ -10,6 +10,8 @@ export default interface IMouseEventInit extends IUIEventInit {
 	shiftKey?: boolean;
 	altKey?: boolean;
 	metaKey?: boolean;
+	movementX?: number;
+	movementY?: number;
 	button?: number;
 	buttons?: number;
 	relatedTarget?: EventTarget;

--- a/packages/happy-dom/src/event/events/MouseEvent.ts
+++ b/packages/happy-dom/src/event/events/MouseEvent.ts
@@ -40,6 +40,8 @@ export default class MouseEvent extends UIEvent {
 			this.clientY = eventInit.clientY !== undefined ? eventInit.clientY : 0;
 			this.ctrlKey = eventInit.ctrlKey || false;
 			this.metaKey = eventInit.metaKey || false;
+			this.movementX = eventInit.movementX || 0;
+			this.movementY = eventInit.movementY || 0;
 			this.region = eventInit.region || '';
 			this.relatedTarget = eventInit.relatedTarget || null;
 			this.screenX = eventInit.screenX !== undefined ? eventInit.screenX : 0;


### PR DESCRIPTION
movementX and movementY values provide mouse movements basically. I was trying to test a panning method and noticed that this is not working.