### PR TITLE
fix [#1788]: preserve slashes in filename and match browser behavior

### DIFF
--- a/packages/happy-dom/src/file/File.ts
+++ b/packages/happy-dom/src/file/File.ts
@@ -37,7 +37,7 @@ export default class File extends Blob {
 
 		super(bits, options);
 
-		this.name = name.replace(/\//g, ':');
+		this.name = name;
 		this.lastModified = options && options.lastModified ? options.lastModified : Date.now();
 	}
 }


### PR DESCRIPTION
The File constructor was incorrectly replacing slashes (/) in the filename with colons (:), resulting in names like "foo:bar.jpg" instead of the expected "foo/bar.jpg".

This commit updates the behavior to align with browser implementations:
- Slashes in the provided filename are preserved.

Reference: 
https://github.com/jsdom/jsdom/commit/2ab99ad18d58585e4958aca0911ed142fac80b71
https://developer.mozilla.org/en-US/docs/Web/API/File/File#filename