### PR TITLE
fix: [#1621] Allow for an URL to be a string or an URL object in History.pushState() and History.replaceState() APIs

### DIFF
--- a/packages/happy-dom/src/browser/utilities/BrowserFrameURL.ts
+++ b/packages/happy-dom/src/browser/utilities/BrowserFrameURL.ts
@@ -12,8 +12,8 @@ export default class BrowserFrameURL {
 	 * @param url URL.
 	 * @returns Relative URL.
 	 */
-	public static getRelativeURL(frame: IBrowserFrame, url: string): URL {
-		url = url || 'about:blank';
+	public static getRelativeURL(frame: IBrowserFrame, url: string | URL): URL {
+		url = (url instanceof URL ? url.toString() : url) || 'about:blank';
 
 		if (url.startsWith('about:') || url.startsWith('javascript:')) {
 			return new URL(url);

--- a/packages/happy-dom/src/history/History.ts
+++ b/packages/happy-dom/src/history/History.ts
@@ -119,7 +119,7 @@ export default class History {
 	 * @param title Title.
 	 * @param [url] URL.
 	 */
-	public pushState(state: object, title, url?: string): void {
+	public pushState(state: object, title, url?: string | URL): void {
 		if (this.#window.closed) {
 			return;
 		}
@@ -135,7 +135,7 @@ export default class History {
 
 		if (url && newURL.origin !== location.origin) {
 			throw new this.#window.DOMException(
-				`Failed to execute 'pushState' on 'History': A history state object with URL '${url}' cannot be created in a document with origin '${location.origin}' and URL '${location.href}'.`,
+				`Failed to execute 'pushState' on 'History': A history state object with URL '${url.toString()}' cannot be created in a document with origin '${location.origin}' and URL '${location.href}'.`,
 				DOMExceptionNameEnum.securityError
 			);
 		}
@@ -177,7 +177,7 @@ export default class History {
 	 * @param title Title.
 	 * @param [url] URL.
 	 */
-	public replaceState(state: object, title, url?: string): void {
+	public replaceState(state: object, title, url?: string | URL): void {
 		if (this.#window.closed) {
 			return;
 		}
@@ -193,7 +193,7 @@ export default class History {
 
 		if (url && newURL.origin !== location.origin) {
 			throw new this.#window.DOMException(
-				`Failed to execute 'pushState' on 'History': A history state object with URL '${url}' cannot be created in a document with origin '${location.origin}' and URL '${location.href}'.`,
+				`Failed to execute 'pushState' on 'History': A history state object with URL '${url.toString()}' cannot be created in a document with origin '${location.origin}' and URL '${location.href}'.`,
 				DOMExceptionNameEnum.securityError
 			);
 		}


### PR DESCRIPTION
Allow for an URL to be a string or an URL object in History.pushState() and History.replaceState() APIs. 
Solves [1621](https://github.com/capricorn86/happy-dom/issues/1621)