### PR TITLE
fix: [#1772] Set 0 instead of undefined as default in setTimeout to prevent Bun from logging a "TimeoutNaNWarning"

### DIFF
--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -1335,7 +1335,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 							timeout.callback();
 						}
 					}
-				});
+				}, 0);
 
 				zeroDelayTimeout.timeouts = [];
 				this.#browserFrame[PropertySymbol.asyncTaskManager].startTimer(id);


### PR DESCRIPTION
Without this, I get a TimeoutNaNWarning: NaN is not a number. (with bun)

It doesn't seem a bad thing to actually set the timer to 0 for all anyway, but it might very well be something that bun needs to fix