### PR TITLE
fix: [#1775] Anchor tag handles bubbling clicks

### DIFF
--- a/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
+++ b/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
@@ -411,7 +411,7 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 			!event[PropertySymbol.defaultPrevented] &&
 			event.type === 'click' &&
 			event instanceof MouseEvent &&
-			event.eventPhase === EventPhaseEnum.none
+			(event.eventPhase === EventPhaseEnum.none || event.eventPhase === EventPhaseEnum.bubbling)
 		) {
 			const href = this.href;
 

--- a/packages/happy-dom/test/nodes/html-anchor-element/HTMLAnchorElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-anchor-element/HTMLAnchorElement.test.ts
@@ -417,6 +417,39 @@ describe('HTMLAnchorElement', () => {
 			expect(newWindow.closed).toBe(true);
 		});
 
+		it('Navigates the browser when a "click" event bubbles up to an element.', async () => {
+			const browser = new Browser();
+			const page = browser.newPage();
+			const window = page.mainFrame.window;
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(function (): Promise<Response> {
+				return Promise.resolve(<Response>{
+					text: () => Promise.resolve('Test')
+				});
+			});
+
+			const divElement = window.document.createElement('div');
+			const anchorElement = <HTMLAnchorElement>window.document.createElement('a');
+			anchorElement.href = 'https://www.example.com';
+			anchorElement.appendChild(divElement);
+			window.document.body.appendChild(anchorElement);
+
+			divElement.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			const newWindow = page.mainFrame.window;
+
+			expect(newWindow === window).toBe(false);
+			expect(newWindow.location.href).toBe('https://www.example.com/');
+
+			await browser.waitUntilComplete();
+
+			expect(newWindow.document.body.innerHTML).toBe('Test');
+
+			newWindow.close();
+
+			expect(newWindow.closed).toBe(true);
+		});
+
 		it('Navigates the browser when a "click" event is dispatched on an element with target "_blank".', async () => {
 			const browser = new Browser();
 			const page = browser.newPage();


### PR DESCRIPTION
From the spec anchor tags should handle bubbling events.

https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element

This is also the behaviour of Chrome and Firefox.