### PR TITLE
fix: [#1718] AbortSignal reason can have any type and the value should be used without being wrapped when rejecting a fetch

### DIFF
--- a/packages/happy-dom/src/PropertySymbol.ts
+++ b/packages/happy-dom/src/PropertySymbol.ts
@@ -391,3 +391,4 @@ export const blocking = Symbol('blocking');
 export const moduleImportMap = Symbol('moduleImportMap');
 export const dispatchError = Symbol('dispatchError');
 export const supports = Symbol('supports');
+export const reason = Symbol('reason');

--- a/packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts
+++ b/packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts
@@ -10,6 +10,7 @@ import AsyncTaskManager from '../../async-task-manager/AsyncTaskManager.js';
 import FormData from '../../form-data/FormData.js';
 import HistoryScrollRestorationEnum from '../../history/HistoryScrollRestorationEnum.js';
 import IHistoryItem from '../../history/IHistoryItem.js';
+import DOMExceptionNameEnum from '../../exception/DOMExceptionNameEnum.js';
 
 /**
  * Browser frame navigation utility.
@@ -178,7 +179,13 @@ export default class BrowserFrameNavigator {
 		const readyStateManager = frame.window[PropertySymbol.readyStateManager];
 		const abortController = new frame.window.AbortController();
 		const timeout = frame.window.setTimeout(
-			() => abortController.abort(new Error('Request timed out.')),
+			() =>
+				abortController.abort(
+					new frame.window.DOMException(
+						'The operation was aborted. Request timed out.',
+						DOMExceptionNameEnum.timeoutError
+					)
+				),
 			goToOptions?.timeout ?? 30000
 		);
 		const finalize = (): void => {

--- a/packages/happy-dom/src/fetch/AbortController.ts
+++ b/packages/happy-dom/src/fetch/AbortController.ts
@@ -19,7 +19,7 @@ export default class AbortController {
 	 *
 	 * @param [reason] Reason.
 	 */
-	public abort(reason?: Error): void {
+	public abort(reason?: any): void {
 		this.signal[PropertySymbol.abort](reason);
 	}
 }

--- a/packages/happy-dom/src/fetch/AbortSignal.ts
+++ b/packages/happy-dom/src/fetch/AbortSignal.ts
@@ -16,7 +16,7 @@ export default class AbortSignal extends EventTarget {
 
 	// Public properties
 	public readonly aborted: boolean = false;
-	public readonly reason: Error | null = null;
+	public reason: any = null;
 
 	// Events
 	public onabort: ((this: AbortSignal, event: Event) => void) | null = null;
@@ -46,16 +46,17 @@ export default class AbortSignal extends EventTarget {
 	 *
 	 * @param [reason] Reason.
 	 */
-	public [PropertySymbol.abort](reason?: Error): void {
+	public [PropertySymbol.abort](reason?: any): void {
 		if (this.aborted) {
 			return;
 		}
-		(<Error>this.reason) =
-			reason ||
-			new this[PropertySymbol.window].DOMException(
-				'signal is aborted without reason',
-				DOMExceptionNameEnum.abortError
-			);
+		this.reason =
+			reason !== undefined
+				? reason
+				: new this[PropertySymbol.window].DOMException(
+						'signal is aborted without reason',
+						DOMExceptionNameEnum.abortError
+					);
 		(<boolean>this.aborted) = true;
 		this.dispatchEvent(new Event('abort'));
 	}
@@ -75,14 +76,15 @@ export default class AbortSignal extends EventTarget {
 	 * @param [reason] Reason.
 	 * @returns AbortSignal instance.
 	 */
-	public static abort(reason?: Error): AbortSignal {
+	public static abort(reason?: any): AbortSignal {
 		const signal = new this();
-		(<Error>signal.reason) =
-			reason ||
-			new this[PropertySymbol.window].DOMException(
-				'signal is aborted without reason',
-				DOMExceptionNameEnum.abortError
-			);
+		signal.reason =
+			reason !== undefined
+				? reason
+				: new this[PropertySymbol.window].DOMException(
+						'signal is aborted without reason',
+						DOMExceptionNameEnum.abortError
+					);
 		(<boolean>signal.aborted) = true;
 		return signal;
 	}

--- a/packages/happy-dom/src/fetch/AbortSignal.ts
+++ b/packages/happy-dom/src/fetch/AbortSignal.ts
@@ -14,9 +14,9 @@ export default class AbortSignal extends EventTarget {
 	protected declare static [PropertySymbol.window]: BrowserWindow;
 	protected declare [PropertySymbol.window]: BrowserWindow;
 
-	// Public properties
-	public readonly aborted: boolean = false;
-	public reason: any = null;
+	// Internal properties
+	public [PropertySymbol.aborted]: boolean = false;
+	public [PropertySymbol.reason]: any = undefined;
 
 	// Events
 	public onabort: ((this: AbortSignal, event: Event) => void) | null = null;
@@ -28,9 +28,7 @@ export default class AbortSignal extends EventTarget {
 		super();
 
 		if (!this[PropertySymbol.window]) {
-			throw new TypeError(
-				`Failed to construct '${this.constructor.name}': '${this.constructor.name}' was constructed outside a Window context.`
-			);
+			throw new TypeError(`Failed to construct 'AbortSignal': Illegal constructor`);
 		}
 	}
 
@@ -42,6 +40,42 @@ export default class AbortSignal extends EventTarget {
 	}
 
 	/**
+	 * Returns true if the signal has been aborted.
+	 *
+	 * @returns True if the signal has been aborted.
+	 */
+	public get aborted(): boolean {
+		return this[PropertySymbol.aborted];
+	}
+
+	/**
+	 * Setter for aborted. Value will be ignored as the property is read-only.
+	 *
+	 * @param _value Aborted.
+	 */
+	public set aborted(_value: boolean) {
+		// Do nothing
+	}
+
+	/**
+	 * Returns the reason the signal was aborted.
+	 *
+	 * @returns Reason.
+	 */
+	public get reason(): any {
+		return this[PropertySymbol.reason];
+	}
+
+	/**
+	 * Setter for reason. Value will be ignored as the property is read-only.
+	 *
+	 * @param _value Reason.
+	 */
+	public set reason(_value: any) {
+		// Do nothing
+	}
+
+	/**
 	 * Aborts the signal.
 	 *
 	 * @param [reason] Reason.
@@ -50,14 +84,14 @@ export default class AbortSignal extends EventTarget {
 		if (this.aborted) {
 			return;
 		}
-		this.reason =
+		this[PropertySymbol.reason] =
 			reason !== undefined
 				? reason
 				: new this[PropertySymbol.window].DOMException(
 						'signal is aborted without reason',
 						DOMExceptionNameEnum.abortError
-					);
-		(<boolean>this.aborted) = true;
+				  );
+		this[PropertySymbol.aborted] = true;
 		this.dispatchEvent(new Event('abort'));
 	}
 
@@ -78,14 +112,14 @@ export default class AbortSignal extends EventTarget {
 	 */
 	public static abort(reason?: any): AbortSignal {
 		const signal = new this();
-		signal.reason =
+		signal[PropertySymbol.reason] =
 			reason !== undefined
 				? reason
 				: new this[PropertySymbol.window].DOMException(
 						'signal is aborted without reason',
 						DOMExceptionNameEnum.abortError
-					);
-		(<boolean>signal.aborted) = true;
+				  );
+		signal[PropertySymbol.aborted] = true;
 		return signal;
 	}
 
@@ -120,8 +154,8 @@ export default class AbortSignal extends EventTarget {
 	 */
 	public static any(signals: AbortSignal[]): AbortSignal {
 		for (const signal of signals) {
-			if (signal.aborted) {
-				return this.abort(signal.reason);
+			if (signal[PropertySymbol.aborted]) {
+				return this.abort(signal[PropertySymbol.reason]);
 			}
 		}
 
@@ -137,7 +171,7 @@ export default class AbortSignal extends EventTarget {
 		for (const signal of signals) {
 			const handler = (): void => {
 				stopListening();
-				anySignal[PropertySymbol.abort](signal.reason);
+				anySignal[PropertySymbol.abort](signal[PropertySymbol.reason]);
 			};
 			handlers.set(signal, handler);
 			signal.addEventListener('abort', handler);

--- a/packages/happy-dom/src/fetch/AbortSignal.ts
+++ b/packages/happy-dom/src/fetch/AbortSignal.ts
@@ -90,7 +90,7 @@ export default class AbortSignal extends EventTarget {
 				: new this[PropertySymbol.window].DOMException(
 						'signal is aborted without reason',
 						DOMExceptionNameEnum.abortError
-				  );
+					);
 		this[PropertySymbol.aborted] = true;
 		this.dispatchEvent(new Event('abort'));
 	}
@@ -118,7 +118,7 @@ export default class AbortSignal extends EventTarget {
 				: new this[PropertySymbol.window].DOMException(
 						'signal is aborted without reason',
 						DOMExceptionNameEnum.abortError
-				  );
+					);
 		signal[PropertySymbol.aborted] = true;
 		return signal;
 	}

--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -154,7 +154,7 @@ export default class Fetch {
 						window: this.#window,
 						response: this.response,
 						request: this.request
-				  })
+					})
 				: undefined;
 			return interceptedResponse instanceof Response ? interceptedResponse : this.response;
 		}
@@ -341,7 +341,7 @@ export default class Fetch {
 						window: this.#window,
 						response: await response,
 						request: this.request
-				  })
+					})
 				: undefined;
 			this.#browserFrame[PropertySymbol.asyncTaskManager].endTask(taskID);
 			return interceptedResponse instanceof Response ? interceptedResponse : response;
@@ -364,7 +364,7 @@ export default class Fetch {
 						window: this.#window,
 						response: await response,
 						request: this.request
-				  })
+					})
 				: undefined;
 			this.#browserFrame[PropertySymbol.asyncTaskManager].endTask(taskID);
 			return interceptedResponse instanceof Response ? interceptedResponse : response;
