### PR TITLE
#999@patch: Adds support for URLs in attributes that doesn't use apos…

### DIFF
--- a/packages/happy-dom/src/xml-parser/XMLParser.ts
+++ b/packages/happy-dom/src/xml-parser/XMLParser.ts
@@ -40,7 +40,7 @@ const MARKUP_REGEXP =
  * Group 9: Attribute name when the attribute has no value (e.g. "disabled" in "<div disabled>").
  */
 const ATTRIBUTE_REGEXP =
-	/\s*([a-zA-Z0-9-_:.$@?]+) *= *([a-zA-Z0-9-_:.$@?{}]+)|\s*([a-zA-Z0-9-_:.$@?]+) *= *"([^"]*)("{0,1})|\s*([a-zA-Z0-9-_:.$@?]+) *= *'([^']*)('{0,1})|\s*([a-zA-Z0-9-_:.$@?]+)/gm;
+	/\s*([a-zA-Z0-9-_:.$@?]+) *= *([a-zA-Z0-9-_:.$@?{}/]+)|\s*([a-zA-Z0-9-_:.$@?]+) *= *"([^"]*)("{0,1})|\s*([a-zA-Z0-9-_:.$@?]+) *= *'([^']*)('{0,1})|\s*([a-zA-Z0-9-_:.$@?]+)/gm;
 
 enum MarkupReadStateEnum {
 	startOrEndTag = 'startOrEndTag',

--- a/packages/happy-dom/test/xml-parser/XMLParser.test.ts
+++ b/packages/happy-dom/test/xml-parser/XMLParser.test.ts
@@ -669,6 +669,14 @@ describe('XMLParser', () => {
 			);
 		});
 
+		it('Parses attributes with URL without apostrophs.', () => {
+			const root = XMLParser.parse(document, `<a href=http://www.github.com/path>Click me</a>`);
+
+			expect(new XMLSerializer().serializeToString(root)).toBe(
+				'<a href="http://www.github.com/path">Click me</a>'
+			);
+		});
+
 		it('Parses attributes with single apostrophs.', () => {
 			const root = XMLParser.parse(document, `<div key1='value1' key2='value2'>Test</div>`);
 


### PR DESCRIPTION
…trophs in XMLParser.