### PR TITLE
feat: [#1886] Use RegExp to convert ASCII character casing

### DIFF
--- a/packages/happy-dom/src/utilities/StringUtility.ts
+++ b/packages/happy-dom/src/utilities/StringUtility.ts
@@ -1,5 +1,7 @@
 const ASCII_LOWER_CASE_CACHE: Map<string, string> = new Map();
 const ASCII_UPPER_CASE_CACHE: Map<string, string> = new Map();
+const ASCII_UPPER_CASE_REGEXP = /[A-Z]/g;
+const ASCII_LOWER_CASE_REGEXP = /[a-z]/g;
 
 /**
  * String utility.
@@ -17,15 +19,9 @@ export default class StringUtility {
 		if (cached) {
 			return cached;
 		}
-		let newText = '';
-		for (const char of text) {
-			const value = char.charCodeAt(0);
-			if (value >= 65 && value <= 90) {
-				newText += String.fromCharCode(value + 32);
-			} else {
-				newText += char;
-			}
-		}
+		const newText = text.replace(ASCII_UPPER_CASE_REGEXP, (char) =>
+			String.fromCharCode(char.charCodeAt(0) + 32)
+		);
 		ASCII_LOWER_CASE_CACHE.set(text, newText);
 		return newText;
 	}
@@ -42,15 +38,9 @@ export default class StringUtility {
 		if (cached) {
 			return cached;
 		}
-		let newText = '';
-		for (const char of text) {
-			const value = char.charCodeAt(0);
-			if (value >= 97 && value <= 122) {
-				newText += String.fromCharCode(value - 32);
-			} else {
-				newText += char;
-			}
-		}
+		const newText = text.replace(ASCII_LOWER_CASE_REGEXP, (char) =>
+			String.fromCharCode(char.charCodeAt(0) - 32)
+		);
 		ASCII_UPPER_CASE_CACHE.set(text, newText);
 		return newText;
 	}

--- a/packages/happy-dom/test/utilities/StringUtility.test.ts
+++ b/packages/happy-dom/test/utilities/StringUtility.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import StringUtility from '../../src/utilities/StringUtility';
+
+describe('StringUtility', () => {
+	describe('asciiLowerCase()', () => {
+		it('converts uppercase ASCII characters to lowercase.', () => {
+			expect(StringUtility.asciiLowerCase('HELLO')).toBe('hello');
+		});
+
+		it('returns the same string if it is already lowercase.', () => {
+			expect(StringUtility.asciiLowerCase('hello')).toBe('hello');
+		});
+
+		it('converts mixed case ASCII characters to lowercase.', () => {
+			expect(StringUtility.asciiLowerCase('HeLlO')).toBe('hello');
+		});
+
+		it('leaves non-ASCII characters unchanged.', () => {
+			expect(StringUtility.asciiLowerCase('HéLLÖ')).toBe('héllö');
+		});
+
+		it('handles empty strings.', () => {
+			expect(StringUtility.asciiLowerCase('')).toBe('');
+		});
+
+		it('leaves numbers and symbols unchanged.', () => {
+			expect(StringUtility.asciiLowerCase('H3LL0!@#')).toBe('h3ll0!@#');
+		});
+	});
+
+	describe('asciiUpperCase()', () => {
+		it('converts lowercase ASCII characters to uppercase.', () => {
+			expect(StringUtility.asciiUpperCase('hello')).toBe('HELLO');
+		});
+
+		it('returns the same string if it is already uppercase.', () => {
+			expect(StringUtility.asciiUpperCase('HELLO')).toBe('HELLO');
+		});
+
+		it('converts mixed case ASCII characters to uppercase.', () => {
+			expect(StringUtility.asciiUpperCase('HeLlO')).toBe('HELLO');
+		});
+
+		it('leaves non-ASCII characters unchanged.', () => {
+			expect(StringUtility.asciiUpperCase('hélLö')).toBe('HéLLÖ');
+		});
+
+		it('handles empty strings.', () => {
+			expect(StringUtility.asciiUpperCase('')).toBe('');
+		});
+
+		it('leaves numbers and symbols unchanged.', () => {
+			expect(StringUtility.asciiUpperCase('h3ll0!@#')).toBe('H3LL0!@#');
+		});
+	});
+});


### PR DESCRIPTION
This PR converts the loops used to convert ASCII character casing in `StringUtils` to regular expressions, which should be more efficient. I've also added unit tests to prevent regressions.

As an aside, it would be interesting to do some benchmarks to see how much benefit the caches have here. I'm sure a cache lookup is a bit faster than the regex, but the tradeoff is that the caches could potentially consume quite a bit of extra memory in a DOM with lots of custom tags and attributes.