### PR TITLE
fix: Remove redundant querySelector type check

### DIFF
--- a/packages/happy-dom/src/query-selector/QuerySelector.ts
+++ b/packages/happy-dom/src/query-selector/QuerySelector.ts
@@ -92,7 +92,9 @@ export default class QuerySelector {
 		}
 
 		if (typeof selector === 'symbol') {
-			throw new window.TypeError(`Cannot convert a Symbol value to a string`);
+			throw new window.TypeError(
+				`Failed to execute 'querySelectorAll' on '${node.constructor.name}': Cannot convert a Symbol value to a string`
+			);
 		}
 
 		selector = String(selector);
@@ -212,7 +214,9 @@ export default class QuerySelector {
 		}
 
 		if (typeof selector === 'symbol') {
-			throw new window.TypeError(`Cannot convert a Symbol value to a string`);
+			throw new window.TypeError(
+				`Failed to execute 'querySelector' on '${node.constructor.name}': Cannot convert a Symbol value to a string`
+			);
 		}
 
 		selector = String(selector);

--- a/packages/happy-dom/src/query-selector/QuerySelector.ts
+++ b/packages/happy-dom/src/query-selector/QuerySelector.ts
@@ -205,12 +205,6 @@ export default class QuerySelector {
 			);
 		}
 
-		if (typeof selector === 'function' || typeof selector === 'symbol') {
-			throw new window.DOMException(
-				`Failed to execute 'querySelector' on '${node.constructor.name}': '${selector}' is not a valid selector.`
-			);
-		}
-
 		if (typeof selector === 'function') {
 			throw new window.DOMException(
 				`Failed to execute 'querySelector' on '${node.constructor.name}': '${selector}' is not a valid selector.`

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -34,7 +34,9 @@ describe('QuerySelector', () => {
 				)
 			);
 			expect(() => container.querySelectorAll(<string>(<unknown>Symbol('test')))).toThrow(
-				new Error(`Cannot convert a Symbol value to a string`)
+				new TypeError(
+					`Failed to execute 'querySelectorAll' on 'HTMLDivElement': Cannot convert a Symbol value to a string`
+				)
 			);
 			expect(() => container.querySelectorAll(<string>(<unknown>true))).not.toThrow();
 		});
@@ -1225,7 +1227,9 @@ describe('QuerySelector', () => {
 				)
 			);
 			expect(() => container.querySelector(<string>(<unknown>Symbol('test')))).toThrow(
-				new Error(`Cannot convert a Symbol value to a string`)
+				new TypeError(
+					`Failed to execute 'querySelector' on 'HTMLDivElement': Cannot convert a Symbol value to a string`
+				)
 			);
 			expect(() => container.querySelector(<string>(<unknown>true))).not.toThrow();
 		});


### PR DESCRIPTION
Remove a type check which is covered by (and shadows) subsequent checks.