### PR TITLE
fix: [#1363] Fix bug with missing fallback value

### DIFF
--- a/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
@@ -20,6 +20,7 @@ import MediaQueryList from '../../../match-media/MediaQueryList.js';
 import WindowBrowserSettingsReader from '../../../window/WindowBrowserSettingsReader.js';
 
 const CSS_MEASUREMENT_REGEXP = /[0-9.]+(px|rem|em|vw|vh|%|vmin|vmax|cm|mm|in|pt|pc|Q)/g;
+const CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+)\)|var\( *(--[^), ]+), *(.+)\)/;
 
 type IStyleAndElement = {
 	element: Element | ShadowRoot | Document;
@@ -385,20 +386,16 @@ export default class CSSStyleDeclarationElementStyle {
 	 * @returns CSS value.
 	 */
 	private parseCSSVariablesInValue(value: string, cssVariables: { [k: string]: string }): string {
-		const SINGLE_CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+)\)/;
-		const CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+), *([^), ]+)\)/;
-
 		let newValue = value;
 		let match: RegExpMatchArray | null;
 
-		while ((match = newValue.match(SINGLE_CSS_VARIABLE_REGEXP)) != null) {
-			// Without fallback value - E.g. var(--my-var)
-			newValue = newValue.replace(match[0], cssVariables[match[1]] || '');
-		}
-
 		while ((match = newValue.match(CSS_VARIABLE_REGEXP)) !== null) {
 			// Fallback value - E.g. var(--my-var, #FFFFFF)
-			newValue = newValue.replace(match[0], cssVariables[match[1]] || match[2]);
+			if (match[2] !== undefined) {
+				newValue = newValue.replace(match[0], cssVariables[match[2]] || match[3]);
+			} else {
+				newValue = newValue.replace(match[0], cssVariables[match[1]] || '');
+			}
 		}
 
 		return newValue;

--- a/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
@@ -19,7 +19,6 @@ import CSSMeasurementConverter from '../measurement-converter/CSSMeasurementConv
 import MediaQueryList from '../../../match-media/MediaQueryList.js';
 import WindowBrowserSettingsReader from '../../../window/WindowBrowserSettingsReader.js';
 
-const CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+)\)|var\( *(--[^), ]+), *([^), ]+)\)/;
 const CSS_MEASUREMENT_REGEXP = /[0-9.]+(px|rem|em|vw|vh|%|vmin|vmax|cm|mm|in|pt|pc|Q)/g;
 
 type IStyleAndElement = {
@@ -366,16 +365,21 @@ export default class CSSStyleDeclarationElementStyle {
 	 * @returns CSS value.
 	 */
 	private parseCSSVariablesInValue(value: string, cssVariables: { [k: string]: string }): string {
+		const SINGLE_CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+)\)/;
+		const CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+), *([^), ]+)\)/;
+
 		let newValue = value;
 		let match;
 
+		if (newValue.match(SINGLE_CSS_VARIABLE_REGEXP)) {
+			// Without fallback value - E.g. var(--my-var)
+			match = newValue.match(SINGLE_CSS_VARIABLE_REGEXP);
+			newValue = newValue.replace(match[0], cssVariables[match[1]] || '');
+		}
+
 		while ((match = newValue.match(CSS_VARIABLE_REGEXP)) !== null) {
 			// Fallback value - E.g. var(--my-var, #FFFFFF)
-			if (match[2] !== undefined) {
-				newValue = newValue.replace(match[0], cssVariables[match[2]] || match[3]);
-			} else {
-				newValue = newValue.replace(match[0], cssVariables[match[1]] || '');
-			}
+			newValue = newValue.replace(match[0], cssVariables[match[1]] || match[2]);
 		}
 
 		return newValue;

--- a/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
+++ b/packages/happy-dom/src/css/declaration/element-style/CSSStyleDeclarationElementStyle.ts
@@ -389,11 +389,10 @@ export default class CSSStyleDeclarationElementStyle {
 		const CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+), *([^), ]+)\)/;
 
 		let newValue = value;
-		let match;
+		let match: RegExpMatchArray | null;
 