@@ -388,7 +388,7 @@ export default class Fetch {
 					window: this.#window,
 					response: await response,
 					request: this.request
-			  })
+				})
 			: undefined;
 
 		this.#browserFrame[PropertySymbol.asyncTaskManager].endTask(taskID);
@@ -545,7 +545,7 @@ export default class Fetch {
 							window: this.#window,
 							response: await response,
 							request: this.request
-					  })
+						})
 					: undefined;
 				this.#browserFrame[PropertySymbol.asyncTaskManager].endTask(taskID);
 				const returnResponse =

--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -137,6 +137,7 @@ export default class Fetch {
 		if (this.request.signal.aborted) {
 			throw new this.#window.DOMException(
 				'The operation was aborted.',
+				this.request.signal.reason.name ||
 				DOMExceptionNameEnum.abortError
 			);
 		}

--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -137,8 +137,7 @@ export default class Fetch {
 		if (this.request.signal.aborted) {
 			throw new this.#window.DOMException(
 				'The operation was aborted.',
-				this.request.signal.reason.name ||
-				DOMExceptionNameEnum.abortError
+				this.request.signal.reason.name || DOMExceptionNameEnum.abortError
 			);
 		}
 

--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -135,10 +135,13 @@ export default class Fetch {
 		FetchRequestValidationUtility.validateSchema(this.request);
 
 		if (this.request.signal.aborted) {
-			throw new this.#window.DOMException(
-				'The operation was aborted.',
-				this.request.signal.reason.name || DOMExceptionNameEnum.abortError
-			);
+			if (this.request.signal.reason instanceof Error) {
+				throw new this.#window.DOMException(
+					this.request.signal.reason.message || 'The operation was aborted.',
+					this.request.signal.reason.name || DOMExceptionNameEnum.abortError
+				);
+			}
+			throw this.request.signal.reason;
 		}
 
 		if (this.request[PropertySymbol.url].protocol === 'data:') {

--- a/packages/happy-dom/src/fetch/SyncFetch.ts
+++ b/packages/happy-dom/src/fetch/SyncFetch.ts
@@ -104,7 +104,7 @@ export default class SyncFetch {
 			? this.interceptor.beforeSyncRequest({
 					request: this.request,
 					window: this.#window
-			  })
+				})
 			: undefined;
 
 		if (typeof beforeRequestResponse === 'object') {
@@ -139,7 +139,7 @@ export default class SyncFetch {
 						window: this.#window,
 						response,
 						request: this.request
-				  })
+					})
 				: undefined;
 			return typeof interceptedResponse === 'object' ? interceptedResponse : response;
 		}
