### PR TITLE
Fix a bug in createTextNode when the data argument is a non-string

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1165,7 +1165,12 @@ export default class Document extends Node {
 	 * @param [data] Text data.
 	 * @returns Text node.
 	 */
-	public createTextNode(data?: string): Text {
+	public createTextNode(data: string): Text {
+		if (arguments.length < 1) {
+			throw new TypeError(
+				`Failed to execute 'createTextNode' on 'Document': 1 argument required, but only ${arguments.length} present.`
+			);
+		}
 		return NodeFactory.createNode<Text>(this, this[PropertySymbol.ownerWindow].Text, String(data));
 	}
 

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1166,7 +1166,7 @@ export default class Document extends Node {
 	 * @returns Text node.
 	 */
 	public createTextNode(data?: string): Text {
-		return NodeFactory.createNode<Text>(this, this[PropertySymbol.ownerWindow].Text, data);
+		return NodeFactory.createNode<Text>(this, this[PropertySymbol.ownerWindow].Text, String(data));
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1045,6 +1045,17 @@ describe('Document', () => {
 			const textNode = document.createTextNode();
 			expect(textNode.data).toBe('');
 		});
+
+		it('Creates a text node with non string content.', () => {
+			const inputs = [1, -1, true, false, null, undefined, {}, []];
+			const outputs = ['1', '-1', 'true', 'false', 'null', 'undefined', '[object Object]', ''];
+
+			for (let i = 0; i < inputs.length; i++) {
+				// @ts-ignore
+				const textNode = document.createTextNode(inputs[i]);
+				expect(textNode.data).toBe(outputs[i]);
+			}
+		});
 	});
 
 	describe('createComment()', () => {

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1042,8 +1042,12 @@ describe('Document', () => {
 		});
 
 		it('Creates a text node without content.', () => {
-			const textNode = document.createTextNode();
-			expect(textNode.data).toBe('');
+			// @ts-ignore
+			expect(() => document.createTextNode()).toThrow(
+				new TypeError(
+					`Failed to execute 'createTextNode' on 'Document': 1 argument required, but only 0 present.`
+				)
+			);
 		});
 
 		it('Creates a text node with non string content.', () => {


### PR DESCRIPTION
Close #1380

Run in Chrome:

<img width="567" alt=" 2024-04-06 1 30 54" src="https://github.com/capricorn86/happy-dom/assets/6040962/5a565434-6ae4-4c7a-86fa-8493e45892ea">

Run in Safari:
<img width="464" alt=" 2024-04-06 1 31 22" src="https://github.com/capricorn86/happy-dom/assets/6040962/8551917e-ae9d-4feb-97fe-83448bead1a7">

Run in Firefox:
<img width="447" alt=" 2024-04-06 1 33 02" src="https://github.com/capricorn86/happy-dom/assets/6040962/5321dd9e-e450-44bd-b2b6-3d67715f7885">
