### PR TITLE
fix: [#1803] Fixes issue where the sibling obtained when MutationObserver monitors node removal was null

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -548,13 +548,6 @@ export default class Node extends EventTarget {
 			node = node[PropertySymbol.proxy];
 		}
 
-		const previousSibling = node.previousSibling;
-		const nextSibling = node.nextSibling;
-
-		node[PropertySymbol.parentNode] = null;
-
-		node[PropertySymbol.clearCache]();
-
 		const index = this[PropertySymbol.nodeArray].indexOf(node);
 
 		if (index === -1) {
@@ -562,6 +555,13 @@ export default class Node extends EventTarget {
 				`Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`
 			);
 		}
+
+		const previousSibling = node.previousSibling;
+		const nextSibling = node.nextSibling;
+
+		node[PropertySymbol.parentNode] = null;
+
+		node[PropertySymbol.clearCache]();
 
 		this[PropertySymbol.nodeArray].splice(index, 1);
 

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -548,6 +548,9 @@ export default class Node extends EventTarget {
 			node = node[PropertySymbol.proxy];
 		}
 
+		const previousSibling = node.previousSibling;
+		const nextSibling = node.nextSibling;
+
 		node[PropertySymbol.parentNode] = null;
 
 		node[PropertySymbol.clearCache]();
@@ -590,7 +593,9 @@ export default class Node extends EventTarget {
 			new MutationRecord({
 				target: this[PropertySymbol.proxy] || this,
 				type: MutationTypeEnum.childList,
-				removedNodes: [node]
+				removedNodes: [node],
+				previousSibling,
+				nextSibling
 			})
 		);
 

--- a/packages/happy-dom/test/mutation-observer/MutationObserver.test.ts
+++ b/packages/happy-dom/test/mutation-observer/MutationObserver.test.ts
@@ -196,6 +196,10 @@ describe('MutationObserver', () => {
 			const div = document.createElement('div');
 			const span = document.createElement('span');
 			const article = document.createElement('article');
+			const h1 = document.createElement('h1');
+			const h2 = document.createElement('h2');
+			const h3 = document.createElement('h3');
+			const h4 = document.createElement('h4');
 			const text = document.createTextNode('old');
 			const observer = new window.MutationObserver((mutationRecords) => {
 				records.push(mutationRecords);
@@ -203,7 +207,14 @@ describe('MutationObserver', () => {
 			observer.observe(div, { subtree: true, childList: true });
 			div.appendChild(text);
 			div.appendChild(span);
+			article.appendChild(h1);
+			article.appendChild(h2);
+			article.appendChild(h3);
+			article.appendChild(h4);
 			span.appendChild(article);
+			article.removeChild(h2);
+			article.removeChild(h4);
+			article.removeChild(h1);
 			span.removeChild(article);
 
 			await new Promise((resolve) => setTimeout(resolve, 1));
@@ -241,6 +252,39 @@ describe('MutationObserver', () => {
 						previousSibling: null,
 						removedNodes: [],
 						target: span,
+						type: 'childList'
+					},
+					{
+						addedNodes: [],
+						attributeName: null,
+						attributeNamespace: null,
+						nextSibling: h3,
+						oldValue: null,
+						previousSibling: h1,
+						removedNodes: [h2],
+						target: article,
+						type: 'childList'
+					},
+					{
+						addedNodes: [],
+						attributeName: null,
+						attributeNamespace: null,
+						nextSibling: null,
+						oldValue: null,
+						previousSibling: h3,
+						removedNodes: [h4],
+						target: article,
+						type: 'childList'
+					},
+					{
+						addedNodes: [],
+						attributeName: null,
+						attributeNamespace: null,
+						nextSibling: h3,
+						oldValue: null,
+						previousSibling: null,
+						removedNodes: [h1],
+						target: article,
 						type: 'childList'
 					},
 					{


### PR DESCRIPTION
Fixes: https://github.com/capricorn86/happy-dom/issues/1803

The test content is consistent with browser behavior:
> ![image](https://github.com/user-attachments/assets/fbe5718f-3094-45aa-b2cd-2407cb0284b6)
