### PR TITLE
fix: Overwrite existing URL query string on form submit when method is "GET"

### DIFF
--- a/packages/happy-dom/src/nodes/html-form-element/HTMLFormElement.ts
+++ b/packages/happy-dom/src/nodes/html-form-element/HTMLFormElement.ts
@@ -633,6 +633,7 @@ export default class HTMLFormElement extends HTMLElement {
 
 		if (method === 'get') {
 			const url = new URL(action);
+			url.search = '';
 
 			for (const [key, value] of formData) {
 				if (typeof value === 'string') {


### PR DESCRIPTION
Aligns with the [HTML spec](https://html.spec.whatwg.org/#constructing-form-data-set) ("4. Let entry list be a new empty entry list.") and observed behaviour in browsers. Previously the existing query string would be appended to.