### PR TITLE
fix: [#1308] Fix a bug of multiple fallbacks of custom property

### DIFF
--- a/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
@@ -366,14 +366,9 @@ export default class CSSStyleDeclarationElementStyle {
 	private parseCSSVariablesInValue(value: string, cssVariables: { [k: string]: string }): string {
 		const regexp = new RegExp(CSS_VARIABLE_REGEXP);
 		let newValue = value;
-		let matches;
+		let match;
 
-		while ((matches = newValue.matchAll(regexp)) !== null) {
-			const match = matches.next().value;
-
-			if (!match) {
-				break;
-			}
+		while ((match = regexp.exec(newValue)) !== null) {
 			// Fallback value - E.g. var(--my-var, #FFFFFF)
 			if (match[2] !== undefined) {
 				newValue = newValue.replace(match[0], cssVariables[match[2]] || match[3]);

--- a/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
@@ -366,11 +366,16 @@ export default class CSSStyleDeclarationElementStyle {
 	private parseCSSVariablesInValue(value: string, cssVariables: { [k: string]: string }): string {
 		const regexp = new RegExp(CSS_VARIABLE_REGEXP);
 		let newValue = value;
-		let match;
+		let matches;
 
-		while ((match = regexp.exec(value)) !== null) {
+		while ((matches = newValue.matchAll(regexp)) !== null) {
+			const match = matches.next().value;
+
+			if (!match) {
+				break;
+			}
 			// Fallback value - E.g. var(--my-var, #FFFFFF)
-			if (match[2] !== undefined) {
+			if (match && match[2] !== undefined) {
 				newValue = newValue.replace(match[0], cssVariables[match[2]] || match[3]);
 			} else {
 				newValue = newValue.replace(match[0], cssVariables[match[1]] || '');

--- a/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
@@ -375,7 +375,7 @@ export default class CSSStyleDeclarationElementStyle {
 				break;
 			}
 			// Fallback value - E.g. var(--my-var, #FFFFFF)
-			if (match && match[2] !== undefined) {
+			if (match[2] !== undefined) {
 				newValue = newValue.replace(match[0], cssVariables[match[2]] || match[3]);
 			} else {
 				newValue = newValue.replace(match[0], cssVariables[match[1]] || '');

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -564,6 +564,36 @@ describe('BrowserWindow', () => {
 			expect(computedStyle.color).toBe('');
 		});
 
+		it('Returns values defined by a CSS variables when multiple fallbacks are used', () => {
+			const div = <IHTMLElement>document.createElement('div');
+			const divStyle = document.createElement('style');
+
+			divStyle.innerHTML = `
+				div {
+					color: var(--my-var, var(--my-background, pink));
+
+					--color1: red;
+					--result1: var(--color1, var(--unknown, var(--unknown, green)));
+					--result2: var(--unknown, var(--color1, var(--unknown, green)));
+					--result3: var(--unknown, var(--unknown, var(--color1, green)));
+					
+					--result4: var(--unknown, var(--unknown, var(--unknown, var(--unknown, white))));
+				}
+			`;
+
+			document.body.appendChild(divStyle);
+			document.body.appendChild(div);
+
+			const computedStyle = window.getComputedStyle(div);
+			expect(computedStyle.color).toBe('pink');
+
+			expect(computedStyle.getPropertyValue('--result1')).toBe('red');
+			expect(computedStyle.getPropertyValue('--result2')).toBe('red');
+			expect(computedStyle.getPropertyValue('--result2')).toBe('red');
+
+			expect(computedStyle.getPropertyValue('--result4')).toBe('white');
+		});
+
 		it('Returns a CSSStyleDeclaration object with computed styles containing "rem" and "em" measurement values converted to pixels.', () => {
 			const parent = <IHTMLElement>document.createElement('div');
 			const element = <IHTMLElement>document.createElement('span');


### PR DESCRIPTION
Fix: https://github.com/capricorn86/happy-dom/issues/1308

The previous code was incorrect in its use of [RegExp.prototype.exec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec), and the regular expression matching was performed only once.

`RegExp.prototype.exec` is difficult to use correctly because it is a stateful API.
I modified the logic using [String.prototype.matchAll](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll) as described in MDN.

> In addition, [String.prototype.matchAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll) helps to simplify matching multiple parts of a string (with capture groups) by allowing you to iterate over the matches.
> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#description