### PR TITLE
feat: [#1398] Add support for iframe srcdoc

### DIFF
--- a/packages/happy-dom/src/browser/types/IGoToOptions.ts
+++ b/packages/happy-dom/src/browser/types/IGoToOptions.ts
@@ -14,4 +14,8 @@ export default interface IGoToOptions extends IReloadOptions {
 	 * Referrer policy.
 	 */
 	referrerPolicy?: IRequestReferrerPolicy;
+	/**
+	 * If `srcdoc` is set, it can be used to replace the data obtained by fetch.
+	 */
+	substituteData?: string;
 }

--- a/packages/happy-dom/src/browser/types/IGoToOptions.ts
+++ b/packages/happy-dom/src/browser/types/IGoToOptions.ts
@@ -14,8 +14,4 @@ export default interface IGoToOptions extends IReloadOptions {
 	 * Referrer policy.
 	 */
 	referrerPolicy?: IRequestReferrerPolicy;
-	/**
-	 * If `srcdoc` is set, it can be used to replace the data obtained by fetch.
-	 */
-	substituteData?: string;
 }

--- a/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameElementNamedNodeMap.ts
+++ b/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameElementNamedNodeMap.ts
@@ -45,9 +45,13 @@ export default class HTMLIFrameElementNamedNodeMap extends HTMLElementNamedNodeM
 	 */
 	public override setNamedItem(item: Attr): Attr | null {
 		const replacedAttribute = super.setNamedItem(item);
-
+		if (item[PropertySymbol.name] === 'srcdoc') {
+			this.#pageLoader.loadPage();
+		}
+		// If the src attribute and the srcdoc attribute are both specified together, the srcdoc attribute takes priority.
 		if (
 			item[PropertySymbol.name] === 'src' &&
+			this[PropertySymbol.ownerElement].getAttribute('srcdoc') === null &&
 			item[PropertySymbol.value] &&
 			item[PropertySymbol.value] !== replacedAttribute?.[PropertySymbol.value]
 		) {
@@ -68,6 +72,21 @@ export default class HTMLIFrameElementNamedNodeMap extends HTMLElementNamedNodeM
 		}
 
 		return replacedAttribute || null;
+	}
+
+	/**
+	 * @override
+	 */
+	public override [PropertySymbol.removeNamedItem](name: string): Attr | null {
+		const removedItem = super[PropertySymbol.removeNamedItem](name);
+		if (
+			removedItem &&
+			(removedItem[PropertySymbol.name] === 'srcdoc' || removedItem[PropertySymbol.name] === 'src')
+		) {
+			this.#pageLoader.loadPage();
+		}
+
+		return removedItem;
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameElementNamedNodeMap.ts
+++ b/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameElementNamedNodeMap.ts
@@ -45,13 +45,15 @@ export default class HTMLIFrameElementNamedNodeMap extends HTMLElementNamedNodeM
 	 */
 	public override setNamedItem(item: Attr): Attr | null {
 		const replacedAttribute = super.setNamedItem(item);
+
 		if (item[PropertySymbol.name] === 'srcdoc') {
 			this.#pageLoader.loadPage();
 		}
+
 		// If the src attribute and the srcdoc attribute are both specified together, the srcdoc attribute takes priority.
 		if (
 			item[PropertySymbol.name] === 'src' &&
-			this[PropertySymbol.ownerElement].getAttribute('srcdoc') === null &&
+			this[PropertySymbol.ownerElement][PropertySymbol.attributes]['srcdoc']?.value === undefined &&
 			item[PropertySymbol.value] &&
 			item[PropertySymbol.value] !== replacedAttribute?.[PropertySymbol.value]
 		) {

--- a/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameElementPageLoader.ts
+++ b/packages/happy-dom/src/nodes/html-iframe-element/HTMLIFrameElementPageLoader.ts
@@ -128,7 +128,7 @@ export default class HTMLIFrameElementPageLoader {
 	/**
 	 * Unloads an iframe page.
 	 */
-	private unloadPage(): void {
+	public unloadPage(): void {
 		if (this.#browserIFrame) {
 			BrowserFrameFactory.destroyFrame(this.#browserIFrame);
 			this.#browserIFrame = null;


### PR DESCRIPTION
Implement the iframe srcdoc attribute, which should operate similarly to the src attribute but with higher priority, without the need to initiate a fetch request.

Also, I have fixed several bugs: 
+ When remove the src or srcdoc attributes, the iframe should be reloaded.
+ For non-cross-domain iframes, after being connected to the Document, their contentWindow’s parent/top properties should not be null.

References:
+ [W3C-the-iframe-element.html#attr-iframe-src](https://www.w3.org/TR/2010/WD-html5-20100624/the-iframe-element.html#attr-iframe-src)