### PR TITLE
#652@patch: Allow deletion of nonexistent keys from dataset

### DIFF
--- a/packages/happy-dom/src/nodes/element/Dataset.ts
+++ b/packages/happy-dom/src/nodes/element/Dataset.ts
@@ -46,10 +46,10 @@ export default class Dataset {
 				return true;
 			},
 			deleteProperty(dataset: DatasetRecord, key: string): boolean {
-				return (
-					!!element.attributes.removeNamedItem('data-' + Dataset.camelCaseToKebab(key)) &&
-					delete dataset[key]
-				);
+				if (element.attributes.removeNamedItem('data-' + Dataset.camelCaseToKebab(key))) {
+					return delete dataset[key];
+				}
+				return true;
 			},
 			ownKeys(dataset: DatasetRecord): string[] {
 				// According to Mozilla we have to update the dataset object (target) to contain the same keys as what we return:

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -300,6 +300,8 @@ describe('HTMLElement', () => {
 			expect(element.getAttribute('data-test-delta')).toBe(null);
 			expect(Object.keys(dataset)).toEqual(['testAlpha', 'testBeta', 'testGamma']);
 			expect(Object.values(dataset)).toEqual(['value2', 'value4', 'value5']);
+
+			delete dataset.nonExistentKey;
 		});
 
 		// https://github.com/capricorn86/happy-dom/issues/493


### PR DESCRIPTION
Fixes #652. This matches the behavior in the browser.