### PR TITLE
Add window.crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			],
 			"devDependencies": {
 				"@types/he": "^1.1.2",
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"chalk": "^4.1.0",
@@ -1969,9 +1969,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "15.14.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-			"integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+			"version": "16.18.50",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
+			"integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw=="
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "2.6.2",
@@ -11355,7 +11355,7 @@
 				"happy-dom": "0.0.0"
 			},
 			"devDependencies": {
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"eslint": "^8.11.0",
@@ -11385,7 +11385,7 @@
 			},
 			"devDependencies": {
 				"@types/css.escape": "^1.5.0",
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@types/node-fetch": "^2.6.1",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
@@ -11412,7 +11412,7 @@
 				"happy-dom": "^0.0.0"
 			},
 			"devDependencies": {
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"eslint": "^8.11.0",
@@ -11449,7 +11449,7 @@
 				"@testing-library/react": "^12.1.2",
 				"@testing-library/user-event": "^14.4.3",
 				"@types/jest": "29.5.2",
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@types/react": "^17.0.2",
 				"@types/react-dom": "^17.0.2",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
@@ -11486,7 +11486,7 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"eslint": "^8.11.0",
@@ -12216,7 +12216,7 @@
 		"@happy-dom/global-registrator": {
 			"version": "file:packages/global-registrator",
 			"requires": {
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"eslint": "^8.11.0",
@@ -12237,7 +12237,7 @@
 		"@happy-dom/integration-test": {
 			"version": "file:packages/integration-test",
 			"requires": {
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"eslint": "^8.11.0",
@@ -12268,7 +12268,7 @@
 				"@testing-library/react": "^12.1.2",
 				"@testing-library/user-event": "^14.4.3",
 				"@types/jest": "29.5.2",
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@types/react": "^17.0.2",
 				"@types/react-dom": "^17.0.2",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
@@ -12306,7 +12306,7 @@
 		"@happy-dom/uncaught-exception-observer": {
 			"version": "file:packages/uncaught-exception-observer",
 			"requires": {
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
 				"eslint": "^8.11.0",
@@ -12828,7 +12828,8 @@
 			"version": "14.4.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
 			"integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@types/aria-query": {
 			"version": "5.0.1",
@@ -12998,9 +12999,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "15.14.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-			"integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+			"version": "16.18.50",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
+			"integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw=="
 		},
 		"@types/node-fetch": {
 			"version": "2.6.2",
@@ -13482,7 +13483,8 @@
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/@webref/css/-/css-6.6.2.tgz",
 			"integrity": "sha512-BtX/sMtWl6eJfspxTQfmINpSEP/BvwQz1OL1FEiPffRDRZVEP9s4Nf/pyf16o9j/1SEj1LmevUCHABzSsktDvQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"accepts": {
 			"version": "1.3.8",
@@ -13504,7 +13506,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "8.2.0",
@@ -14968,7 +14971,8 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.7",
@@ -15121,7 +15125,8 @@
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-turbo/-/eslint-plugin-turbo-0.0.7.tgz",
 			"integrity": "sha512-iajOH8eD4jha3duztGVBD1BEmvNrQBaA/y3HFHf91vMDRYRwH7BpHSDFtxydDpk5ghlhRxG299SFxz7D6z4MBQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -15920,7 +15925,7 @@
 			"version": "file:packages/happy-dom",
 			"requires": {
 				"@types/css.escape": "^1.5.0",
-				"@types/node": "^15.6.0",
+				"@types/node": "^16.11.7",
 				"@types/node-fetch": "^2.6.1",
 				"@typescript-eslint/eslint-plugin": "^5.16.0",
 				"@typescript-eslint/parser": "^5.16.0",
@@ -17051,7 +17056,8 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
 			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "29.4.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@types/he": "^1.1.2",
-		"@types/node": "^15.6.0",
+		"@types/node": "^16.11.7",
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",
 		"chalk": "^4.1.0",

--- a/packages/global-registrator/package.json
+++ b/packages/global-registrator/package.json
@@ -79,7 +79,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",
-		"@types/node": "^15.6.0",
+		"@types/node": "^16.11.7",
 		"eslint": "^8.11.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.0.0",

--- a/packages/global-registrator/test/tsconfig.json
+++ b/packages/global-registrator/test/tsconfig.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"outDir": "../tmp",
 		"rootDir": "../test",
-		"tsBuildInfoFile": "../tmp/.tsbuildinfo-test",
 		"jsx": "react",
         "module": "CommonJS",
 		"lib": [

--- a/packages/happy-dom/package.json
+++ b/packages/happy-dom/package.json
@@ -85,7 +85,7 @@
 	},
 	"devDependencies": {
 		"@types/css.escape": "^1.5.0",
-		"@types/node": "^15.6.0",
+		"@types/node": "^16.11.7",
 		"@types/node-fetch": "^2.6.1",
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",

--- a/packages/happy-dom/src/console/VirtualConsole.ts
+++ b/packages/happy-dom/src/console/VirtualConsole.ts
@@ -3,6 +3,7 @@ import VirtualConsoleLogLevelEnum from './enums/VirtualConsoleLogLevelEnum.js';
 import VirtualConsoleLogTypeEnum from './enums/VirtualConsoleLogTypeEnum.js';
 import IVirtualConsoleLogGroup from './types/IVirtualConsoleLogGroup.js';
 import * as PerfHooks from 'perf_hooks';
+import { ConsoleConstructor } from 'console';
 
 /**
  * Virtual Console.
@@ -12,7 +13,7 @@ import * as PerfHooks from 'perf_hooks';
 export default class VirtualConsole implements Console {
 	// This is needed as the interface for the NodeJS Console also have a reference to the ConsoleConstructor class as a property for some reason.
 	// This is not part of the browser specs.
-	public Console: NodeJS.ConsoleConstructor;
+	public Console: ConsoleConstructor;
 
 	private _printer: IVirtualConsolePrinter;
 	private _count: { [label: string]: number } = {};

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -114,6 +114,7 @@ import IHappyDOMSettings from './IHappyDOMSettings.js';
 import RequestInfo from '../fetch/types/IRequestInfo.js';
 import FileList from '../nodes/html-input-element/FileList.js';
 import Stream from 'stream';
+import { webcrypto } from 'crypto';
 import FormData from '../form-data/FormData.js';
 import AbortController from '../fetch/AbortController.js';
 import AbortSignal from '../fetch/AbortSignal.js';
@@ -295,6 +296,7 @@ export default interface IWindow extends IEventTarget, INodeJSGlobal {
 	readonly pageYOffset: number;
 	readonly scrollX: number;
 	readonly scrollY: number;
+	readonly crypto: typeof webcrypto;
 
 	/**
 	 * Returns an object containing the values of all CSS properties of an element.

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -114,6 +114,7 @@ import VMGlobalPropertyScript from './VMGlobalPropertyScript.js';
 import * as PerfHooks from 'perf_hooks';
 import VM from 'vm';
 import { Buffer } from 'buffer';
+import { webcrypto } from 'crypto';
 import XMLHttpRequestImplementation from '../xml-http-request/XMLHttpRequest.js';
 import XMLHttpRequestUpload from '../xml-http-request/XMLHttpRequestUpload.js';
 import XMLHttpRequestEventTarget from '../xml-http-request/XMLHttpRequestEventTarget.js';
@@ -364,6 +365,7 @@ export default class Window extends EventTarget implements IWindow {
 	public readonly innerHeight: number = 768;
 	public readonly outerWidth: number = 1024;
 	public readonly outerHeight: number = 768;
+	public readonly crypto = webcrypto;
 
 	// Node.js Globals
 	public Array: typeof Array;

--- a/packages/happy-dom/test/window/Window.test.ts
+++ b/packages/happy-dom/test/window/Window.test.ts
@@ -418,6 +418,18 @@ describe('Window', () => {
 		});
 	});
 
+	describe('get crypto()', () => {
+		it('Exposes "crypto" from the NodeJS crypto package.', () => {
+			const array = new Uint32Array(5);
+			window.crypto.getRandomValues(array);
+			expect(array[0]).toBeGreaterThan(0);
+			expect(array[1]).toBeGreaterThan(0);
+			expect(array[2]).toBeGreaterThan(0);
+			expect(array[3]).toBeGreaterThan(0);
+			expect(array[4]).toBeGreaterThan(0);
+		});
+	});
+
 	describe('get navigator()', () => {
 		it('Returns an instance of Navigator with browser data.', () => {
 			expect(window.navigator instanceof Navigator).toBe(true);

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -21,7 +21,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",
-		"@types/node": "^15.6.0",
+		"@types/node": "^16.11.7",
 		"eslint": "^8.11.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.0.0",

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",
-		"@types/node": "^15.6.0",
+		"@types/node": "^16.11.7",
 		"@types/react": "^17.0.2",
 		"@testing-library/react": "^12.1.2",
 		"@testing-library/user-event": "^14.4.3",

--- a/packages/uncaught-exception-observer/package.json
+++ b/packages/uncaught-exception-observer/package.json
@@ -80,7 +80,7 @@
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",
-		"@types/node": "^15.6.0",
+		"@types/node": "^16.11.7",
 		"eslint": "^8.11.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.0.0",

--- a/packages/uncaught-exception-observer/test/UncaughtExceptionObserver.test.ts
+++ b/packages/uncaught-exception-observer/test/UncaughtExceptionObserver.test.ts
@@ -1,4 +1,4 @@
-import { Window, ErrorEvent } from 'happy-dom';
+import { Window, ErrorEvent, IResponse } from 'happy-dom';
 import UncaughtExceptionObserver from '../lib/UncaughtExceptionObserver.js';
 
 async function itObservesUnhandledRejections(): Promise<void> {
@@ -12,7 +12,7 @@ async function itObservesUnhandledRejections(): Promise<void> {
 	window.addEventListener('error', (event) => (errorEvent = <ErrorEvent>event));
 
 	window.fetch = () => {
-		return new Promise((resolve) => setTimeout(resolve, 0));
+		return new Promise((resolve) => setTimeout(() => resolve(<IResponse>{}), 0));
 	};
 
 	document.write(`


### PR DESCRIPTION
Fixes https://github.com/capricorn86/happy-dom/issues/1050

- Update `@types/node`
  - The v15 was listed but the v16 is used in the CI (by the way, the v16 is OEL, see [Node versions support](https://github.com/nodejs/release#release-schedule), so it should be updated to v18 or to the v20, and same for the types)
  - Node v15 supports webcrypto but the types for Node v15 don't include it
  - Update import for `ConsoleConstructor` (not available anymore on the global `NodeJS` object, but has to be imported from `node:console`)
- Define as `window.crypto = require('crypto').webcrypto`