### PR TITLE
fix!: [#1774] Handle enctype for form submissions

### DIFF
--- a/packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts
+++ b/packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts
@@ -39,7 +39,7 @@ export default class BrowserFrameNavigator {
 		url: string;
 		goToOptions?: IGoToOptions;
 		method?: string;
-		formData?: FormData | null;
+		formData?: FormData | URLSearchParams | null;
 		disableHistory?: boolean;
 	}): Promise<Response | null> {
 		const { windowClass, frame, url, formData, method, goToOptions, disableHistory } = options;

--- a/packages/happy-dom/src/history/IHistoryItem.ts
+++ b/packages/happy-dom/src/history/IHistoryItem.ts
@@ -7,6 +7,6 @@ export default interface IHistoryItem {
 	state: any | null;
 	scrollRestoration: HistoryScrollRestorationEnum;
 	method: string;
-	formData: FormData | null;
+	formData: FormData | URLSearchParams | null;
 	isCurrent: boolean;
 }

--- a/packages/happy-dom/src/nodes/html-form-element/HTMLFormElement.ts
+++ b/packages/happy-dom/src/nodes/html-form-element/HTMLFormElement.ts
@@ -19,6 +19,7 @@ import Element from '../element/Element.js';
 import EventTarget from '../../event/EventTarget.js';
 import HTMLDialogElement from '../html-dialog-element/HTMLDialogElement.js';
 import ElementEventAttributeUtility from '../element/ElementEventAttributeUtility.js';
+import type FormData from '../../form-data/FormData.js';
 
 /**
  * HTML Form Element.
@@ -597,6 +598,9 @@ export default class HTMLFormElement extends HTMLElement {
 		const action = submitter?.hasAttribute('formaction')
 			? submitter?.formAction || this.action
 			: this.action;
+		const enctype = submitter?.hasAttribute('formenctype')
+			? submitter.formEnctype || this.enctype
+			: this.enctype;
 		const browserFrame = new WindowBrowserContext(this[PropertySymbol.window]).getBrowserFrame();
 
 		if (!browserFrame) {
@@ -654,6 +658,18 @@ export default class HTMLFormElement extends HTMLElement {
 			return;
 		}
 
+		let navigateBody: FormData | URLSearchParams;
+		if (enctype === 'multipart/form-data') {
+			navigateBody = formData;
+		} else {
+			navigateBody = new URLSearchParams();
+			for (const [key, value] of formData) {
+				if (typeof value === 'string') {
+					navigateBody.append(key, value);
+				}
+			}
+		}
+
 		BrowserFrameNavigator.navigate({
 			windowClass: <typeof BrowserWindow>(
 				this[PropertySymbol.ownerDocument][PropertySymbol.defaultView].constructor
@@ -661,7 +677,7 @@ export default class HTMLFormElement extends HTMLElement {
 			frame: targetFrame,
 			method: method,
 			url: action,
-			formData,
+			formData: navigateBody,
 			goToOptions: {
 				referrer: browserFrame.page.mainFrame.window.location.origin
 			}

--- a/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
@@ -650,7 +650,7 @@ describe('HTMLFormElement', () => {
 				expect(
 					(<Request>(<unknown>request)).headers
 						.get('Content-Type')
-						?.startsWith('multipart/form-data; boundary=----HappyDOMFormDataBoundary')
+						?.startsWith('application/x-www-form-urlencoded')
 				).toBe(true);
 
 				const requestFormData = await (<Request>(<unknown>request)).formData();
@@ -674,6 +674,54 @@ describe('HTMLFormElement', () => {
 				expect(page.mainFrame.window.document.body.innerHTML).toBe('Test');
 			});
 		}
+
+		it(`Supports enctype`, async () => {
+			const documentBody = `
+                    <button form="form-id" formenctype="multipart/form-data">Submit</button>
+                    <form id="form-id" action="http://example.com" method="post" enctype="application/x-www-form-urlencoded">
+                        <input type="text" name="text1" value="value1">
+		                    <input type="submit" name="button1" formenctype="multipart/form-data">
+                    </form>
+                `;
+			let request: Request | null = null;
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(function (): Promise<Response> {
+				request = this.request;
+				return Promise.resolve(<Response>{
+					url: request?.url,
+					text: () => Promise.resolve(documentBody)
+				});
+			});
+
+			const browser = new Browser();
+			const page = browser.newPage();
+
+			page.mainFrame.window.document.write(documentBody);
+
+			(<HTMLElement>page.mainFrame.window.document.body.children[0]).click();
+			await page.mainFrame.waitForNavigation();
+			expect(
+				(<Request>(<unknown>request)).headers
+					.get('Content-Type')
+					?.startsWith('multipart/form-data; boundary=----HappyDOMFormDataBoundary')
+			).toBe(true);
+
+			(<HTMLFormElement>page.mainFrame.window.document.body.children[1]).submit();
+			await page.mainFrame.waitForNavigation();
+			expect(
+				(<Request>(<unknown>request)).headers
+					.get('Content-Type')
+					?.startsWith('application/x-www-form-urlencoded')
+			).toBe(true);
+
+			(<HTMLElement>page.mainFrame.window.document.body.children[1]['button1']).click();
+			await page.mainFrame.waitForNavigation();
+			expect(
+				(<Request>(<unknown>request)).headers
+					.get('Content-Type')
+					?.startsWith('multipart/form-data; boundary=----HappyDOMFormDataBoundary')
+			).toBe(true);
+		});
 
 		it(`Supports "_self" as target.`, async () => {
 			let request: Request | null = null;


### PR DESCRIPTION
Forms now correctly handle `<form enctype="...">`, `<button formenctype="...">`, and `<input type="button" formenctype="...">`.

Limitations:
1. `text/plain` is not supported.
2. `<input type="image">` is not supported.

BREAKING CHANGE: The default encoding for form submissions is now `application/x-www-form-urlencoded` instead of `multipart/form-data`

PR Notes:
1. I've opted to change the `formData` field on `BrowserFrameNavigator.navigate` to allow passing in `URLSearchParams` instead of adding a new field or renaming the field as that seemed to be the simplest approach. That being said, this also now adds that as an option to the `IHistoryItem` field which might also result in a breaking change in types, so I'm happy to revisit this.
2. We could reuse the logic that creates the `URLSearchParams` in the `GET` submission and here, but that might be better done after #1786 has landed.
3. Submitting a form that contains `<input type="file">` without specifying `enctype="multipart/form-data"` will submit the form with `application/x-www-form-urlencoded` resulting in a `file=<filename>` body without any file contents which doesn't make much sense but does align with browser behaviour.