@@ -293,7 +293,7 @@ export default class SyncFetch {
 						window: this.#window,
 						response,
 						request: this.request
-				  })
+					})
 				: undefined;
 			return typeof interceptedResponse === 'object' ? interceptedResponse : response;
 		}
@@ -312,7 +312,7 @@ export default class SyncFetch {
 						window: this.#window,
 						response,
 						request: this.request
-				  })
+					})
 				: undefined;
 			return typeof interceptedResponse === 'object' ? interceptedResponse : response;
 		}
@@ -331,7 +331,7 @@ export default class SyncFetch {
 					window: this.#window,
 					response,
 					request: this.request
-			  })
+				})
 			: undefined;
 		const returnResponse = typeof interceptedResponse === 'object' ? interceptedResponse : response;
 
@@ -528,7 +528,7 @@ export default class SyncFetch {
 					window: this.#window,
 					response: redirectedResponse,
 					request: this.request
-			  })
+				})
 			: undefined;
 		const returnResponse =
 			typeof interceptedResponse === 'object' ? interceptedResponse : redirectedResponse;

--- a/packages/happy-dom/src/fetch/SyncFetch.ts
+++ b/packages/happy-dom/src/fetch/SyncFetch.ts
@@ -104,7 +104,7 @@ export default class SyncFetch {
 			? this.interceptor.beforeSyncRequest({
 					request: this.request,
 					window: this.#window
-				})
+			  })
 			: undefined;
 
 		if (typeof beforeRequestResponse === 'object') {
@@ -113,9 +113,12 @@ export default class SyncFetch {
 
 		FetchRequestValidationUtility.validateSchema(this.request);
 
-		if (this.request.signal.aborted) {
-			throw new this.#window.DOMException(
-				'The operation was aborted.',
+		if (this.request.signal[PropertySymbol.aborted]) {
+			if (this.request.signal[PropertySymbol.reason] !== undefined) {
+				throw this.request.signal[PropertySymbol.reason];
+			}
+			throw new this[PropertySymbol.window].DOMException(
+				'signal is aborted without reason',
 				DOMExceptionNameEnum.abortError
 			);
 		}
@@ -136,7 +139,7 @@ export default class SyncFetch {
 						window: this.#window,
 						response,
 						request: this.request
-					})
+				  })
 				: undefined;
 			return typeof interceptedResponse === 'object' ? interceptedResponse : response;
 		}
