### PR TITLE
fix: [#1153] Fixes problem with ClipboardItem not supporting text and…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7220,6 +7220,12 @@
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
 			"dev": true
 		},
+		"node_modules/lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"dev": true
+		},
 		"node_modules/lodash.kebabcase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -9538,6 +9544,21 @@
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
 		},
+		"node_modules/usehooks-ts": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.0.1.tgz",
+			"integrity": "sha512-bgJ8S9w/SnQyACd3RvWp3CGncROxEENGqQLCsdaoyTb0zTENIna7MIV3OW6ywCfPaYYD2OPokw7oLPmSLLWP4w==",
+			"dev": true,
+			"dependencies": {
+				"lodash.debounce": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=16.15.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0  || ^17 || ^18"
+			}
+		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -10540,6 +10561,7 @@
 				"rxjs": "^6.5.3",
 				"ts-jest": "^29.1.1",
 				"typescript": "^5.0.4",
+				"usehooks-ts": "^3.0.1",
 				"vue": "^3.2.31",
 				"zone.js": "^0.10.3"
 			},

--- a/packages/happy-dom/src/clipboard/Clipboard.ts
+++ b/packages/happy-dom/src/clipboard/Clipboard.ts
@@ -54,7 +54,13 @@ export default class Clipboard {
 		let text = '';
 		for (const item of this.#data) {
 			if (item.types.includes('text/plain')) {
-				text += await (await item.getType('text/plain')).text();
+				const data = await item.getType('text/plain');
+				if (typeof data === 'string') {
+					text += data;
+				} else {
+					// Instance of Blob
+					text += await data.text();
+				}
 			}
 		}
 		return text;

--- a/packages/happy-dom/src/clipboard/ClipboardItem.ts
+++ b/packages/happy-dom/src/clipboard/ClipboardItem.ts
@@ -9,7 +9,7 @@ import Blob from '../file/Blob.js';
  */
 export default class ClipboardItem {
 	public readonly presentationStyle: 'unspecified' | 'inline' | 'attachment' = 'unspecified';
-	#data: { [mimeType: string]: Blob };
+	#data: { [mimeType: string]: Blob | string | Promise<Blob | string> };
 
 	/**
 	 * Constructor.
@@ -19,14 +19,9 @@ export default class ClipboardItem {
 	 * @param [options.presentationStyle] Presentation style.
 	 */
 	constructor(
-		data: { [mimeType: string]: Blob },
+		data: { [mimeType: string]: Blob | string | Promise<Blob | string> },
 		options?: { presentationStyle?: 'unspecified' | 'inline' | 'attachment' }
 	) {
-		for (const mimeType of Object.keys(data)) {
-			if (mimeType !== data[mimeType].type) {
-				throw new DOMException(`Type ${mimeType} does not match the blob's type`);
-			}
-		}
 		this.#data = data;
 		if (options?.presentationStyle) {
 			this.presentationStyle = options.presentationStyle;
@@ -48,7 +43,7 @@ export default class ClipboardItem {
 	 * @param type Type.
 	 * @returns Data.
 	 */
-	public async getType(type: string): Promise<Blob> {
+	public async getType(type: string): Promise<Blob | string> {
 		if (!this.#data[type]) {
 			throw new DOMException(
 				`Failed to execute 'getType' on 'ClipboardItem': The type '${type}' was not found`

--- a/packages/happy-dom/test/clipboard/Clipboard.test.ts
+++ b/packages/happy-dom/test/clipboard/Clipboard.test.ts
@@ -15,15 +15,37 @@ describe('Clipboard', () => {
 		it('Reads from the clipboard.', async () => {
 			const items = [
 				new ClipboardItem({
-					'text/plain': new Blob(['test'], { type: 'text/plain' })
+					'text/plain': new Blob(['test-a'], { type: 'text/plain' })
 				}),
 				new ClipboardItem({
-					'text/html': new Blob(['<b>test</b>'], { type: 'text/html' })
+					'text/html': new Blob(['<b>test-b</b>'], { type: 'text/html' })
+				}),
+				new ClipboardItem({
+					'text/plain': 'test-c'
+				}),
+				new ClipboardItem({
+					'text/plain': Promise.resolve('test-d')
+				}),
+				new ClipboardItem({
+					'text/plain': Promise.resolve(new Blob(['test-e'], { type: 'text/plain' }))
 				})
 			];
 			await window.navigator.clipboard.write(items);
 			const data = await window.navigator.clipboard.read();
 			expect(data).toEqual(items);
+
+			let text = '';
+
+			for (const item of data) {
+				const data = await item.getType(item.types[0]);
+				if (typeof data === 'string') {
+					text += data;
+				} else {
+					text += await data.text();
+				}
+			}
+
+			expect(text).toBe('test-a<b>test-b</b>test-ctest-dtest-e');
 		});
 
 		it('Throws an error if the permission is denied.', async () => {
@@ -50,15 +72,24 @@ describe('Clipboard', () => {
 		it('Reads text from the clipboard.', async () => {
 			const items = [
 				new ClipboardItem({
-					'text/plain': new Blob(['test'], { type: 'text/plain' })
+					'text/plain': new Blob(['test-a'], { type: 'text/plain' })
 				}),
 				new ClipboardItem({
-					'text/html': new Blob(['<b>test</b>'], { type: 'text/html' })
+					'text/html': new Blob(['<b>test-b</b>'], { type: 'text/html' })
+				}),
+				new ClipboardItem({
+					'text/plain': 'test-c'
+				}),
+				new ClipboardItem({
+					'text/plain': Promise.resolve('test-d')
+				}),
+				new ClipboardItem({
+					'text/plain': Promise.resolve(new Blob(['test-e'], { type: 'text/plain' }))
 				})
 			];
 			await window.navigator.clipboard.write(items);
 			const data = await window.navigator.clipboard.readText();
-			expect(data).toBe('test');
+			expect(data).toBe('test-atest-ctest-dtest-e');
 		});
 
 		it('Throws an error if the permission is denied.', async () => {

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -81,6 +81,7 @@
 		"prettier": "^2.6.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
+		"usehooks-ts": "^3.0.1",
 		"rxjs": "^6.5.3",
 		"ts-jest": "^29.1.1",
 		"typescript": "^5.0.4",

--- a/packages/jest-environment/test/react/React.test.tsx
+++ b/packages/jest-environment/test/react/React.test.tsx
@@ -3,7 +3,12 @@ import ReactDOM from 'react-dom/client';
 import * as ReactTestingLibrary from '@testing-library/react';
 import ReactTestingLibraryUserEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
-import { ReactDivComponent, ReactSelectComponent, ReactInputComponent } from './ReactComponents';
+import {
+	ReactDivComponent,
+	ReactSelectComponent,
+	ReactInputComponent,
+	ReactClipboardComponent
+} from './ReactComponents';
 import * as Select from '@radix-ui/react-select';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
@@ -96,5 +101,13 @@ describe('React', () => {
 		expect(document.body.innerHTML).toBe(
 			'<app><button type="button" role="combobox" aria-controls="radix-:r0:" aria-expanded="false" aria-autocomplete="none" dir="ltr" data-state="closed" data-placeholder=""><span style="pointer-events: none;"></span><span aria-hidden="true">▼</span></button></app>'
 		);
+	});
+
+	it('Can use copy to clipboard hook component', async () => {
+		const { getByRole } = ReactTestingLibrary.render(<ReactClipboardComponent />);
+		expect(document.querySelector('p span').textContent).toBe('Nothing');
+		const button: HTMLButtonElement = getByRole('button') as HTMLButtonElement;
+		await TESTING_LIBRARY_USER.click(button);
+		expect(document.querySelector('p span').textContent).toBe('test');
 	});
 });

--- a/packages/jest-environment/test/react/ReactComponents.tsx
+++ b/packages/jest-environment/test/react/ReactComponents.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useCopyToClipboard } from 'usehooks-ts';
 
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 
@@ -72,4 +73,24 @@ export class ReactInputComponent extends React.Component<{}, {}> {
 	public render(): React.ReactElement {
 		return <input placeholder="input field" />;
 	}
+}
+
+/**
+ *
+ */
+export function ReactClipboardComponent(): React.ReactElement {
+	const [copiedText, copy] = useCopyToClipboard();
+
+	const handleCopy = (text: string) => () => {
+		copy(text);
+	};
+
+	return (
+		<>
+			<button onClick={handleCopy('test')}>A</button>
+			<p>
+				Copied value: <span>{copiedText ?? 'Nothing'}</span>
+			</p>
+		</>
+	);
 }


### PR DESCRIPTION
… Promise as data type, causing React tests to fail, as testing-library overrides the Clipboard implementation with an implementation relying on Promise as data type