### PR TITLE
fix: [#1349] Return forms as html collection

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -318,8 +318,8 @@ export default class Document extends Node {
 	/**
 	 * Returns a collection of all form elements in a document.
 	 */
-	public get forms(): NodeList<HTMLFormElement> {
-		return this.querySelectorAll('form');
+	public get forms(): HTMLCollection<HTMLFormElement> {
+		return this.getElementsByTagName('form');
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -124,6 +124,7 @@ describe('Document', () => {
 
 			const forms = document.forms;
 
+			expect(forms).toBeInstanceOf(HTMLCollection);
 			expect(forms.length).toBe(2);
 			expect(forms[0]).toBe(form1);
 			expect(forms[1]).toBe(form2);


### PR DESCRIPTION
Return `document.forms` as `HTMLCollection` instead of `NodeList`.

https://developer.mozilla.org/en-US/docs/Web/API/Document/forms
![image](https://github.com/capricorn86/happy-dom/assets/48924243/3cb42640-be18-46c1-a02f-ca149e66e046)

Related to #1349.