@@ -290,7 +293,7 @@ export default class SyncFetch {
 						window: this.#window,
 						response,
 						request: this.request
-					})
+				  })
 				: undefined;
 			return typeof interceptedResponse === 'object' ? interceptedResponse : response;
 		}
@@ -309,7 +312,7 @@ export default class SyncFetch {
 						window: this.#window,
 						response,
 						request: this.request
-					})
+				  })
 				: undefined;
 			return typeof interceptedResponse === 'object' ? interceptedResponse : response;
 		}
@@ -328,7 +331,7 @@ export default class SyncFetch {
 					window: this.#window,
 					response,
 					request: this.request
-				})
+			  })
 			: undefined;
 		const returnResponse = typeof interceptedResponse === 'object' ? interceptedResponse : response;
 
@@ -525,7 +528,7 @@ export default class SyncFetch {
 					window: this.#window,
 					response: redirectedResponse,
 					request: this.request
-				})
+			  })
 			: undefined;
 		const returnResponse =
 			typeof interceptedResponse === 'object' ? interceptedResponse : redirectedResponse;

--- a/packages/happy-dom/test/browser/BrowserFrame.test.ts
+++ b/packages/happy-dom/test/browser/BrowserFrame.test.ts
@@ -352,7 +352,7 @@ Task #1
 
 			expect(error).toEqual(
 				new DOMException(
-					'The operation was aborted. Error: Request timed out.',
+					'The operation was aborted. Request timed out.',
 					DOMExceptionNameEnum.abortError
 				)
 			);

