### PR TITLE
feat: Adds support for application/x-www-form-urlencoded in Request.formData

### DIFF
--- a/packages/happy-dom/test/fetch/Response.test.ts
+++ b/packages/happy-dom/test/fetch/Response.test.ts
@@ -321,6 +321,25 @@ describe('Response', () => {
 	});
 
 	describe('formData()', () => {
+		it('Returns FormData for FormData object (multipart)', async () => {
+			const formData = new FormData();
+			formData.append('some', 'test');
+			const response = new window.Response(formData);
+			const formDataResponse = await response.formData();
+
+			expect(formDataResponse).toEqual(formData);
+		});
+
+		it('Returns FormData for URLSearchParams object (application/x-www-form-urlencoded)', async () => {
+			const urlSearchParams = new URLSearchParams();
+			urlSearchParams.append('some', 'test');
+			const response = new window.Response(urlSearchParams);
+			const formDataResponse = await response.formData();
+
+			expect(formDataResponse instanceof FormData).toBe(true);
+			expect(formDataResponse.get('some')).toBe('test');
+		});
+
 		it('Returns FormData for "application/x-www-form-urlencoded" content.', async () => {
 			const urlSearchParams = new URLSearchParams();
 


### PR DESCRIPTION
Currently `Request.formData` only handles "multipart/form-data", but it seems that it should also support "application/x-www-form-urlencoded" according to the specs. https://fetch.spec.whatwg.org/#dom-body-formdata

Current behavior:
```typescript
const params = new URLSearchParams();
params.append("d", "data");

const req = new Request("https://example.com", { method: "POST", body: params });

for (const [key, value] of req.headers.entries()) {
    console.log(`${key}: ${value.split(";")[0]}`);
}
// content-type: application/x-www-form-urlencoded

(async () => {
    for (const [key, value] of (await req.formData()).entries()) {
        console.log(`${key}: ${value}`);
    }
    // DOMException [InvalidStateError]: Failed to build FormData object: The "content-type" header isn't of type "multipart/form-data".
})();
```

The current implementation of `Request.formData` in happy-dom directly calls a method which seems to be based on `toFormData` in node-fetch. [[source](https://github.com/capricorn86/happy-dom/blob/75041b205dc7a24861599ce08262c8f30241afb3/packages/happy-dom/src/fetch/multipart/MultipartFormDataParser.ts#L12)] However, `Request.formData` in node-fetch only calls `toFormData` after handling "application/x-www-form-urlencoded" [[source](https://github.com/node-fetch/node-fetch/blob/8b3320d2a7c07bce4afc6b2bf6c3bbddda85b01f/src/body.js#L110)], which probably should be reflected in this project too.

Thank you for the awesome project. I hope this helps!