### PR TITLE
#1140@patch: Fix Node 18.18.2+ support in global-registrator.

### DIFF
--- a/packages/global-registrator/src/GlobalRegistrator.ts
+++ b/packages/global-registrator/src/GlobalRegistrator.ts
@@ -25,7 +25,11 @@ export default class GlobalRegistrator {
 			if (global[key] !== window[key] && !IGNORE_LIST.includes(key)) {
 				this.registered[key] =
 					global[key] !== window[key] && global[key] !== undefined ? global[key] : null;
-				global[key] = typeof window[key] === 'function' ? window[key].bind(global) : window[key];
+
+				// Only bind functions that aren't used as classes, since bound functions can't be extended.
+				const bind = typeof window[key] === 'function' && !isClassLikeName(key);
+
+				global[key] = bind ? window[key].bind(global) : window[key];
 			}
 		}
 
@@ -55,4 +59,8 @@ export default class GlobalRegistrator {
 
 		this.registered = null;
 	}
+}
+
+function isClassLikeName(name: string): boolean {
+	return name[0] === name[0].toUpperCase();
 }


### PR DESCRIPTION
I'm far from an expert in this area, but it seems to do the trick. Inspired by the approach used by vitest to populate the globals: https://github.com/vitest-dev/vitest/blob/ffaf16b489cdaa39ef5cafba11a3f8139c184d35/packages/vitest/src/integrations/env/utils.ts#L44.

No test because tests are already broken on Node 18, and this will fix them (for this package).

Fixes #1140 