### PR TITLE
#1087@patch: Makes sure that HTMLUnknownElement is disconnected from …

### DIFF
--- a/packages/happy-dom/src/nodes/html-unknown-element/HTMLUnknownElement.ts
+++ b/packages/happy-dom/src/nodes/html-unknown-element/HTMLUnknownElement.ts
@@ -78,6 +78,8 @@ export default class HTMLUnknownElement extends HTMLElement implements IHTMLElem
 						if (newElement.isConnected && newElement.connectedCallback) {
 							newElement.connectedCallback();
 						}
+
+						this._connectToNode(null);
 					}
 				};
 				callbacks[tagName] = callbacks[tagName] || [];

--- a/turbo.json
+++ b/turbo.json
@@ -12,18 +12,28 @@
 		"jest-environment#compile": {
 			"dependsOn": ["happy-dom#compile"]
 		},
+		"integration-test#compile": {
+			"dependsOn": ["happy-dom#compile"]
+		},
+		"uncaught-exception-observer#compile": {
+			"dependsOn": ["happy-dom#compile"]
+		},
 		"happy-dom#test": {
 			"outputs": ["node_modules/vitest/**"]
 		},
 		"global-registrator#test": {
-			"dependsOn": ["happy-dom#compile"],
+			"dependsOn": ["happy-dom#compile", "global-registrator#compile"],
 			"outputs": ["tmp/**"]
 		},
 		"jest-environment#test": {
-			"dependsOn": ["happy-dom#compile"]
+			"dependsOn": ["happy-dom#compile", "jest-environment#compile"]
 		},
 		"integration-test#test": {
-			"dependsOn": ["happy-dom#compile"]
+			"dependsOn": ["happy-dom#compile", "integration-test#compile"]
+		},
+		"uncaught-exception-observer#test": {
+			"dependsOn": ["happy-dom#compile", "uncaught-exception-observer#compile"],
+			"outputs": ["tmp/**"]
 		},
 		"lint": {
 			"outputs": []


### PR DESCRIPTION
…its parent when replaces by a custom element.