### PR TITLE
fix: [#1442] It is common do make dynamic imports in connectedCallbac…

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -551,7 +551,23 @@ export default class Node extends EventTarget {
 			}
 
 			if (isConnected && this.connectedCallback) {
-				this.connectedCallback();
+				const result = <void | Promise<void>>this.connectedCallback();
+				/**
+				 * It is common to import dependencies in the connectedCallback() method of web components.
+				 * As Happy DOM doesn't have support for dynamic imports yet, this is a temporary solution to wait for imports in connectedCallback().
+				 *
+				 * @see https://github.com/capricorn86/happy-dom/issues/1442
+				 */
+				if (result instanceof Promise) {
+					const asyncTaskManager =
+						this[PropertySymbol.ownerDocument][PropertySymbol.ownerWindow][
+							PropertySymbol.asyncTaskManager
+						];
+					const taskID = asyncTaskManager.startTask();
+					result
+						.then(() => asyncTaskManager.endTask(taskID))
+						.catch(() => asyncTaskManager.endTask(taskID));
+				}
 			} else if (!isConnected && this.disconnectedCallback) {
 				this.disconnectedCallback();
 			}

--- a/packages/happy-dom/test/window/DetachedWindowAPI.test.ts
+++ b/packages/happy-dom/test/window/DetachedWindowAPI.test.ts
@@ -87,7 +87,13 @@ describe('DetachedWindowAPI', () => {
 			});
 			window.clearInterval(intervalID);
 			window.setTimeout(() => {
-				tasksDone++;
+				window.setTimeout(() => {
+					window.setTimeout(() => {
+						window.setTimeout(() => {
+							tasksDone++;
+						});
+					});
+				});
 			});
 			window.setTimeout(() => {
 				tasksDone++;
@@ -100,7 +106,19 @@ describe('DetachedWindowAPI', () => {
 			});
 			window.fetch('/url/1/').then((response) => {
 				response.json().then(() => {
-					tasksDone++;
+					window.fetch('/url/1/').then((response) => {
+						response.json().then(() => {
+							window.fetch('/url/1/').then((response) => {
+								response.json().then(() => {
+									window.fetch('/url/1/').then((response) => {
+										response.json().then(() => {
+											tasksDone++;
+										});
+									});
+								});
+							});
+						});
+					});
 				});
 			});
 			window.fetch('/url/2/').then((response) => {
@@ -108,8 +126,36 @@ describe('DetachedWindowAPI', () => {
 					tasksDone++;
 				});
 			});
+
+			/**
+			 * It is common to import dependencies in the connectedCallback() method of web components.
+			 * As Happy DOM doesn't have support for dynamic imports yet, this is a temporary solution to wait for imports in connectedCallback().
+			 *
+			 * @see https://github.com/capricorn86/happy-dom/issues/1442
+			 */
+			class CustomElement extends window.HTMLElement {
+				/** */
+				public async connectedCallback(): Promise<void> {
+					await new Promise((resolve) => setTimeout(resolve, 200));
+					tasksDone++;
+				}
+			}
+			/** */
+			class CustomElement2 extends window.HTMLElement {
+				/** */
+				public async connectedCallback(): Promise<void> {
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					tasksDone++;
+				}
+			}
+
+			window.customElements.define('custom-element', CustomElement);
+			window.document.body.appendChild(new CustomElement());
+			window.document.body.appendChild(window.document.createElement('custom-element-2'));
+			window.customElements.define('custom-element-2', CustomElement2);
+
 			await window.happyDOM?.waitUntilComplete();
-			expect(tasksDone).toBe(6);
+			expect(tasksDone).toBe(8);
 			expect(isFirstWhenAsyncCompleteCalled).toBe(true);
 		});
 	});


### PR DESCRIPTION
…k() of a web component. As Happy DOM doesn't have support for dynamic imports using waitUntilComplete(), a temporary fix has been added to hook into promises returned by connectedCallback().