### PR TITLE
#1097@patch: Implements Symbol.toStringTag on EventTarget and AbortSignal.

### DIFF
--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -20,6 +20,13 @@ export default abstract class EventTarget implements IEventTarget {
 	} = {};
 
 	/**
+	 * Return a default description for the EventTarget class.
+	 */
+	public get [Symbol.toStringTag](): string {
+		return 'EventTarget';
+	}
+
+	/**
 	 * Adds an event listener.
 	 *
 	 * @param type Event type.

--- a/packages/happy-dom/src/event/IEventTarget.ts
+++ b/packages/happy-dom/src/event/IEventTarget.ts
@@ -7,6 +7,11 @@ import IEventListenerOptions from './IEventListenerOptions.js';
  */
 export default interface IEventTarget {
 	/**
+	 * Return a default description for the EventTarget class.
+	 */
+	[Symbol.toStringTag]: string;
+
+	/**
 	 * Adds an event listener.
 	 *
 	 * @param type Event type.

--- a/packages/happy-dom/src/fetch/AbortSignal.ts
+++ b/packages/happy-dom/src/fetch/AbortSignal.ts
@@ -12,6 +12,13 @@ export default class AbortSignal extends EventTarget {
 	public onabort: ((this: AbortSignal, event: Event) => void) | null = null;
 
 	/**
+	 * Return a default description for the AbortSignal class.
+	 */
+	public get [Symbol.toStringTag](): string {
+		return 'AbortSignal';
+	}
+
+	/**
 	 * Aborts the signal.
 	 *
 	 * @param [reason] Reason.

--- a/packages/happy-dom/test/event/EventTarget.test.ts
+++ b/packages/happy-dom/test/event/EventTarget.test.ts
@@ -189,7 +189,7 @@ describe('EventTarget', () => {
 		});
 	});
 
-	describe('toString()', () => {
+	describe('[Symbol.toStringTag]', () => {
 		it('Returns EventTarget string.', () => {
 			const description = 'EventTarget';
 

--- a/packages/happy-dom/test/event/EventTarget.test.ts
+++ b/packages/happy-dom/test/event/EventTarget.test.ts
@@ -188,4 +188,12 @@ describe('EventTarget', () => {
 			expect(recievedEvent).toBe(null);
 		});
 	});
+
+	describe('toString()', () => {
+		it('Returns EventTarget string.', () => {
+			const description = 'EventTarget';
+
+			expect(eventTarget[Symbol.toStringTag]).toBe(description);
+		});
+	});
 });

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -28,4 +28,13 @@ describe('AbortSignal', () => {
 			expect(signal.reason).toBe(reason);
 		});
 	});
+
+	describe('AbortSignal.toString()', () => {
+		it('Returns AbortSignal string.', () => {
+			const description = 'AbortSignal';
+			const signal = new AbortSignal();
+
+			expect(signal[Symbol.toStringTag]).toBe(description);
+		});
+	});
 });

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -29,7 +29,7 @@ describe('AbortSignal', () => {
 		});
 	});
 
-	describe('AbortSignal.toString()', () => {
+	describe('AbortSignal[Symbol.toStringTag]', () => {
 		it('Returns AbortSignal string.', () => {
 			const description = 'AbortSignal';
 			const signal = new AbortSignal();


### PR DESCRIPTION
Fixes #1097 