### PR TITLE
reduce node specific dependencies

### DIFF
--- a/packages/happy-dom/src/console/VirtualConsole.ts
+++ b/packages/happy-dom/src/console/VirtualConsole.ts
@@ -2,7 +2,6 @@ import IVirtualConsolePrinter from './types/IVirtualConsolePrinter.js';
 import VirtualConsoleLogLevelEnum from './enums/VirtualConsoleLogLevelEnum.js';
 import VirtualConsoleLogTypeEnum from './enums/VirtualConsoleLogTypeEnum.js';
 import IVirtualConsoleLogGroup from './types/IVirtualConsoleLogGroup.js';
-import * as PerfHooks from 'perf_hooks';
 import { ConsoleConstructor } from 'console';
 
 /**
@@ -276,7 +275,7 @@ export default class VirtualConsole implements Console {
 	 * @param [label=default] Label.
 	 */
 	public time(label = 'default'): void {
-		this._time[label] = PerfHooks.performance.now();
+		this._time[label] = performance.now();
 	}
 
 	/**
@@ -288,7 +287,7 @@ export default class VirtualConsole implements Console {
 	public timeEnd(label = 'default'): void {
 		const time = this._time[label];
 		if (time) {
-			const duration = PerfHooks.performance.now() - time;
+			const duration = performance.now() - time;
 			this._printer.print({
 				type: VirtualConsoleLogTypeEnum.timeEnd,
 				level: VirtualConsoleLogLevelEnum.info,
@@ -308,7 +307,7 @@ export default class VirtualConsole implements Console {
 	public timeLog(label = 'default', ...args: Array<object | string>): void {
 		const time = this._time[label];
 		if (time) {
-			const duration = PerfHooks.performance.now() - time;
+			const duration = performance.now() - time;
 			this._printer.print({
 				type: VirtualConsoleLogTypeEnum.timeLog,
 				level: VirtualConsoleLogLevelEnum.info,

--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -4,7 +4,6 @@ import IWindow from '../window/IWindow.js';
 import IShadowRoot from '../nodes/shadow-root/IShadowRoot.js';
 import IEventTarget from './IEventTarget.js';
 import NodeTypeEnum from '../nodes/node/NodeTypeEnum.js';
-import { performance } from 'perf_hooks';
 import EventPhaseEnum from './EventPhaseEnum.js';
 import IDocument from '../nodes/document/IDocument.js';
 

--- a/packages/happy-dom/src/fetch/Request.ts
+++ b/packages/happy-dom/src/fetch/Request.ts
@@ -11,7 +11,6 @@ import FetchBodyUtility from './utilities/FetchBodyUtility.js';
 import AbortSignal from './AbortSignal.js';
 import Stream from 'stream';
 import Blob from '../file/Blob.js';
-import { TextDecoder } from 'util';
 import FetchRequestValidationUtility from './utilities/FetchRequestValidationUtility.js';
 import IRequestReferrerPolicy from './types/IRequestReferrerPolicy.js';
 import IRequestRedirect from './types/IRequestRedirect.js';

--- a/packages/happy-dom/src/fetch/Response.ts
+++ b/packages/happy-dom/src/fetch/Response.ts
@@ -13,7 +13,6 @@ import FormData from '../form-data/FormData.js';
 import FetchBodyUtility from './utilities/FetchBodyUtility.js';
 import DOMException from '../exception/DOMException.js';
 import DOMExceptionNameEnum from '../exception/DOMExceptionNameEnum.js';
-import { TextDecoder } from 'util';
 import MultipartFormDataParser from './multipart/MultipartFormDataParser.js';
 
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];

--- a/packages/happy-dom/src/fetch/utilities/FetchRequestReferrerUtility.ts
+++ b/packages/happy-dom/src/fetch/utilities/FetchRequestReferrerUtility.ts
@@ -1,7 +1,6 @@
 import URL from '../../url/URL.js';
 import IRequest from '../types/IRequest.js';
 import IDocument from '../../nodes/document/IDocument.js';
-import { isIP } from 'net';
 import Headers from '../Headers.js';
 import IRequestReferrerPolicy from '../types/IRequestReferrerPolicy.js';
 
@@ -207,13 +206,32 @@ export default class FetchRequestReferrerUtility {
 
 		// 4. If origin's host component matches one of the CIDR notations 127.0.0.0/8 or ::1/128 [RFC4632], return "Potentially Trustworthy".
 		const hostIp = url.host.replace(/(^\[)|(]$)/g, '');
-		const hostIPVersion = isIP(hostIp);
 
-		if (hostIPVersion === 4 && /^127\./.test(hostIp)) {
+		// IPv4 addr test pattern
+		const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
+		const v4Str = `(?:${v4Seg}\\.){3}${v4Seg}`;
+		const IPv4Reg = new RegExp(`^${v4Str}$`);
+
+		// IPv6 addr test pattern
+		const v6Seg = '(?:[0-9a-fA-F]{1,4})';
+		const IPv6Reg = new RegExp(
+			'^(?:' +
+				`(?:${v6Seg}:){7}(?:${v6Seg}|:)|` +
+				`(?:${v6Seg}:){6}(?:${v4Str}|:${v6Seg}|:)|` +
+				`(?:${v6Seg}:){5}(?::${v4Str}|(?::${v6Seg}){1,2}|:)|` +
+				`(?:${v6Seg}:){4}(?:(?::${v6Seg}){0,1}:${v4Str}|(?::${v6Seg}){1,3}|:)|` +
+				`(?:${v6Seg}:){3}(?:(?::${v6Seg}){0,2}:${v4Str}|(?::${v6Seg}){1,4}|:)|` +
+				`(?:${v6Seg}:){2}(?:(?::${v6Seg}){0,3}:${v4Str}|(?::${v6Seg}){1,5}|:)|` +
+				`(?:${v6Seg}:){1}(?:(?::${v6Seg}){0,4}:${v4Str}|(?::${v6Seg}){1,6}|:)|` +
+				`(?::(?:(?::${v6Seg}){0,5}:${v4Str}|(?::${v6Seg}){1,7}|:))` +
+				')(?:%[0-9a-zA-Z-.:]{1,})?$'
+		);
+
+		if (IPv4Reg.test(hostIp) && /^127\./.test(hostIp)) {
 			return true;
 		}
 
-		if (hostIPVersion === 6 && /^(((0+:){7})|(::(0+:){0,6}))0*1$/.test(hostIp)) {
+		if (IPv6Reg.test(hostIp) && /^(((0+:){7})|(::(0+:){0,6}))0*1$/.test(hostIp)) {
 			return true;
 		}
 

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -116,7 +116,6 @@ import IHappyDOMSettings from './IHappyDOMSettings.js';
 import RequestInfo from '../fetch/types/IRequestInfo.js';
 import FileList from '../nodes/html-input-element/FileList.js';
 import Stream from 'stream';
-import { webcrypto } from 'crypto';
 import FormData from '../form-data/FormData.js';
 import AbortController from '../fetch/AbortController.js';
 import AbortSignal from '../fetch/AbortSignal.js';
@@ -132,6 +131,13 @@ import PermissionStatus from '../permissions/PermissionStatus.js';
 import Clipboard from '../clipboard/Clipboard.js';
 import ClipboardItem from '../clipboard/ClipboardItem.js';
 import ClipboardEvent from '../event/events/ClipboardEvent.js';
+
+if (
+	!('crypto' in globalThis) ||
+	Object.getPrototypeOf(globalThis.crypto) === Object.getPrototypeOf({})
+) {
+	globalThis['crypto'] = import('crypto').then((c) => c.webcrypto);
+}
 
 /**
  * Browser window.
@@ -414,7 +420,7 @@ export default interface IWindow extends IEventTarget, INodeJSGlobal {
 	readonly pageYOffset: number;
 	readonly scrollX: number;
 	readonly scrollY: number;
-	readonly crypto: typeof webcrypto;
+	readonly crypto: typeof globalThis.crypto;
 
 	/**
 	 * Returns an object containing the values of all CSS properties of an element.

--- a/packages/happy-dom/src/window/IWindow.ts
+++ b/packages/happy-dom/src/window/IWindow.ts
@@ -132,12 +132,16 @@ import Clipboard from '../clipboard/Clipboard.js';
 import ClipboardItem from '../clipboard/ClipboardItem.js';
 import ClipboardEvent from '../event/events/ClipboardEvent.js';
 
-if (
-	!('crypto' in globalThis) ||
-	Object.getPrototypeOf(globalThis.crypto) === Object.getPrototypeOf({})
-) {
-	globalThis['crypto'] = import('crypto').then((c) => c.webcrypto);
+async function webcryptoImportFallback(): Promise<void> {
+	if (
+		!('crypto' in globalThis) ||
+		Object.getPrototypeOf(globalThis.crypto) === Object.getPrototypeOf({})
+	) {
+		// Import required only on node < 19
+		globalThis['crypto'] = (await import('crypto')).webcrypto;
+	}
 }
+webcryptoImportFallback();
 
 /**
  * Browser window.

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -225,7 +225,12 @@ export default class Window extends EventTarget implements IWindow {
 			enableFileSystemHttpRequests: false,
 			navigator: {
 				userAgent: `Mozilla/5.0 (X11; ${
-					process.platform.charAt(0).toUpperCase() + process.platform.slice(1) + ' ' + process.arch
+					process?.platform
+						? process.platform.charAt(0).toUpperCase() +
+						  process.platform.slice(1) +
+						  ' ' +
+						  process.arch
+						: 'Unknown'
 				}) AppleWebKit/537.36 (KHTML, like Gecko) HappyDOM/${PackageVersion.version}`
 			},
 			device: {

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -111,7 +111,6 @@ import Fetch from '../fetch/Fetch.js';
 import RangeImplementation from '../range/Range.js';
 import DOMRect from '../nodes/element/DOMRect.js';
 import VMGlobalPropertyScript from './VMGlobalPropertyScript.js';
-import * as PerfHooks from 'perf_hooks';
 import VM from 'vm';
 import { Buffer } from 'buffer';
 import XMLHttpRequestImplementation from '../xml-http-request/XMLHttpRequest.js';
@@ -489,7 +488,7 @@ export default class Window extends EventTarget implements IWindow {
 	public readonly devicePixelRatio = 1;
 	public readonly sessionStorage: Storage;
 	public readonly localStorage: Storage;
-	public readonly performance = PerfHooks.performance;
+	public readonly performance = performance;
 	public readonly innerWidth: number = 1024;
 	public readonly innerHeight: number = 768;
 	public readonly outerWidth: number = 1024;

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -114,7 +114,6 @@ import VMGlobalPropertyScript from './VMGlobalPropertyScript.js';
 import * as PerfHooks from 'perf_hooks';
 import VM from 'vm';
 import { Buffer } from 'buffer';
-import { webcrypto } from 'crypto';
 import XMLHttpRequestImplementation from '../xml-http-request/XMLHttpRequest.js';
 import XMLHttpRequestUpload from '../xml-http-request/XMLHttpRequestUpload.js';
 import XMLHttpRequestEventTarget from '../xml-http-request/XMLHttpRequestEventTarget.js';
@@ -146,6 +145,13 @@ import PermissionStatus from '../permissions/PermissionStatus.js';
 import Clipboard from '../clipboard/Clipboard.js';
 import ClipboardItem from '../clipboard/ClipboardItem.js';
 import ClipboardEvent from '../event/events/ClipboardEvent.js';
+
+if (
+	!('crypto' in globalThis) ||
+	Object.getPrototypeOf(globalThis.crypto) === Object.getPrototypeOf({})
+) {
+	globalThis['crypto'] = import('crypto').then((c) => c.webcrypto);
+}
 
 const ORIGINAL_SET_TIMEOUT = setTimeout;
 const ORIGINAL_CLEAR_TIMEOUT = clearTimeout;
@@ -483,7 +489,7 @@ export default class Window extends EventTarget implements IWindow {
 	public readonly innerHeight: number = 768;
 	public readonly outerWidth: number = 1024;
 	public readonly outerHeight: number = 768;
-	public readonly crypto = webcrypto;
+	public readonly crypto = globalThis.crypto;
 
 	// Node.js Globals
 	public Array: typeof Array;

--- a/packages/happy-dom/src/window/Window.ts
+++ b/packages/happy-dom/src/window/Window.ts
@@ -145,12 +145,16 @@ import Clipboard from '../clipboard/Clipboard.js';
 import ClipboardItem from '../clipboard/ClipboardItem.js';
 import ClipboardEvent from '../event/events/ClipboardEvent.js';
 
-if (
-	!('crypto' in globalThis) ||
-	Object.getPrototypeOf(globalThis.crypto) === Object.getPrototypeOf({})
-) {
-	globalThis['crypto'] = import('crypto').then((c) => c.webcrypto);
+async function webcryptoImportFallback(): Promise<void> {
+	if (
+		!('crypto' in globalThis) ||
+		Object.getPrototypeOf(globalThis.crypto) === Object.getPrototypeOf({})
+	) {
+		// Import required only on node < 19
+		globalThis['crypto'] = (await import('crypto')).webcrypto;
+	}
 }
+webcryptoImportFallback();
 
 const ORIGINAL_SET_TIMEOUT = setTimeout;
 const ORIGINAL_CLEAR_TIMEOUT = clearTimeout;

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -7,7 +7,6 @@ import XMLHttpRequestSyncRequestScriptBuilder from '../../src/xml-http-request/u
 import XMLHttpRequestCertificate from '../../src/xml-http-request/XMLHttpRequestCertificate.js';
 import ProgressEvent from '../../src/event/events/ProgressEvent.js';
 import HTTP from 'http';
-import { TextDecoder } from 'util';
 import Blob from '../../src/file/Blob.js';
 import IDocument from '../../src/nodes/document/IDocument.js';
 import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';


### PR DESCRIPTION
Although most of the `happy-dom` works very well in node independent JS environments like in `vite` utilizing `vite-plugin-node-polyfills` I still had to modify the source code to work around two minor issues:

1. The explicit import of  `performance` from `perf_hooks` shouldn't be necessary in node >= v16 anymore, because it's now present in global scope out of the box. This eliminates the difference to WebAPI based solutions, where it is also globally provided as `window.performance`.

2. The other obstacle concerns the `isIP` import from `node:net`. This is a somehow tricky issue, because most of `node:net` can't be substituted by polyfills and is therefore not supported in `vite-plugin-node-polyfills` and similar solutions. There are few npm packages available, which provide the isIP group of functions in a more or less compatible manner, but in the given case, where these routines are only called once, it's perhaps better to inline the necessary regex test patterns and avoid any additional dependency. That's the way suggested by this PR. For this purpose I have chosen a set of performance optimized regex patterns that is also faster than the implementation used in older node releases (see: https://github.com/nodejs/node/pull/49568). 