### PR TITLE
chore: [#1795] Replace old Angular domain angular.io with angular.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ And much more..
  - [Vue](https://vuejs.org/)
  - [React](https://reactjs.org)
  - [Svelte](https://svelte.dev/)
- - [Angular](https://angular.io/)
+ - [Angular](https://angular.dev/)
 
 ## Sponsors
 

--- a/packages/happy-dom/README.md
+++ b/packages/happy-dom/README.md
@@ -22,7 +22,7 @@ And much more..
 
 ## Works With
 
-[Vitest](https://vitest.dev/) | [Bun](https://bun.sh) | [Jest](https://jestjs.io/) | [Testing Library](https://testing-library.com/) | [Google LitElement](https://lit.dev/) | [Vue](https://vuejs.org/) | [React](https://reactjs.org) | [Svelte](https://svelte.dev/) | [Angular](https://angular.io/)
+[Vitest](https://vitest.dev/) | [Bun](https://bun.sh) | [Jest](https://jestjs.io/) | [Testing Library](https://testing-library.com/) | [Google LitElement](https://lit.dev/) | [Vue](https://vuejs.org/) | [React](https://reactjs.org) | [Svelte](https://svelte.dev/) | [Angular](https://angular.dev/)
 
 ## Module Systems
 


### PR DESCRIPTION
Fix for https://github.com/capricorn86/happy-dom/issues/1795