### PR TITLE
chore: [#1541] Set time zone when running unit tests

### DIFF
--- a/packages/happy-dom/test/setup.ts
+++ b/packages/happy-dom/test/setup.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { vi, beforeAll } from 'vitest';
 
 const mockedModuleNames = ['child_process', 'http', 'https'];
 const mockedModuleImplementations = {};
@@ -68,4 +68,8 @@ vi.mock('https', async (importOriginal) => {
 			mockedModuleImplementations['https'].default || mockedModuleImplementations['https'];
 	}
 	return mockedModuleImplementations['https'];
+});
+
+beforeAll(() => {
+	process.env.TZ = 'Etc/GMT-2';
 });


### PR DESCRIPTION
I pulled down the repo to contribute a patch and noticed that two of the tests immediately failed on my device here in the US. I found #1541, which described the same issue and suggested this fix. Setting `TZ` when you have tests involving dates is, I think, fairly standard.

✅ With this change, all tests pass on my machine.