### PR TITLE
fix: [1720] Fix bug where nested query selector is not returning the correct result when there are multiple matching selectorGroups

### DIFF
--- a/packages/happy-dom/src/query-selector/QuerySelector.ts
+++ b/packages/happy-dom/src/query-selector/QuerySelector.ts
@@ -601,7 +601,8 @@ export default class QuerySelector {
 									rootElement,
 									[nextElementSibling],
 									selectorItems.slice(1),
-									cachedItem
+									cachedItem,
+									position
 								);
 								if (match) {
 									return match;
@@ -614,7 +615,8 @@ export default class QuerySelector {
 								rootElement,
 								childrenOfChild,
 								selectorItems.slice(1),
-								cachedItem
+								cachedItem,
+								position
 							);
 							if (match) {
 								return match;
@@ -628,7 +630,8 @@ export default class QuerySelector {
 									rootElement,
 									[sibling],
 									selectorItems.slice(1),
-									cachedItem
+									cachedItem,
+									position
 								);
 								if (match) {
 									return match;
@@ -640,7 +643,13 @@ export default class QuerySelector {
 			}
 
 			if (selectorItem.combinator === SelectorCombinatorEnum.descendant && childrenOfChild.length) {
-				const match = this.findFirst(rootElement, childrenOfChild, selectorItems, cachedItem);
+				const match = this.findFirst(
+					rootElement,
+					childrenOfChild,
+					selectorItems,
+					cachedItem,
+					position
+				);
 
 				if (match) {
 					return match;

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -1946,5 +1946,24 @@ describe('QuerySelector', () => {
 
 			expect(div.querySelector('.a,h1')).toBe(div.children[0].children[0]);
 		});
+
+		it('Matches grouped selectors with nesting', () => {
+			const div = document.createElement('div');
+
+			div.innerHTML = `
+			 <div>
+              <blockquote>
+                <div class="a">
+                  <ul>
+                    <li><span>Item 1</span></li>
+                    <li><span>Item 2</span></li>
+                  </ul>
+                </div>
+              </blockquote>
+            </div>
+			`;
+
+			expect(div.querySelector('.a,BLOCKQUOTE')).toBe(div.children[0].children[0]);
+		});
 	});
 });


### PR DESCRIPTION
Found and fixed a minor bug where we still aren't quite returning the same result in querySelect() and querySelectAll()[0] when there are grouped selectors. The fix was to pass through the updated document position to recursive calls, which was missed during #1713.

Fixes #1720 