### PR TITLE
fix: [#1882] Fix caching in querySelector and avoid sort

### DIFF
--- a/packages/happy-dom/src/query-selector/QuerySelector.ts
+++ b/packages/happy-dom/src/query-selector/QuerySelector.ts
@@ -249,8 +249,9 @@ export default class QuerySelector {
 			(node[PropertySymbol.ownerDocument] || node)[PropertySymbol.affectsCache].push(cachedItem);
 		}
 
-		const matchesMap: Map<string, Element> = new Map();
-		const matchedPositions: string[] = [];
+		let bestMatch: DocumentPositionAndElement | null = null;
+		const matchesMap: Map<string, boolean> = new Map();
+
 		for (const items of SelectorParser.getSelectorGroups(selector)) {
 			const match =
 				node[PropertySymbol.nodeType] === NodeTypeEnum.elementNode
@@ -258,17 +259,18 @@ export default class QuerySelector {
 					: this.findFirst(null, (<Element>node)[PropertySymbol.elementArray], items, cachedItem);
 
 			if (match && !matchesMap.has(match.documentPosition)) {
-				matchesMap.set(match.documentPosition, match.element);
-				matchedPositions.push(match.documentPosition);
+				matchesMap.set(match.documentPosition, true);
+				if (!bestMatch || match.documentPosition < bestMatch.documentPosition) {
+					bestMatch = match;
+				}
 			}
 		}
 
-		if (matchedPositions.length > 0) {
-			const keys = matchedPositions.sort();
-			return matchesMap.get(keys[0])!;
-		}
+		const element = bestMatch?.element || null;
 
-		return null;
+		cachedItem.result = element ? new WeakRef(element) : null;
+
+		return element;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1882

This pull request optimizes the `querySelector` method by fixing caching and avoiding an unnecessary sort step.

### Caching Bug Fix

**The Bug:**

The previous implementation of `querySelector` did not update the cache with the result of the query. It would read from the cache, but it would never write the result back to the cache. This meant that for repeated calls with the same selector, the query would be re-executed every time, negating the benefits of caching.

**The Fix:**

The new implementation correctly updates the cache with the result of the query. If an element is found, a `WeakRef` to it is stored in the cache. If no element is found, `null` is stored.

**Cache Invalidation:**

`happy-dom` invalidates the cache for all selectors that were affected by the change. The existing unit test coverage confirms that stale values are not returned from the cache.

### Sorting Algorithm Improvement

In this analysis:

- `n` is the total number of nodes in the DOM (or the relevant subtree).
- `g` is the number of selector groups in the query (e.g., `div, p` has `g=2`).

**Old Algorithm:**

1. **Find Matches:** For each of the `g` selector groups, the algorithm would traverse the DOM to find the first matching element. In the worst case, this traversal could visit all `n` nodes. This step is repeated for each group, so the complexity is `O(g * n)`.
2. **Sort Matches:** The `g` matched elements were then sorted to determine the first one in document order. The complexity of this sort is `O(g log g)`.

The total complexity of the old algorithm was **O(g \* n + g log g)**.

**New Algorithm:**

1. **Find Matches and Compare:** The new algorithm also traverses the DOM for each of the `g` selector groups. However, instead of collecting all matches and sorting them at the end, it maintains a running "best candidate". When a new match is found, it's compared to the current best, which is a constant time `O(1)` operation.

The total complexity of the new algorithm is **O(g \* n)**, making it more efficient for selectors with multiple selector groups.
