### PR TITLE
#1036@patch: Adds a check for if the selector text for a CSSStyleRule…

### DIFF
--- a/packages/happy-dom/test/css/CSSParser.test.ts
+++ b/packages/happy-dom/test/css/CSSParser.test.ts
@@ -15,7 +15,7 @@ describe('CSSParser', () => {
 			const cssStyleSheet = new CSSStyleSheet();
 			const cssRules = CSSParser.parseFromString(cssStyleSheet, CSSParserInput);
 
-			expect(cssRules.length).toBe(10);
+			expect(cssRules.length).toBe(11);
 
 			// CSSStyleRule
 			expect((<CSSStyleRule>cssRules[0]).parentRule).toBe(null);
@@ -208,6 +208,16 @@ describe('CSSParser', () => {
 			expect((<CSSStyleRule>cssRules[9]).style.parentRule).toBe(cssRules[9]);
 			expect((<CSSStyleRule>cssRules[9]).style.length).toBe(1);
 			expect((<CSSStyleRule>cssRules[9]).style.cssText).toBe('color: red;');
+
+			expect((<CSSStyleRule>cssRules[10]).parentRule).toBe(null);
+			expect((<CSSStyleRule>cssRules[10]).parentStyleSheet).toBe(cssStyleSheet);
+			expect((<CSSStyleRule>cssRules[10]).selectorText).toBe('.validAsThereIsNoSemicolon');
+			expect((<CSSStyleRule>cssRules[10]).cssText).toBe(
+				'.validAsThereIsNoSemicolon { color: pink; }'
+			);
+			expect((<CSSStyleRule>cssRules[10]).style.parentRule).toBe(cssRules[10]);
+			expect((<CSSStyleRule>cssRules[10]).style.length).toBe(1);
+			expect((<CSSStyleRule>cssRules[10]).style.cssText).toBe('color: pink;');
 		});
 	});
 });

--- a/packages/happy-dom/test/css/data/CSSParserInput.ts
+++ b/packages/happy-dom/test/css/data/CSSParserInput.ts
@@ -79,4 +79,13 @@ export default `
     /* Single-line comment */
     .foo { color: red; }
 
+    ;
+
+	.invalidAsThereIsASemicolon {
+		color: red;
+	}
+
+    .validAsThereIsNoSemicolon {
+        color: pink;
+    }
 `.trim();


### PR DESCRIPTION
… is valid when parsing a Stylesheet. Invalid selectors will be ignored (this is also how the spec is defined).