### PR TITLE
fix: [#1494] Escape content in getInnerHTML

### DIFF
--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -375,7 +375,7 @@ export default class Element
 	 * @returns HTML.
 	 */
 	public get outerHTML(): string {
-		return new XMLSerializer({ escapeEntities: false }).serializeToString(this);
+		return new XMLSerializer({ escapeEntities: true }).serializeToString(this);
 	}
 
 	/**
@@ -448,6 +448,7 @@ export default class Element
 	 *
 	 * @see https://web.dev/declarative-shadow-dom/
 	 * @see https://chromestatus.com/feature/5191745052606464
+	 * @see https://html.spec.whatwg.org/#serialising-html-fragments
 	 * @param [options] Options.
 	 * @param [options.includeShadowRoots] Set to "true" to include shadow roots.
 	 * @returns HTML.
@@ -455,7 +456,7 @@ export default class Element
 	public getInnerHTML(options?: { includeShadowRoots?: boolean }): string {
 		const xmlSerializer = new XMLSerializer({
 			includeShadowRoots: options && options.includeShadowRoots,
-			escapeEntities: false
+			escapeEntities: true
 		});
 		let xml = '';
 		for (const node of this[PropertySymbol.childNodes]) {

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -873,7 +873,7 @@ describe('Document', () => {
 			const html = `<html test="1"><body>Test></body></html>`;
 			document.write(html);
 			expect(document.documentElement.outerHTML).toBe(
-				'<html test="1"><head></head><body>Test></body></html>'
+				'<html test="1"><head></head><body>Test&gt;</body></html>'
 			);
 		});
 	});

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -201,21 +201,6 @@ describe('Element', () => {
 		});
 	});
 
-	describe('get innerHTML()', () => {
-		it('Returns HTML of children as a concatenated string.', () => {
-			const div = document.createElement('div');
-
-			element.appendChild(div);
-
-			vi.spyOn(XMLSerializer.prototype, 'serializeToString').mockImplementation((rootElement) => {
-				expect(rootElement).toBe(div);
-				return 'EXPECTED_HTML';
-			});
-
-			expect(element.innerHTML).toBe('EXPECTED_HTML');
-		});
-	});
-
 	describe('set innerHTML()', () => {
 		it('Creates child nodes from provided HTML.', () => {
 			const div = document.createElement('div');
@@ -246,6 +231,29 @@ describe('Element', () => {
 			element.appendChild(textNode1);
 
 			expect(element.outerHTML).toBe('<div><div></div>text1</div>');
+		});
+
+		it('Returns HTML of children as a concatenated string.', () => {
+			const div = document.createElement('div');
+
+			element.appendChild(div);
+
+			vi.spyOn(XMLSerializer.prototype, 'serializeToString').mockImplementation((rootElement) => {
+				expect(rootElement).toBe(div);
+				return 'EXPECTED_HTML';
+			});
+
+			expect(element.innerHTML).toBe('EXPECTED_HTML');
+		});
+
+		it('Returns encoded HTML string with setter innerText.', () => {
+			const div = document.createElement('div');
+
+			div.innerText = '<b>&a</b>';
+
+			element.appendChild(div);
+
+			expect(element.innerHTML).toBe('<div>&lt;b&gt;&amp;a&lt;/b&gt;</div>');
 		});
 	});
 


### PR DESCRIPTION
According to the https://html.spec.whatwg.org/#serialising-html-fragments, in innerHTML, textnode should be escaped like https://html.spec.whatwg.org/#escapingString 

The actual browser behavior of the modified existing test is also as follows.
<img width="399" alt="스크린샷 2024-07-27 오전 12 47 56" src="https://github.com/user-attachments/assets/c3f13903-a7b1-4134-8c05-62bbc799e2e4">

Fix: #1494