### PR TITLE
#1148@patch: Element.cloneNode() should not set scroll properties on …

### DIFF
--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -379,10 +379,6 @@ export default class Element extends Node implements IElement {
 		}
 
 		(<string>clone.tagName) = this.tagName;
-		clone.scrollLeft = this.scrollLeft;
-		clone.scrollTop = this.scrollTop;
-		clone.scrollWidth = this.scrollWidth;
-		clone.scrollHeight = this.scrollHeight;
 		(<string>clone.namespaceURI) = this.namespaceURI;
 
 		return <IElement>clone;

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -1551,8 +1551,6 @@ describe('Element', () => {
 			child.className = 'className';
 
 			(<string>element.tagName) = 'tagName';
-			(<number>element.scrollLeft) = 10;
-			(<number>element.scrollTop) = 10;
 
 			// @ts-ignore
 			element.namespaceURI = 'namespaceURI';
@@ -1562,8 +1560,6 @@ describe('Element', () => {
 			const clone = element.cloneNode(false);
 			const clone2 = element.cloneNode(true);
 			expect(clone.tagName).toBe('tagName');
-			expect(clone.scrollLeft).toBe(10);
-			expect(clone.scrollTop).toBe(10);
 			expect(clone.namespaceURI).toBe('namespaceURI');
 			expect(clone.children.length).toEqual(0);
 			expect(clone2.children.length).toBe(1);


### PR DESCRIPTION
…the clone.