### PR TITLE
fix: [#1418] Fix Object.{entries,key,values} on Storage

### DIFF
--- a/packages/happy-dom/src/storage/StorageFactory.ts
+++ b/packages/happy-dom/src/storage/StorageFactory.ts
@@ -82,11 +82,12 @@ export default class StorageFactory {
 				) {
 					return;
 				}
+
 				return {
 					value: storage[PropertySymbol.data][key],
 					writable: true,
 					enumerable: true,
-					configurable: false
+					configurable: true
 				};
 			}
 		});

--- a/packages/happy-dom/test/storage/Storage.test.ts
+++ b/packages/happy-dom/test/storage/Storage.test.ts
@@ -141,6 +141,51 @@ describe('Storage', () => {
 		});
 	});
 
+	describe('Object.keys()', () => {
+		it(`Returns an array of storage's own enumerable string-keyed property names.`, () => {
+			storage.setItem('key1', 'value1');
+			storage.setItem('key2', 'value2');
+
+			expect(storage.length).toBe(2);
+			expect(storage.getItem('key1')).toBe('value1');
+			expect(storage.getItem('key2')).toBe('value2');
+			expect(storage['key1']).toBe('value1');
+			expect(storage['key2']).toBe('value2');
+			expect(Object.keys(storage)).toEqual(['key1', 'key2']);
+		});
+	});
+
+	describe('Object.values()', () => {
+		it(`Returns an array of storage's own enumerable string-keyed property values.`, () => {
+			storage.setItem('key1', 'value1');
+			storage.setItem('key2', 'value2');
+
+			expect(storage.length).toBe(2);
+			expect(storage.getItem('key1')).toBe('value1');
+			expect(storage.getItem('key2')).toBe('value2');
+			expect(storage['key1']).toBe('value1');
+			expect(storage['key2']).toBe('value2');
+			expect(Object.values(storage)).toEqual(['value1', 'value2']);
+		});
+	});
+
+	describe('Object.entries()', () => {
+		it(`Returns an array of storage's own enumerable string-keyed property key-value pairs.`, () => {
+			storage.setItem('key1', 'value1');
+			storage.setItem('key2', 'value2');
+
+			expect(storage.length).toBe(2);
+			expect(storage.getItem('key1')).toBe('value1');
+			expect(storage.getItem('key2')).toBe('value2');
+			expect(storage['key1']).toBe('value1');
+			expect(storage['key2']).toBe('value2');
+			expect(Object.entries(storage)).toEqual([
+				['key1', 'value1'],
+				['key2', 'value2']
+			]);
+		});
+	});
+
 	describe('vi.spyOn()', () => {
 		it('Should spy on a method.', () => {
 			const spy = vi.spyOn(storage, 'getItem');


### PR DESCRIPTION
## Background

This fixes #1418.

`L79-84` checks that if a property does not exist in proxy target it return `undefined` for the configuration of the property and `Object.keys(window.sessionStorage, '<existent_property_key>')` returns `{ configurable: true, /** truncated for brevity */ }` on the browser (_Tested on MS Edge 124_). 

https://github.com/capricorn86/happy-dom/blob/c29f36c5644eacd0546b5c302ecd6bd7feacf50f/packages/happy-dom/src/storage/StorageFactory.ts#L78-L92

## Changes

1. Fix `Object.{entries,keys,values}()` throwing `TypeError` on `Storage` by setting `{ configurable: true }` for all existent property in the `Storage`
1. Add tests for above changes