### PR TITLE
refactor: Node API replaces cp command

### DIFF
--- a/packages/jest-environment/bin/copy-tsdef-for-lit.cjs
+++ b/packages/jest-environment/bin/copy-tsdef-for-lit.cjs
@@ -24,9 +24,9 @@ async function copyTsDefFiles(lib) {
 
 	const files = await fsp.readdir(srcDir);
 
-	const tsDefFiles = files.filter(file => file.endsWith('.d.ts'));
+	const tsDefFiles = files.filter((file) => file.endsWith('.d.ts'));
 
-	const copyPromises = tsDefFiles.map(file => {
+	const copyPromises = tsDefFiles.map((file) => {
 		const srcFile = Path.join(srcDir, file);
 		const destFile = Path.join(destDir, file);
 		return fsp.copyFile(srcFile, destFile);
@@ -35,9 +35,7 @@ async function copyTsDefFiles(lib) {
 }
 
 async function main() {
-	await Promise.all(
-		LIBS.map(lib => copyTsDefFiles(lib))
-	);
+	await Promise.all(LIBS.map((lib) => copyTsDefFiles(lib)));
 }
 
 process.on('unhandledRejection', (reason) => {

--- a/packages/jest-environment/bin/copy-tsdef-for-lit.cjs
+++ b/packages/jest-environment/bin/copy-tsdef-for-lit.cjs
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires*/
 
 const Path = require('path');
-const ChildProcess = require('child_process');
+const fsp = require('fs/promises');
 
 const LIBS = ['@lit/reactive-element', 'lit', 'lit-element', 'lit-html'];
 
@@ -16,25 +16,27 @@ function getLibPath(lib) {
 	return Path.join(split[0], 'node_modules', modulePath);
 }
 
+async function copyTsDefFiles(lib) {
+	const srcDir = getLibPath(lib);
+	const destDir = Path.resolve(Path.join('lib', 'node_modules', lib));
+
+	await fsp.mkdir(destDir, { recursive: true });
+
+	const files = await fsp.readdir(srcDir);
+
+	const tsDefFiles = files.filter(file => file.endsWith('.d.ts'));
+
+	const copyPromises = tsDefFiles.map(file => {
+		const srcFile = Path.join(srcDir, file);
+		const destFile = Path.join(destDir, file);
+		return fsp.copyFile(srcFile, destFile);
+	});
+	await Promise.all(copyPromises);
+}
+
 async function main() {
 	await Promise.all(
-		LIBS.map(
-			(lib) =>
-				new Promise((resolve, reject) => {
-					ChildProcess.exec(
-						`cp ${Path.join(getLibPath(lib), '*.d.ts')} ${Path.resolve(
-							Path.join('lib', 'node_modules', lib)
-						)}`,
-						(error, stdout, stderr) => {
-							if (error || stderr) {
-								reject(error || new Error(stderr));
-								return;
-							}
-							resolve(stdout);
-						}
-					);
-				})
-		)
+		LIBS.map(lib => copyTsDefFiles(lib))
 	);
 }
 


### PR DESCRIPTION
The node api replaces the cp command, which is not compatible with Windows.