### PR TITLE
feat: [#1884] Use classList.contains instead of splitting className

### DIFF
--- a/packages/happy-dom/src/query-selector/SelectorItem.ts
+++ b/packages/happy-dom/src/query-selector/SelectorItem.ts
@@ -7,8 +7,6 @@ import ISelectorAttribute from './ISelectorAttribute.js';
 import ISelectorMatch from './ISelectorMatch.js';
 import ISelectorPseudo from './ISelectorPseudo.js';
 
-const SPACE_REGEXP = /\s+/;
-
 /**
  * Selector item.
  */
@@ -430,11 +428,10 @@ export default class SelectorItem {
 			return null;
 		}
 
-		const classList = element.className.split(SPACE_REGEXP);
 		let priorityWeight = 0;
 
 		for (const className of this.classNames) {
-			if (!classList.includes(className)) {
+			if (!element.classList.contains(className)) {
 				return null;
 			}
 			priorityWeight += 10;


### PR DESCRIPTION
Resolves #1884

This change should yield a small performance improvement.

Note that the splitting logic was introduced by https://github.com/capricorn86/happy-dom/pull/386, which was a bugfix. However, the tests introduced by that PR (which should cover the issue it describes) still pass with `contains`.