--- a/packages/happy-dom/test/browser/detached-browser/DetachedBrowserFrame.test.ts
+++ b/packages/happy-dom/test/browser/detached-browser/DetachedBrowserFrame.test.ts
@@ -329,7 +329,7 @@ describe('DetachedBrowserFrame', () => {
 
 			expect(error).toEqual(
 				new DOMException(
-					'The operation was aborted. Error: Request timed out.',
+					'The operation was aborted. Request timed out.',
 					DOMExceptionNameEnum.abortError
 				)
 			);

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -66,14 +66,14 @@ describe('AbortSignal', () => {
 
 		it('After Abortsignal timeout, sending a request with the wrong name still being "TimeoutError" ', async () => {
 			try {
-				const signal = AbortSignal.timeout(20)
-				const now = Date.now()
-				await vi.waitUntil(() => Date.now() - now > 100)
-				await fetch('https://example.com', { signal })
+				const signal = AbortSignal.timeout(20);
+				const now = Date.now();
+				await vi.waitUntil(() => Date.now() - now > 100);
+				await fetch('https://example.com', { signal });
 			} catch (e) {
-				expect((e as Error).name).toStrictEqual('TimeoutError')
+				expect((e as Error).name).toStrictEqual('TimeoutError');
 			}
-		})
+		});
 	});
 
 	describe('AbortSignal.any()', () => {

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -1,5 +1,5 @@
 import Event from '../../src/event/Event.js';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as PropertySymbol from '../../src/PropertySymbol.js';
 import BrowserWindow from '../../src/window/BrowserWindow.js';
 import Window from '../../src/window/Window.js';
@@ -63,6 +63,17 @@ describe('AbortSignal', () => {
 			expect(signal.reason).toBeInstanceOf(DOMException);
 			expect(signal.reason?.name).toBe('TimeoutError');
 		});
+
+		it('After Abortsignal timeout, sending a request with the wrong name still being "TimeoutError" ', async () => {
+			try {
+				const signal = AbortSignal.timeout(20)
+				const now = Date.now()
+				await vi.waitUntil(() => Date.now() - now > 100)
+				await fetch('https://example.com', { signal })
+			} catch (e) {
+				expect((e as Error).name).toStrictEqual('TimeoutError')
+			}
+		})
 	});
 
 	describe('AbortSignal.any()', () => {

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -54,7 +54,8 @@ describe('AbortSignal', () => {
 			const signal = window.AbortSignal.abort();
 
 			expect(signal.aborted).toBe(true);
-			expect(signal.reason instanceof Error).toBe(true);
+			expect(signal.reason instanceof window.DOMException).toBe(true);
+			expect(signal.reason.message).toBe('signal is aborted without reason');
 			expect(signal.reason.name).toBe('AbortError');
 		});
 
@@ -84,19 +85,9 @@ describe('AbortSignal', () => {
 			await new Promise((resolve) => setTimeout(resolve, 100));
 
 			expect(signal.aborted).toBe(true);
-			expect(signal.reason).toBeInstanceOf(DOMException);
+			expect(signal.reason).toBeInstanceOf(window.DOMException);
+			expect(signal.reason?.message).toBe('signal timed out');
 			expect(signal.reason?.name).toBe('TimeoutError');
-		});
-
-		it('After Abortsignal timeout, sending a request with the wrong name still being "TimeoutError" ', async () => {
-			try {
-				const signal = AbortSignal.timeout(20);
-				const now = Date.now();
-				await vi.waitUntil(() => Date.now() - now > 100);
-				await fetch('https://example.com', { signal });
-			} catch (e) {
-				expect((<Error>e).name).toStrictEqual('TimeoutError');
-			}
 		});
 	});
 

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -49,6 +49,30 @@ describe('AbortSignal', () => {
 			expect(signal.aborted).toBe(true);
 			expect(signal.reason).toBe(reason);
 		});
