### PR TITLE
perf: [#1609] Replace `startsWith` with the equal sign

### DIFF
--- a/packages/happy-dom/src/cookie/urilities/CookieStringUtility.ts
+++ b/packages/happy-dom/src/cookie/urilities/CookieStringUtility.ts
@@ -57,7 +57,7 @@ export default class CookieStringUtility {
 					cookie.domain = value;
 					break;
 				case 'path':
-					cookie.path = value.startsWith('/') ? value : `/${value}`;
+					cookie.path = value[0] === '/' ? value : `/${value}`;
 					break;
 				case 'httponly':
 					cookie.httpOnly = true;

--- a/packages/happy-dom/src/css/utilities/CSSParser.ts
+++ b/packages/happy-dom/src/css/utilities/CSSParser.ts
@@ -88,7 +88,7 @@ export default class CSSParser {
 					newRule.parentStyleSheet = parentStyleSheet;
 					cssRules.push(newRule);
 					parentRule = newRule;
-				} else if (selectorText.startsWith('@')) {
+				} else if (selectorText[0] === '@') {
 					// Unknown rule.
 					// We will create a new rule to let it grab its content, but we will not add it to the cssRules array.
 					const newRule = new CSSRule(PropertySymbol.illegalConstructor, window);

--- a/packages/happy-dom/src/nodes/html-hyperlink-element/HTMLHyperlinkElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-hyperlink-element/HTMLHyperlinkElementUtility.ts
@@ -299,7 +299,7 @@ export default class HTMLHyperlinkElementUtility {
 	 */
 	public getHash(): string {
 		const href = this.element.getAttribute('href');
-		if (href.startsWith('#')) {
+		if (href[0] === '#') {
 			return href;
 		}
 		let url: URL;

--- a/packages/happy-dom/src/query-selector/SelectorItem.ts
+++ b/packages/happy-dom/src/query-selector/SelectorItem.ts
@@ -330,7 +330,7 @@ export default class SelectorItem {
 				return null;
 			case 'has':
 				let priorityWeightForHas = 0;
-				if (pseudo.arguments.startsWith('+')) {
+				if (pseudo.arguments[0] === '+') {
 					const nextSibling = element.nextElementSibling;
 					if (!nextSibling) {
 						return null;

--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -329,7 +329,7 @@ export default class SelectorParser {
 				// The ":has()" pseudo selector doesn't allow for it to be nested inside another ":has()" pseudo selector, as it can lead to cyclic querying.
 				if (!args.includes(':has(')) {
 					for (const group of this.getSelectorGroups(
-						args.startsWith('+') ? args.replace('+', '') : args,
+						args[0] === '+' ? args.replace('+', '') : args,
 						options
 					)) {
 						hasSelectorItems.push(group[0]);


### PR DESCRIPTION
If you want to determine the first character only, it is more efficient to use `===` directly. [example](https://perf.link/#eyJpZCI6InVqYjN3Z21wOXNxIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikuc2xpY2UoMikpIiwidGVzdHMiOlt7Im5hbWUiOiJzdGFydHNXaXRoIiwiY29kZSI6ImRhdGEuZm9yRWFjaChzdHIgPT4gc3RyLnN0YXJ0c1dpdGgoc3RyKSkiLCJydW5zIjpbMzAwMCwyODAwMCwyOTAwMCwxNjAwMCw0MDAwLDE1MDAwLDEwMDAwLDE1MDAwLDIxMDAwLDQyMDAwLDQwMDAsNDcwMDAsMzkwMDAsNDcwMDAsMTAwMDAsMzYwMDAsNDYwMDAsNDQwMDAsNDAwMDAsMTAwMCwyMDAwMCwzNTAwMCw0OTAwMCw0MjAwMCwzMDAwLDQ1MDAwLDM2MDAwLDQ2MDAwLDIwMDAsMTAwMCw5MDAwLDIwMDAsMzUwMDAsNDMwMDAsMzAwMCw0MDAwLDYwMDAsMTEwMDAsNDAwMCwzNzAwMCw0NjAwMCwyMDAwLDYwMDAsNDAwMCw5MDAwLDkwMDAsNDUwMDAsMzkwMDAsODAwMCwzMDAwLDgwMDAsMTAwMDAsMTAwMCwzODAwMCw0NjAwMCw2MDAwLDYwMDAsMTAwMDAsMTEwMDAsMTAwMDAsNDAwMCw0NzAwMCw1MDAwLDQwMDAsNzAwMCw1MjAwMCwzMDAwLDkwMDAsMzQwMDAsNDUwMDAsMTAwMCw1MDAwLDE1MDAwLDMyMDAwLDUwMDAsNzAwMCwyMTAwMCwyMDAwMCw1MDAwLDEwMDAsNDgwMDAsNDYwMDAsMjYwMDAsNDgwMDAsMzAwMCw1MDAwLDkwMDAsMTAwMDAsNzAwMCw0NTAwMCwxMDAwLDEzMDAwLDYwMDAsNDAwMCwxMjAwMCw4MDAwLDM2MDAwLDQyMDAwLDcwMDAsODAwMF0sIm9wcyI6MTk1MzB9LHsibmFtZSI6ImluZGV4IDAiLCJjb2RlIjoiZGF0YS5mb3JFYWNoKHN0ciA9PiBzdHJbMF0gPT09ICcoJykiLCJydW5zIjpbNDAwMCw1NjAwMCw2MjAwMCw0MzAwMCw2MDAwLDI0MDAwLDIxMDAwLDM1MDAwLDM4MDAwLDExMjAwMCw2MDAwLDExMDAwMCw5ODAwMCwxMjcwMDAsMjIwMDAsMTAxMDAwLDEzMjAwMCwxNDAwMDAsMTEyMDAwLDEzNDAwMCw0OTAwMCw5ODAwMCwxMjIwMDAsMTI1MDAwLDMwMDAsMTExMDAwLDkxMDAwLDEzMzAwMCwyMDAwLDEzMzAwMCwxODAwMCwxNDMwMDAsOTEwMDAsMTMwMDAwLDQwMDAsNDAwMCw4MDAwLDgwMDAsNDAwMCw4NzAwMCwxMTEwMDAsNDAwMCw4MDAwLDIwMDAsODAwMCw2MDAwLDEyNjAwMCwxMDQwMDAsMTAwMDAsNDAwMCw3MDAwLDE3MDAwLDEzMDAwMCw5NTAwMCwxMjMwMDAsNjAwMCwzMDAwLDExMDAwLDEwMDAwLDE2MDAwLDUwMDAsMTM0MDAwLDgwMDAsNDAwMCw2MDAwLDExOTAwMCw0MDAwLDE0MDAwLDg2MDAwLDEzMDAwMCwxMzkwMDAsNzAwMCwyMDAwMCwyNTAwMCwxMDAwLDEyMDAwLDU0MDAwLDE0MDAwLDIzMDAwLDU5MDAwLDEyNjAwMCwxNDAwMDAsNjUwMDAsMTIzMDAwLDMwMDAsMTM4MDAwLDExMDAwLDUwMDAsNTAwMCwxMDQwMDAsMTQyMDAwLDIwMDAwLDYwMDAsNjAwMCwxNjAwMCwxNDAwMCwxMDgwMDAsMTE5MDAwLDExMDAwLDcwMDBdLCJvcHMiOjU1ODEwfV0sInVwZGF0ZWQiOiIyMDI0LTExLTEzVDE0OjI5OjA5LjM0NFoifQ%3D%3D)