### PR TITLE
fix: [#1429] Element.insertBefore works when the node is already inserted

### DIFF
--- a/packages/happy-dom/src/nodes/element/ElementUtility.ts
+++ b/packages/happy-dom/src/nodes/element/ElementUtility.ts
@@ -137,6 +137,10 @@ export default class ElementUtility {
 		referenceNode: Node | null,
 		options?: { disableAncestorValidation?: boolean }
 	): Node {
+		if (newNode === referenceNode) {
+			return newNode;
+		}
+
 		// NodeUtility.insertBefore() will call appendChild() for the scenario where "referenceNode" is "null" or "undefined"
 		if (newNode[PropertySymbol.nodeType] === NodeTypeEnum.elementNode && referenceNode) {
 			if (

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -1247,6 +1247,18 @@ describe('Element', () => {
 			const elements = container.querySelectorAll('p');
 			expect(elements.length).toBe(1);
 		});
+
+		it('Inserts correctly with when adding a children that is already inserted', () => {
+			const container = document.createElement('div');
+			const child = document.createElement('p');
+			child.textContent = 'A';
+			container.appendChild(child);
+
+			container.insertBefore(child, child);
+
+			const elements = container.querySelectorAll('p');
+			expect(elements.length).toBe(1);
+		});
 	});
 
 	describe('get previousElementSibling()', () => {


### PR DESCRIPTION
After recent changes the Element.insertBefore is not behaving as in the browser.
When a node is inserted into a element that already contains it, it does nothing.

Fixes https://github.com/capricorn86/happy-dom/issues/1429

Browser behavior:
<img width="362" alt="image" src="https://github.com/capricorn86/happy-dom/assets/34795714/1ed68078-accd-40e3-93ad-d8348ecb8eed">
