### PR TITLE
fix: [#1182] The handleEvent method should be called with the listener scope

### DIFF
--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -208,7 +208,7 @@ export default abstract class EventTarget implements IEventTarget {
 					if ((<IEventListener>listener).handleEvent) {
 						WindowErrorUtility.captureError(
 							window,
-							(<IEventListener>listener).handleEvent.bind(this, event)
+							(<IEventListener>listener).handleEvent.bind(listener, event)
 						);
 					} else {
 						WindowErrorUtility.captureError(

--- a/packages/happy-dom/test/event/EventTarget.test.ts
+++ b/packages/happy-dom/test/event/EventTarget.test.ts
@@ -103,6 +103,19 @@ describe('EventTarget', () => {
 			eventTarget.dispatchEvent(dispatchedEvent);
 			expect(scope).toBe(eventTarget);
 		});
+
+		it('Event listener with handleEvent is called in the scope of the listener when calling dispatchEvent().', () => {
+			let scope = null;
+			const listener = {
+				handleEvent(): void {
+					scope = this;
+				}
+			};
+			const dispatchedEvent = new Event(EVENT_TYPE);
+			eventTarget.addEventListener(EVENT_TYPE, listener);
+			eventTarget.dispatchEvent(dispatchedEvent);
+			expect(scope).toBe(listener);
+		});
 	});
 
 	describe('removeEventListener()', () => {


### PR DESCRIPTION
This might fix #1182 and fixes usage with `bun test`. 