### PR TITLE
fix: [#1779] Allow empty URL string in Request

### DIFF
--- a/packages/happy-dom/src/fetch/Request.ts
+++ b/packages/happy-dom/src/fetch/Request.ts
@@ -66,7 +66,7 @@ export default class Request implements Request {
 			);
 		}
 
-		if (!input) {
+		if (typeof input !== `string` && !input) {
 			throw new window.TypeError(
 				`Failed to contruct 'Request': 1 argument required, only 0 present.`
 			);

--- a/packages/happy-dom/test/fetch/Request.test.ts
+++ b/packages/happy-dom/test/fetch/Request.test.ts
@@ -72,8 +72,9 @@ describe('Request', () => {
 		});
 
 		it('Supports URL as empty string from init object.', () => {
+			window.happyDOM?.setURL('https://example.com/other/path/');
 			const request = new window.Request('');
-			expect(request.url).toBe('');
+			expect(request.url).toBe('https://example.com/other/path/');
 		});
 
 		it('Supports URL as URL object from init object.', () => {

--- a/packages/happy-dom/test/fetch/Request.test.ts
+++ b/packages/happy-dom/test/fetch/Request.test.ts
@@ -71,6 +71,11 @@ describe('Request', () => {
 			expect(request.url).toBe(TEST_URL);
 		});
 
+		it('Supports URL as empty string from init object.', () => {
+			const request = new window.Request('');
+			expect(request.url).toBe('');
+		});
+
 		it('Supports URL as URL object from init object.', () => {
 			const request = new window.Request(new URL(TEST_URL));
 			expect(request.url).toBe(TEST_URL);


### PR DESCRIPTION
* Allow empty request URL string, e.g. when running `window.fetch("")`.
* Fixes #1779