+
+		it('Returns a new instance of AbortSignal with a default reason if no reason is provided.', () => {
+			const signal = window.AbortSignal.abort();
+
+			expect(signal.aborted).toBe(true);
+			expect(signal.reason instanceof Error).toBe(true);
+			expect(signal.reason.name).toBe('AbortError');
+		});
+
+		it('Returns a new instance of AbortSignal with a custom reason 1.', () => {
+			const signal = window.AbortSignal.abort(1);
+
+			expect(signal.aborted).toBe(true);
+			expect(signal.reason instanceof Error).toBe(false);
+			expect(signal.reason).toBe(1);
+		});
+
+		it('Returns a new instance of AbortSignal with a custom reason null.', () => {
+			const signal = window.AbortSignal.abort(null);
+
+			expect(signal.aborted).toBe(true);
+			expect(signal.reason instanceof Error).toBe(false);
+			expect(signal.reason).toBe(null);
+		});
 	});
 
 	describe('AbortSignal.timeout()', () => {

--- a/packages/happy-dom/test/fetch/AbortSignal.test.ts
+++ b/packages/happy-dom/test/fetch/AbortSignal.test.ts
@@ -71,7 +71,7 @@ describe('AbortSignal', () => {
 				await vi.waitUntil(() => Date.now() - now > 100);
 				await fetch('https://example.com', { signal });
 			} catch (e) {
-				expect((e as Error).name).toStrictEqual('TimeoutError');
+				expect((<Error>e).name).toStrictEqual('TimeoutError');
 			}
 		});
 	});

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -17,6 +17,7 @@ import { ReadableStream } from 'stream/web';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import FetchHTTPSCertificate from '../../src/fetch/certificate/FetchHTTPSCertificate.js';
 import * as PropertySymbol from '../../src/PropertySymbol.js';
+import { abort } from 'process';
 
 const LAST_CHUNK = Buffer.from('0\r\n\r\n');
 
