### PR TITLE
fix: [#1526] handle missing symbol props in HTMLSelectElement 

### DIFF
--- a/packages/happy-dom/src/nodes/html-select-element/HTMLSelectElement.ts
+++ b/packages/happy-dom/src/nodes/html-select-element/HTMLSelectElement.ts
@@ -118,6 +118,10 @@ export default class HTMLSelectElement extends HTMLElement {
 					return true;
 				}
 
+				if (typeof property === 'symbol') {
+					return false;
+				}
+
 				const index = Number(property);
 
 				if (!isNaN(index)) {

--- a/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
@@ -239,6 +239,23 @@ describe('HTMLSelectElement', () => {
 		});
 	});
 
+	describe('get symbol()', () => {
+		it('returns existing symbol properties', () => {
+			const symbol = Symbol('test');
+			element[symbol] = 'test';
+			expect(element[symbol]).toBe('test');
+		});
+
+		it('ignores missing symbol properties', () => {
+			const symbol = Symbol('other-test');
+
+			expect(element[symbol]).toBe(undefined);
+
+			// https://github.com/capricorn86/happy-dom/issues/1526
+			expect(symbol in element).toBe(false);
+		});
+	});
+
 	describe(`set selectedIndex()`, () => {
 		it('Allows -1', () => {
 			element.selectedIndex = -1;


### PR DESCRIPTION
This resolves #1526 and adds a couple of tests to ensure no regression can happen.

I took the main fix here from `HTMLFormElement`: https://github.com/capricorn86/happy-dom/blob/20b520aa40d811dfd297b63fd66276d371b85b90/packages/happy-dom/src/nodes/html-form-element/HTMLFormElement.ts#L99

Let me know if any changes are needed.