### PR TITLE
#1025@major: Replaced window.eval with window.happyDOM.evaluate.

### DIFF
--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -927,7 +927,7 @@ export default class Element extends Node implements IElement {
 			const attribute = this.getAttribute('on' + event.type);
 
 			if (attribute && !event._immediatePropagationStopped) {
-				this.ownerDocument.defaultView.eval(attribute);
+				this.ownerDocument.defaultView.happyDOM.evaluate(attribute);
 			}
 		}
 

--- a/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameUtility.ts
+++ b/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameUtility.ts
@@ -40,7 +40,7 @@ export default class HTMLIFrameUtility {
 
 				if (src.startsWith('javascript:')) {
 					element._contentWindow = contentWindow;
-					element._contentWindow.eval(src.replace('javascript:', ''));
+					element._contentWindow.happyDOM.evaluate(src.replace('javascript:', ''));
 					return;
 				}
 

--- a/packages/happy-dom/src/nodes/html-script-element/HTMLScriptElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-script-element/HTMLScriptElementUtility.ts
@@ -73,7 +73,7 @@ export default class HTMLScriptElementUtility {
 	 */
 	public static eval(element: HTMLScriptElement, code: string): void {
 		try {
-			element.ownerDocument.defaultView.eval(code);
+			element.ownerDocument.defaultView.happyDOM.evaluate(code);
 		} catch (error) {
 			element.ownerDocument.defaultView.console.error(error);
 			element.ownerDocument.defaultView.dispatchEvent(

--- a/packages/happy-dom/src/window/GlobalWindow.ts
+++ b/packages/happy-dom/src/window/GlobalWindow.ts
@@ -75,9 +75,7 @@ export default class GlobalWindow extends Window implements IWindow {
 	 * @param code Code.
 	 * @returns Result.
 	 */
-	public override eval(code: string): unknown {
-		return eval(code);
-	}
+	public eval: (code: string) => unknown = globalThis.eval;
 
 	/**
 	 * Setup of VM context.

--- a/packages/happy-dom/src/window/INodeJSGlobal.ts
+++ b/packages/happy-dom/src/window/INodeJSGlobal.ts
@@ -45,7 +45,6 @@ export default interface INodeJSGlobal {
 	decodeURIComponent: typeof decodeURIComponent;
 	encodeURI: typeof encodeURI;
 	encodeURIComponent: typeof encodeURIComponent;
-	eval: typeof eval;
 	global: typeof globalThis;
 	isFinite: typeof isFinite;
 	isNaN: typeof isNaN;

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -135,6 +135,7 @@ export default interface IWindow extends IEventTarget, INodeJSGlobal {
 		asyncTaskManager: AsyncTaskManager;
 		setWindowSize: (options: { width?: number; height?: number }) => void;
 		setURL: (url: string) => void;
+		evaluate: (code: string) => unknown;
 		settings: IHappyDOMSettings;
 
 		/**
@@ -293,14 +294,6 @@ export default interface IWindow extends IEventTarget, INodeJSGlobal {
 	readonly pageYOffset: number;
 	readonly scrollX: number;
 	readonly scrollY: number;
-
-	/**
-	 * Evaluates code.
-	 *
-	 * @param code Code.
-	 * @returns Result.
-	 */
-	eval(code: string): unknown;
 
 	/**
 	 * Returns an object containing the values of all CSS properties of an element.

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -179,6 +179,12 @@ export default class Window extends EventTarget implements IWindow {
 				this.dispatchEvent(new Event('resize'));
 			}
 		},
+		evaluate: (code: string): unknown => {
+			if (VM.isContext(this)) {
+				return VM.runInContext(code, this);
+			}
+			return eval(code);
+		},
 		settings: {
 			disableJavaScriptEvaluation: false,
 			disableJavaScriptFileLoading: false,
@@ -620,20 +626,6 @@ export default class Window extends EventTarget implements IWindow {
 	 */
 	public get CSS(): CSS {
 		return new CSS();
-	}
-
-	/**
-	 * Evaluates code.
-	 *
-	 * @override
-	 * @param code Code.
-	 * @returns Result.
-	 */
-	public eval(code: string): unknown {
-		if (VM.isContext(this)) {
-			return VM.runInContext(code, this);
-		}
-		return eval(code);
 	}
 
 	/**

--- a/packages/happy-dom/test/window/GlobalWindow.test.ts
+++ b/packages/happy-dom/test/window/GlobalWindow.test.ts
@@ -44,4 +44,34 @@ describe('GlobalWindow', () => {
 			delete global['globalWindow'];
 		});
 	});
+
+	describe('eval', () => {
+		it('Respects direct eval.', () => {
+			global['globalWindow'] = window;
+			const result = window.eval(`
+			global.variable = 'globally defined';
+			(function () {
+				var variable = 'locally defined';
+				return eval('variable');
+			})()`);
+			expect(result).toBe('locally defined');
+			expect(global['variable']).toBe('globally defined');
+			delete global['globalWindow'];
+			delete global['variable'];
+		});
+
+		it('Respects indirect eval.', () => {
+			global['globalWindow'] = window;
+			const result = window.eval(`
+			global.variable = 'globally defined';
+			(function () {
+				var variable = 'locally defined';
+				return (0,eval)('variable');
+			})()`);
+			expect(result).toBe('globally defined');
+			expect(global['variable']).toBe('globally defined');
+			delete global['globalWindow'];
+			delete global['variable'];
+		});
+	});
 });

--- a/packages/happy-dom/test/window/Window.test.ts
+++ b/packages/happy-dom/test/window/Window.test.ts
@@ -331,8 +331,8 @@ describe('Window', () => {
 			expect({}.constructor).not.toBe(window.Object);
 		});
 
-		it('Is the same as {}.constructor when using eval().', () => {
-			expect(window.eval('({}).constructor === window.Object')).toBe(true);
+		it('Is the same as {}.constructor when using evaluate().', () => {
+			expect(window.happyDOM.evaluate('({}).constructor === window.Object')).toBe(true);
 		});
 	});
 
@@ -342,8 +342,8 @@ describe('Window', () => {
 			expect((() => {}).constructor).not.toBe(window.Function);
 		});
 
-		it('Is the same as (() => {}).constructor when using eval().', () => {
-			expect(window.eval('(() => {}).constructor === window.Function')).toBe(true);
+		it('Is the same as (() => {}).constructor when using evaluate().', () => {
+			expect(window.happyDOM.evaluate('(() => {}).constructor === window.Function')).toBe(true);
 		});
 	});
 
@@ -353,8 +353,8 @@ describe('Window', () => {
 			expect([].constructor).not.toBe(window.Array);
 		});
 
-		it('Is the same as [].constructor when using eval().', () => {
-			expect(window.eval('[].constructor === window.Array')).toBe(true);
+		it('Is the same as [].constructor when using evaluate().', () => {
+			expect(window.happyDOM.evaluate('[].constructor === window.Array')).toBe(true);
 		});
 	});
 
@@ -732,15 +732,37 @@ describe('Window', () => {
 		}
 	});
 
-	describe('eval()', () => {
+	describe('evaluate()', () => {
 		it('Evaluates code and returns the result.', () => {
-			const result = <() => number>window.eval('() => 5');
+			const result = <() => number>window.happyDOM.evaluate('() => 5');
 			expect(result()).toBe(5);
 		});
 
 		it('Captures errors and triggers an error event.', () => {
-			const result = <() => number>window.eval('() => 5');
+			const result = <() => number>window.happyDOM.evaluate('() => 5');
 			expect(result()).toBe(5);
+		});
+
+		it('Respects direct eval.', () => {
+			const result = <string>window.happyDOM.evaluate(`
+			variable = 'globally defined';
+			(function () {
+				var variable = 'locally defined';
+				return eval('variable');
+			})()`);
+			expect(result).toBe('locally defined');
+			expect(window['variable']).toBe('globally defined');
+		});
+
+		it('Respects indirect eval.', () => {
+			const result = <string>window.happyDOM.evaluate(`
+			variable = 'globally defined';
+			(function () {
+				var variable = 'locally defined';
+				return (0,eval)('variable');
+			})()`);
+			expect(result).toBe('globally defined');
+			expect(window['variable']).toBe('globally defined');
 		});
 	});
 


### PR DESCRIPTION
The existing `window.eval` is overloaded - it handles calls from inside and from outside the VM. This breaks the "direct" eval call:

```
it('Respects direct eval.', () => {
	const result = <string>window.eval(`(function test () {
		window.variable = 'globally defined';
		var variable = 'locally defined';
		return eval('variable');
	})()`);
	expect(result).toBe('locally defined');
});
```

This test returns `expected 'globally defined' to be 'locally defined'`.

In this PR, `window.eval` is left untouched, to only handle calls from inside the VM. For calls originating outside the VM, there is now `window.happyDOM.evaluate`. The naming is better to show that it is not the native `eval`.

This is a breaking change, of course.