@@ -2062,28 +2063,12 @@ describe('Fetch', () => {
 		it('Supports aborting a request using AbortController and AbortSignal.', async () => {
 			const window = new Window({ url: 'https://localhost:8080/' });
 			const url = 'https://localhost:8080/test/';
-			const responseText = 'some response text';
 
 			mockModule('https', {
 				request: () => {
 					return {
 						end: () => {},
-						on: (event: string, callback: (response: HTTP.IncomingMessage) => void) => {
-							if (event === 'response') {
-								setTimeout(() => {
-									async function* generate(): AsyncGenerator<Buffer> {
-										yield Buffer.from(responseText);
-									}
-									const response = <HTTP.IncomingMessage>Stream.Readable.from(generate());
-
-									response.statusCode = 200;
-									response.headers = {};
-									response.rawHeaders = [];
-
-									callback(response);
-								}, 20);
-							}
-						},
+						on: () => {},
 						setTimeout: () => {},
 						destroy: () => {}
 					};
@@ -2105,11 +2090,76 @@ describe('Fetch', () => {
 			}
 
 			expect(error).toEqual(
-				new DOMException(
-					'The operation was aborted. AbortError: signal is aborted without reason',
-					DOMExceptionNameEnum.abortError
-				)
+				new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 			);
+		});
+
+		it('Supports aborting a request using AbortSignal.timeout()', async () => {
+			const window = new Window({ url: 'https://localhost:8080/' });
+
+			mockModule('https', {
+				request: () => {
+					return {
+						end: () => {},
+						on: () => {},
+						setTimeout: () => {},
+						destroy: () => {}
+					};
+				}
+			});
+
+			const signal = window.AbortSignal.timeout(10);
+
+			let error: Error | null = null;
+
+			try {
+				await window.fetch('https://localhost:8080/test/', { signal });
+			} catch (e) {
+				error = e;
+			}
+
+			expect(error).toBeInstanceOf(window.DOMException);
+			expect((<Error>error).name).toBe('TimeoutError');
+			expect((<Error>error).message).toBe('signal timed out');
+		});
+
+		it('Supports an already aborted signal using a custom reason', async () => {
+			const window = new Window({ url: 'https://localhost:8080/' });
+			const abortController = new window.AbortController();
+			const abortSignal = abortController.signal;
+
+			abortController.abort(1);
+
+			let error: Error | null = null;
+
+			try {
+				await window.fetch('https://example.com', { signal: abortSignal });
+			} catch (e) {
+				error = e;
+			}
+
+			expect(error).toBe(1);
+		});
+
+		it('Supports aborting a request using AbortController and AbortSignal with a custom reason', async () => {
+			const window = new Window({ url: 'https://localhost:8080/' });
+
+			const abortController = new window.AbortController();
+			const abortSignal = abortController.signal;
+
+			setTimeout(() => {
+				abortController.abort(1);
+			}, 10);
+
+			let error: Error | null = null;
+
+			try {
+				await window.fetch('https://localhost:8080/test/', { signal: abortSignal });
+			} catch (e) {
+				error = e;
+			}
+
+			expect(error).toBe(1);
 		});
 
 		it('Supports aborting a redirect request using AbortController and AbortSignal.', async () => {
@@ -2154,7 +2204,7 @@ describe('Fetch', () => {
 
 			setTimeout(() => {
 				abortController.abort();
-			}, 20);
+			}, 15);
 
 			try {
 				await window.fetch(url1, { method: 'GET', signal: abortSignal });
@@ -2163,10 +2213,7 @@ describe('Fetch', () => {
 			}
 
 			expect(error).toEqual(
-				new DOMException(
-					'The operation was aborted. AbortError: signal is aborted without reason',
-					DOMExceptionNameEnum.abortError
-				)
+				new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 			);
 		});
 		it('Supports aborting multiple ongoing requests using AbortController.', async () => {
@@ -2213,16 +2260,10 @@ describe('Fetch', () => {
 				const onFetchCatch = (): void => {
 					if (error1 && error2) {
 						expect(error1).toEqual(
-							new DOMException(
-								'The operation was aborted. AbortError: signal is aborted without reason',
-								DOMExceptionNameEnum.abortError
-							)
+							new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 						);
 						expect(error2).toEqual(
-							new DOMException(
-								'The operation was aborted. AbortError: signal is aborted without reason',
-								DOMExceptionNameEnum.abortError
-							)
+							new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 						);
 						resolve(null);
 					}
@@ -2256,7 +2297,7 @@ describe('Fetch', () => {
 				error = e;
 			}
 			expect(error).toEqual(
-				new DOMException('The operation was aborted.', DOMExceptionNameEnum.abortError)
+				new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 			);
 		});
 
@@ -2443,10 +2484,7 @@ describe('Fetch', () => {
 			}
 
 			expect(error).toEqual(
-				new DOMException(
-					'The operation was aborted. AbortError: signal is aborted without reason',
-					DOMExceptionNameEnum.abortError
-				)
+				new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 			);
 		});
 

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -17,7 +17,6 @@ import { ReadableStream } from 'stream/web';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import FetchHTTPSCertificate from '../../src/fetch/certificate/FetchHTTPSCertificate.js';
 import * as PropertySymbol from '../../src/PropertySymbol.js';
-import { abort } from 'process';
 
 const LAST_CHUNK = Buffer.from('0\r\n\r\n');
 

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -2103,8 +2103,34 @@ describe('SyncFetch', () => {
 				error = e;
 			}
 			expect(error).toEqual(
-				new DOMException('The operation was aborted.', DOMExceptionNameEnum.abortError)
+				new DOMException('signal is aborted without reason', DOMExceptionNameEnum.abortError)
 			);
+		});
+
+		it('Rejects immediately if signal has already been aborted using a custom reason.', () => {
+			browserFrame.url = 'https://localhost:8080/';
+
+			const url = 'https://localhost:8080/test/';
+
+			const abortController = new window.AbortController();
+			const abortSignal = abortController.signal;
+
+			abortController.abort(1);
+
+			let error: Error | null = null;
+			try {
+				new SyncFetch({
+					browserFrame,
+					window,
+					url,
+					init: {
+						signal: abortSignal
+					}
+				}).send();
+			} catch (e) {
+				error = e;
+			}
+			expect(error).toBe(1);
 		});
 
 		it('Supports POST request with body as string.', () => {


### PR DESCRIPTION
close #1718