### PR TITLE
fix: [#1138] Modify option node to return empty string even if the value is empty string

### DIFF
--- a/packages/happy-dom/src/nodes/html-option-element/HTMLOptionElement.ts
+++ b/packages/happy-dom/src/nodes/html-option-element/HTMLOptionElement.ts
@@ -112,7 +112,7 @@ export default class HTMLOptionElement extends HTMLElement implements IHTMLOptio
 	 * @returns Value.
 	 */
 	public get value(): string {
-		return this.getAttribute('value') || this.textContent;
+		return this.getAttribute('value') ?? this.textContent;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
@@ -27,6 +27,12 @@ describe('HTMLOptionElement', () => {
 			expect(element.value).toBe('VALUE');
 		});
 
+		it('Returns the attribute "value" even if the value is empty string.', () => {
+			element.textContent = 'TEXT VALUE';
+			element.setAttribute('value', '');
+			expect(element.value).toBe('');
+		});
+
 		it('Returns the text IDL value if no attribute is present.', () => {
 			element.removeAttribute('value');
 			element.textContent = 'TEXT VALUE';


### PR DESCRIPTION
This might fix "Wrong select value when option with empty value is selected #1138 ".