### PR TITLE
#1073@minor: Adds support for a new setting called disableErrorCaptur…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12828,7 +12828,8 @@
 			"version": "14.4.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
 			"integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@types/aria-query": {
 			"version": "5.0.1",
@@ -13482,7 +13483,8 @@
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/@webref/css/-/css-6.6.2.tgz",
 			"integrity": "sha512-BtX/sMtWl6eJfspxTQfmINpSEP/BvwQz1OL1FEiPffRDRZVEP9s4Nf/pyf16o9j/1SEj1LmevUCHABzSsktDvQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"accepts": {
 			"version": "1.3.8",
@@ -13504,7 +13506,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "8.2.0",
@@ -14968,7 +14971,8 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.7",
@@ -15121,7 +15125,8 @@
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-turbo/-/eslint-plugin-turbo-0.0.7.tgz",
 			"integrity": "sha512-iajOH8eD4jha3duztGVBD1BEmvNrQBaA/y3HFHf91vMDRYRwH7BpHSDFtxydDpk5ghlhRxG299SFxz7D6z4MBQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",
@@ -17051,7 +17056,8 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
 			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "29.4.3",

--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -140,8 +140,12 @@ export default abstract class EventTarget implements IEventTarget {
 
 			if (typeof this[onEventName] === 'function') {
 				// We can end up in a never ending loop if the listener for the error event on Window also throws an error.
-				if (window && (this !== <IEventTarget>window || event.type !== 'error')) {
-					WindowErrorUtility.captureErrorSync(window, this[onEventName].bind(this, event));
+				if (
+					window &&
+					(this !== <IEventTarget>window || event.type !== 'error') &&
+					!window.happyDOM.settings.disableErrorCapturing
+				) {
+					WindowErrorUtility.captureError(window, this[onEventName].bind(this, event));
 				} else {
 					this[onEventName].call(this, event);
 				}
@@ -169,14 +173,18 @@ export default abstract class EventTarget implements IEventTarget {
 				}
 
 				// We can end up in a never ending loop if the listener for the error event on Window also throws an error.
-				if (window && (this !== <IEventTarget>window || event.type !== 'error')) {
+				if (
+					window &&
+					(this !== <IEventTarget>window || event.type !== 'error') &&
+					!window.happyDOM.settings.disableErrorCapturing
+				) {
 					if ((<IEventListener>listener).handleEvent) {
-						WindowErrorUtility.captureErrorSync(
+						WindowErrorUtility.captureError(
 							window,
 							(<IEventListener>listener).handleEvent.bind(this, event)
 						);
 					} else {
-						WindowErrorUtility.captureErrorSync(
+						WindowErrorUtility.captureError(
 							window,
 							(<(event: Event) => void>listener).bind(this, event)
 						);

--- a/packages/happy-dom/src/nodes/html-script-element/HTMLScriptElement.ts
+++ b/packages/happy-dom/src/nodes/html-script-element/HTMLScriptElement.ts
@@ -189,9 +189,13 @@ export default class HTMLScriptElement extends HTMLElement implements IHTMLScrip
 						type === 'application/x-javascript' ||
 						type.startsWith('text/javascript'))
 				) {
-					WindowErrorUtility.captureErrorSync(this.ownerDocument.defaultView, () =>
-						this.ownerDocument.defaultView.eval(textContent)
-					);
+					if (this.ownerDocument.defaultView.happyDOM.settings.disableErrorCapturing) {
+						this.ownerDocument.defaultView.eval(textContent);
+					} else {
+						WindowErrorUtility.captureError(this.ownerDocument.defaultView, () =>
+							this.ownerDocument.defaultView.eval(textContent)
+						);
+					}
 				}
 			}
 		}

--- a/packages/happy-dom/src/window/IHappyDOMOptions.ts
+++ b/packages/happy-dom/src/window/IHappyDOMOptions.ts
@@ -12,6 +12,7 @@ export default interface IHappyDOMOptions {
 		disableCSSFileLoading?: boolean;
 		disableIframePageLoading?: boolean;
 		disableComputedStyleRendering?: boolean;
+		disableErrorCapturing?: boolean;
 		enableFileSystemHttpRequests?: boolean;
 		navigator?: {
 			userAgent?: string;

--- a/packages/happy-dom/src/window/IHappyDOMSettings.ts
+++ b/packages/happy-dom/src/window/IHappyDOMSettings.ts
@@ -7,6 +7,7 @@ export default interface IHappyDOMSettings {
 	disableCSSFileLoading: boolean;
 	disableIframePageLoading: boolean;
 	disableComputedStyleRendering: boolean;
+	disableErrorCapturing: boolean;
 	enableFileSystemHttpRequests: boolean;
 	navigator: {
 		userAgent: string;

--- a/packages/happy-dom/src/window/WindowErrorUtility.ts
+++ b/packages/happy-dom/src/window/WindowErrorUtility.ts
@@ -7,32 +7,6 @@ import { IElement } from '../index.js';
  */
 export default class WindowErrorUtility {
 	/**
-	 * Calls a function asynchronously wrapped in a try/catch block to capture errors and dispatch error events.
-	 *
-	 * It will also output the errors to the console.
-	 *
-	 * @param elementOrWindow Element or Window.
-	 * @param callback Callback.
-	 * @param [cleanup] Cleanup callback on error.
-	 * @returns Promise.
-	 */
-	public static async captureErrorAsync<T>(
-		elementOrWindow: IWindow | IElement,
-		callback: () => Promise<T>,
-		cleanup?: () => void
-	): Promise<T | null> {
-		try {
-			return await callback();
-		} catch (error) {
-			this.dispatchError(elementOrWindow, error);
-			if (cleanup) {
-				cleanup();
-			}
-		}
-		return null;
-	}
-
-	/**
 	 * Calls a function synchronously wrapped in a try/catch block to capture errors and dispatch error events.
 	 * If the callback returns a Promise, it will catch errors from the promise.
 	 *
@@ -43,7 +17,7 @@ export default class WindowErrorUtility {
 	 * @param [cleanup] Cleanup callback on error.
 	 * @returns Result.
 	 */
-	public static captureErrorSync<T>(
+	public static captureError<T>(
 		elementOrWindow: IWindow | IElement,
 		callback: () => T,
 		cleanup?: () => void

--- a/packages/happy-dom/test/nodes/html-script-element/HTMLScriptElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-script-element/HTMLScriptElement.test.ts
@@ -485,5 +485,17 @@ describe('HTMLScriptElement', () => {
 				true
 			);
 		});
+
+		it('Throws an exception when appending an element that contains invalid Javascript and Window.happyDOM.settings.disableErrorCapturing is set to true.', () => {
+			const element = <IHTMLScriptElement>document.createElement('script');
+
+			window.happyDOM.settings.disableErrorCapturing = true;
+
+			element.text = 'globalThis.test = /;';
+
+			expect(() => {
+				document.body.appendChild(element);
+			}).toThrow(new TypeError('Invalid regular expression: missing /'));
+		});
 	});
 });

--- a/packages/happy-dom/test/window/Window.test.ts
+++ b/packages/happy-dom/test/window/Window.test.ts
@@ -132,6 +132,7 @@ describe('Window', () => {
 			expect(windowWithOptions.happyDOM.settings.disableJavaScriptFileLoading).toBe(false);
 			expect(windowWithOptions.happyDOM.settings.disableCSSFileLoading).toBe(false);
 			expect(windowWithOptions.happyDOM.settings.disableIframePageLoading).toBe(false);
+			expect(windowWithOptions.happyDOM.settings.disableErrorCapturing).toBe(false);
 			expect(windowWithOptions.happyDOM.settings.enableFileSystemHttpRequests).toBe(false);
 			expect(windowWithOptions.happyDOM.settings.navigator.userAgent).toBe('test');
 			expect(windowWithOptions.happyDOM.settings.device.prefersColorScheme).toBe('dark');
@@ -150,6 +151,7 @@ describe('Window', () => {
 			expect(windowWithoutOptions.happyDOM.settings.disableJavaScriptFileLoading).toBe(false);
 			expect(windowWithoutOptions.happyDOM.settings.disableCSSFileLoading).toBe(false);
 			expect(windowWithoutOptions.happyDOM.settings.disableIframePageLoading).toBe(false);
+			expect(windowWithoutOptions.happyDOM.settings.disableErrorCapturing).toBe(false);
 			expect(windowWithoutOptions.happyDOM.settings.enableFileSystemHttpRequests).toBe(false);
 			expect(windowWithoutOptions.happyDOM.settings.navigator.userAgent).toBe(
 				`Mozilla/5.0 (${GET_NAVIGATOR_PLATFORM()}) AppleWebKit/537.36 (KHTML, like Gecko) HappyDOM/${
@@ -818,11 +820,6 @@ describe('Window', () => {
 
 	describe('eval()', () => {
 		it('Evaluates code and returns the result.', () => {
-			const result = <() => number>window.eval('() => 5');
-			expect(result()).toBe(5);
-		});
-
-		it('Captures errors and triggers an error event.', () => {
 			const result = <() => number>window.eval('() => 5');
 			expect(result()).toBe(5);
 		});

--- a/packages/uncaught-exception-observer/src/UncaughtExceptionObserver.ts
+++ b/packages/uncaught-exception-observer/src/UncaughtExceptionObserver.ts
@@ -27,14 +27,17 @@ export default class UncaughtExceptionObserver {
 		(<typeof UncaughtExceptionObserver>this.constructor).listenerCount++;
 
 		this.uncaughtExceptionListener = (
-			error: Error,
+			error: unknown,
 			origin: 'uncaughtException' | 'unhandledRejection'
 		) => {
 			if (origin === 'unhandledRejection') {
 				return;
 			}
 
-			if (error instanceof this.window.Error && error.stack?.includes('/happy-dom/')) {
+			if (
+				(error instanceof this.window.Error || error instanceof this.window.DOMException) &&
+				error.stack?.includes('/happy-dom/')
+			) {
 				this.window.console.error(error);
 				this.window.dispatchEvent(
 					new this.window.ErrorEvent('error', { error, message: error.message })
@@ -52,8 +55,11 @@ export default class UncaughtExceptionObserver {
 
 		// The "uncaughtException" event is not always triggered for unhandled rejections.
 		// Therefore we want to use the "unhandledRejection" event as well.
-		this.uncaughtRejectionListener = (error: Error) => {
-			if (error instanceof this.window.Error && error.stack?.includes('/happy-dom/')) {
+		this.uncaughtRejectionListener = (error: unknown) => {
+			if (
+				(error instanceof this.window.Error || error instanceof this.window.DOMException) &&
+				error.stack?.includes('/happy-dom/')
+			) {
 				this.window.console.error(error);
 				this.window.dispatchEvent(
 					new this.window.ErrorEvent('error', { error, message: error.message })


### PR DESCRIPTION
…ing. Happy DOM will by default try to catch errors in functionality such as scripts, timers and event listeners. This setting makes it possible it possible to disable this behaviour.