### PR TITLE
fix: [#1400] Implement document.elementFromPoint

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1336,6 +1336,17 @@ export default class Document extends Node {
 	}
 
 	/**
+	 * Get element at a given point.
+	 *
+	 * @param _x horizontal coordinate
+	 * @param _y vertical coordinate
+	 * @returns Always returns null since Happy DOM does not render elements.
+	 */
+	public elementFromPoint(_x: number, _y: number): Element | null {
+		return null;
+	}
+
+	/**
 	 * Imports a node.
 	 *
 	 * @param node Node.

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1392,4 +1392,11 @@ describe('Document', () => {
 			expect(document.currentScript).toBe(null);
 		});
 	});
+
+	describe('elementFromPoint', () => {
+		it('Returns null.', () => {
+			const element = document.elementFromPoint(0, 0);
+			expect(element).toBe(null);
+		});
+	});
 });


### PR DESCRIPTION
Provide mock implementation of `document.elementFromPoint`