### PR TITLE
fix: [#1464] Fix react click handler with `preventDefault` on anchor not preventing navigation

### DIFF
--- a/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
+++ b/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
@@ -500,8 +500,7 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 		if (
 			event.type === 'click' &&
 			event instanceof MouseEvent &&
-			(event.eventPhase === EventPhaseEnum.atTarget ||
-				event.eventPhase === EventPhaseEnum.bubbling) &&
+			event.eventPhase === EventPhaseEnum.none &&
 			!event.defaultPrevented
 		) {
 			const href = this.href;

--- a/packages/jest-environment/test/react/React.test.tsx
+++ b/packages/jest-environment/test/react/React.test.tsx
@@ -110,4 +110,14 @@ describe('React', () => {
 		await TESTING_LIBRARY_USER.click(button);
 		expect(document.querySelector('p span').textContent).toBe('test');
 	});
+
+	it('Can `preventDefault` to prevent navigation with React click listener on an anchor tag', async () => {
+		location.href = 'http://localhost/';
+		const { getByRole } = ReactTestingLibrary.render(
+			<a href="http://example.com" onClick={(ev) => ev.preventDefault()} />
+		);
+		expect(document.location.href).toBe('http://localhost/');
+		await TESTING_LIBRARY_USER.click(getByRole('link'));
+		expect(document.location.href).toBe('http://localhost/');
+	});
 });


### PR DESCRIPTION
Closes #1464