### PR TITLE
fix: [#1394] Update angular jest environment describe to say Angular

### DIFF
--- a/packages/jest-environment/test/angular/Angular.test.ts
+++ b/packages/jest-environment/test/angular/Angular.test.ts
@@ -3,7 +3,7 @@ import { enableProdMode } from '@angular/core';
 import 'zone.js';
 import AngularModule from './AngularModule';
 
-describe('React', () => {
+describe('Angular', () => {
 	let appElement: Element;
 
 	beforeEach(() => {


### PR DESCRIPTION
Previously, the `describe` block in `Angular.test.ts` was named `React`. This PR names it to `Angular`.

Addresses [this Issue](https://github.com/capricorn86/happy-dom/issues/1394)