-		if (newValue.match(SINGLE_CSS_VARIABLE_REGEXP)) {
+		while ((match = newValue.match(SINGLE_CSS_VARIABLE_REGEXP)) != null) {
 			// Without fallback value - E.g. var(--my-var)
-			match = newValue.match(SINGLE_CSS_VARIABLE_REGEXP);
 			newValue = newValue.replace(match[0], cssVariables[match[1]] || '');
 		}
 

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -653,7 +653,6 @@ describe('BrowserWindow', () => {
 
 			const computedStyle = window.getComputedStyle(div);
 
-
 			expect(computedStyle.getPropertyValue('--my-var1')).toBe('pink');
 			expect(computedStyle.getPropertyValue('--my-var2')).toBe('pink');
 			expect(computedStyle.getPropertyValue('--my-var3')).toBe('pink');

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -592,11 +592,15 @@ describe('BrowserWindow', () => {
 					color: var(--my-var, var(--my-background, pink));
 
 					--color1: red;
+					--color2: blue;
 					--result1: var(--color1, var(--unknown, var(--unknown, green)));
 					--result2: var(--unknown, var(--color1, var(--unknown, green)));
 					--result3: var(--unknown, var(--unknown, var(--color1, green)));
 					
 					--result4: var(--unknown, var(--unknown, var(--unknown, var(--unknown, white))));
+
+					--result5: var(--color1, var(--color2));
+					--result6: var(--unknown, blue);
 				}
 			`;
 
@@ -611,6 +615,9 @@ describe('BrowserWindow', () => {
 			expect(computedStyle.getPropertyValue('--result2')).toBe('red');
 
 			expect(computedStyle.getPropertyValue('--result4')).toBe('white');
+
+			expect(computedStyle.getPropertyValue('--result5')).toBe('red');
+			expect(computedStyle.getPropertyValue('--result6')).toBe('blue');
 		});
 
 		it('Returns a CSSStyleDeclaration object with computed styles containing "rem" and "em" measurement values converted to pixels.', () => {

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -600,7 +600,8 @@ describe('BrowserWindow', () => {
 					--result4: var(--unknown, var(--unknown, var(--unknown, var(--unknown, white))));
 
 					--result5: var(--color1, var(--color2));
-					--result6: var(--unknown, blue);
+					--result6: var(--unknown, var(--color2));
+					--result7: var(--unknown, blue);
 				}
 			`;
 
@@ -618,6 +619,7 @@ describe('BrowserWindow', () => {
 
 			expect(computedStyle.getPropertyValue('--result5')).toBe('red');
 			expect(computedStyle.getPropertyValue('--result6')).toBe('blue');
+			expect(computedStyle.getPropertyValue('--result7')).toBe('blue');
 		});
 
 		it('Returns a CSSStyleDeclaration object with computed styles containing "rem" and "em" measurement values converted to pixels.', () => {

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -622,6 +622,54 @@ describe('BrowserWindow', () => {
 			expect(computedStyle.getPropertyValue('--result7')).toBe('blue');
 		});
 
+		it('Returns values defined by a CSS variables when multiple chained variables are used.', () => {
+			const div = document.createElement('div');
+			const divStyle = document.createElement('style');
+
+			divStyle.innerHTML = `
+				div {
+					--my-var1: var(--my-var2);
+					--my-var2: var(--my-var3);
+					--my-var3: var(--my-var4);
+					--my-var4: pink;
+
+
+					--color1: red;
+					--color2: blue;
+					--case1-result1: var(--case1-result2);
+					--case1-result2: var(--case1-result3);
+					--case1-result3: var(--case1-result4);
+					--case1-result4: var(--color1, var(--color2));
+
+					--case2-result1: var(--case2-result2);
+					--case2-result2: var(--case2-result3);
+					--case2-result3: var(--case2-result4);
+					--case2-result4: var(--unknown, var(--color2));
+				}
+			`;
+
+			document.body.appendChild(divStyle);
+			document.body.appendChild(div);
+
+			const computedStyle = window.getComputedStyle(div);
+
+
+			expect(computedStyle.getPropertyValue('--my-var1')).toBe('pink');
+			expect(computedStyle.getPropertyValue('--my-var2')).toBe('pink');
+			expect(computedStyle.getPropertyValue('--my-var3')).toBe('pink');
+			expect(computedStyle.getPropertyValue('--my-var4')).toBe('pink');
+
+			expect(computedStyle.getPropertyValue('--case1-result1')).toBe('red');
+			expect(computedStyle.getPropertyValue('--case1-result2')).toBe('red');
+			expect(computedStyle.getPropertyValue('--case1-result3')).toBe('red');
+			expect(computedStyle.getPropertyValue('--case1-result4')).toBe('red');
+
+			expect(computedStyle.getPropertyValue('--case2-result1')).toBe('blue');
+			expect(computedStyle.getPropertyValue('--case2-result2')).toBe('blue');
+			expect(computedStyle.getPropertyValue('--case2-result3')).toBe('blue');
+			expect(computedStyle.getPropertyValue('--case2-result4')).toBe('blue');
+		});
+
 		it('Returns a CSSStyleDeclaration object with computed styles containing "rem" and "em" measurement values converted to pixels.', () => {
 			const parent = document.createElement('div');
 			const element = document.createElement('span');


### PR DESCRIPTION
Close #1363 

Custom properties without fallback values can be converted to custom properties with fallback values (using `SINGLE_CSS_VARIABLE_REGEXP`).

e.g.
- `var(--known)`
  - In this case, you can resolve the value of the custom property by examining the value of `--known`.
- `var(--unknown, var(--known)` 
  - This case can be converted to a custom property with a fallback value of the form `var(--unknown, known-color)` by resolving the `--known` value.
- `var(--unknown, var(--unknown, var(--known)))`
  - This case can also be converted to a custom property with a fallback value of the form `var(--unknown, var(--unknown, known-color))` by resolving the value of `--known`.


After converting to a custom property for which a fallback value exists, the value can be found using a regular expression that handles the custom property in this case (using `CSS_VARIABLE_REGEXP`).