### PR TITLE
fix: [#1837] CSS_VARIABLE_REGEXP fails to correctly parse var() inside other functions

### DIFF
--- a/packages/happy-dom/test/css/declaration/computed-style/CSSStyleDeclarationComputedStyle.test.ts
+++ b/packages/happy-dom/test/css/declaration/computed-style/CSSStyleDeclarationComputedStyle.test.ts
@@ -28,5 +28,27 @@ describe('CSSStyleDeclarationElementStyle', () => {
 
 			expect(computedElementStyleDeclaration.getComputedStyle()).not.toBe(computedElementStyle);
 		});
+		it('parses variables correctly.', () => {
+			document.body.appendChild(element);
+			element.setAttribute(
+				'style',
+				`--bg-color: rgb(0 128 0 / 1); background-color: var(--bg-color);`
+			);
+
+			const computedElementStyleDeclaration = new CSSStyleDeclarationElementStyle(element);
+			const computedElementStyle = computedElementStyleDeclaration.getComputedStyle();
+			expect(computedElementStyle.get('background-color').value).toBe('rgb(0 128 0 / 1)');
+		});
+		it('parses nested variables correctly.', () => {
+			document.body.appendChild(element);
+			element.setAttribute(
+				'style',
+				`--bg-color-alpha: 1; background-color: rgb(0 128 0 / var(--bg-color-alpha, 1));`
+			);
+
+			const computedElementStyleDeclaration = new CSSStyleDeclarationElementStyle(element);
+			const computedElementStyle = computedElementStyleDeclaration.getComputedStyle();
+			expect(computedElementStyle.get('background-color').value).toBe('rgb(0 128 0 / 1)');
+		});
 	});
 });


### PR DESCRIPTION
This is to demo #1837 and show that the tests are failing.

I can work on making fixes as you have suggestions.