### PR TITLE
fix: [1406] Fixes issue with insertBefore and comment reference node

### DIFF
--- a/packages/happy-dom/src/nodes/element/ElementUtility.ts
+++ b/packages/happy-dom/src/nodes/element/ElementUtility.ts
@@ -171,6 +171,13 @@ export default class ElementUtility {
 						parentNodeChildren.splice(index, 1);
 					}
 				}
+				const parentChildNodes = (<Element>ancestorNode)[PropertySymbol.childNodes];
+				if (parentChildNodes) {
+					const index = parentChildNodes.indexOf(newNode);
+					if (index !== -1) {
+						parentChildNodes.splice(index, 1);
+					}
+				}
 			}
 
 			const ancestorNodeChildren = <HTMLCollection<HTMLElement>>(

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -1235,6 +1235,18 @@ describe('Element', () => {
 			expect(element.children['div'] === div).toBe(true);
 			expect(element.children['span2'] === span2).toBe(true);
 		});
+
+		it('Inserts correctly with comment reference node', () => {
+			const container = document.createElement('div');
+			const child = document.createElement('p');
+			child.textContent = 'A';
+			container.appendChild(child);
+			const comment = document.createComment('');
+			container.appendChild(comment);
+			container.insertBefore(child, comment);
+			const elements = container.querySelectorAll('p');
+			expect(elements.length).toBe(1);
+		});
 	});
 
 	describe('get previousElementSibling()', () => {


### PR DESCRIPTION
Resolves #1406.

I found that when the reference node is not an Element, such as a comment, the insertion correctly occurs in the `childNodes` array, but the target node is not removed from `childNodes`; it is only removed from `children`. Therefore, I have added code that also removes the target node from `childNodes`.