### PR TITLE
fix: [#1888] Replaces inefficient loops for clearing children

### DIFF
--- a/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
+++ b/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
@@ -84,10 +84,7 @@ export default class DocumentFragment extends Node {
 	 * @param textContent Text content.
 	 */
 	public set textContent(textContent: string) {
-		const childNodes = this[PropertySymbol.nodeArray];
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 		if (textContent) {
 			this.appendChild(this[PropertySymbol.ownerDocument].createTextNode(textContent));
 		}

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1723,10 +1723,7 @@ export default class Document extends Node {
 			}
 		}
 
-		const childNodes = this[PropertySymbol.nodeArray];
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 
 		// Default document elements
 		const doctype = this[PropertySymbol.implementation].createDocumentType('html', '', '');

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -401,10 +401,7 @@ export default class Element
 	 * @param textContent Text content.
 	 */
 	public set textContent(textContent: string) {
-		const childNodes = this[PropertySymbol.nodeArray];
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 		if (textContent) {
 			this.appendChild(this[PropertySymbol.ownerDocument].createTextNode(textContent));
 		}
@@ -425,11 +422,7 @@ export default class Element
 	 * @param html HTML.
 	 */
 	public set innerHTML(html: string) {
-		const childNodes = this[PropertySymbol.nodeArray];
-
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 
 		new HTMLParser(this[PropertySymbol.window]).parse(html, this);
 	}

--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -6,6 +6,7 @@ import NodeTypeEnum from '../node/NodeTypeEnum.js';
 import Event from '../../event/Event.js';
 import HTMLElementUtility from './HTMLElementUtility.js';
 import DOMStringMap from '../../dom/DOMStringMap.js';
+import ParentNodeUtility from '../parent-node/ParentNodeUtility.js';
 import Attr from '../attr/Attr.js';
 import ElementEventAttributeUtility from '../element/ElementEventAttributeUtility.js';
 
@@ -716,11 +717,7 @@ export default class HTMLElement extends Element {
 	 * @param innerText Inner text.
 	 */
 	public set innerText(text: string) {
-		const childNodes = this[PropertySymbol.nodeArray];
-
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 
 		const texts = text.split(/[\n\r]/);
 		const ownerDocument = this[PropertySymbol.ownerDocument];

--- a/packages/happy-dom/src/nodes/html-template-element/HTMLTemplateElement.ts
+++ b/packages/happy-dom/src/nodes/html-template-element/HTMLTemplateElement.ts
@@ -5,6 +5,7 @@ import Node from '../node/Node.js';
 import ShadowRoot from '../shadow-root/ShadowRoot.js';
 import HTMLSerializer from '../../html-serializer/HTMLSerializer.js';
 import HTMLParser from '../../html-parser/HTMLParser.js';
+import ParentNodeUtility from '../parent-node/ParentNodeUtility.js';
 
 /**
  * HTML Template Element.
@@ -41,11 +42,8 @@ export default class HTMLTemplateElement extends HTMLElement {
 	 */
 	public override set innerHTML(html: string) {
 		const content = <DocumentFragment>this[PropertySymbol.content];
-		const childNodes = content[PropertySymbol.nodeArray];
 
-		while (childNodes.length) {
-			content.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(content);
 
 		new HTMLParser(this[PropertySymbol.window], { isTemplateDocumentFragment: true }).parse(
 			html,

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -445,9 +445,14 @@ export default class Node extends EventTarget {
 		// Document has childNodes directly when it is created
 		// We need to remove them
 		if (clone[PropertySymbol.nodeArray].length) {
-			const childNodes = clone[PropertySymbol.nodeArray];
-			while (childNodes.length) {
-				clone.removeChild(childNodes[0]);
+			// Fast-detach clone children using the same algorithm as ParentNodeUtility.clearChildren.
+			const children = clone[PropertySymbol.nodeArray].slice();
+			clone[PropertySymbol.nodeArray].length = 0;
+			clone[PropertySymbol.elementArray].length = 0;
+			for (const child of children) {
+				child[PropertySymbol.parentNode] = null;
+				child[PropertySymbol.clearCache]();
+				child[PropertySymbol.disconnectedFromNode]();
 			}
 		}
 

--- a/packages/happy-dom/src/nodes/shadow-root/ShadowRoot.ts
+++ b/packages/happy-dom/src/nodes/shadow-root/ShadowRoot.ts
@@ -8,6 +8,7 @@ import SVGElement from '../svg-element/SVGElement.js';
 import Document from '../document/Document.js';
 import HTMLSerializer from '../../html-serializer/HTMLSerializer.js';
 import HTMLParser from '../../html-parser/HTMLParser.js';
+import ParentNodeUtility from '../parent-node/ParentNodeUtility.js';
 
 /**
  * ShadowRoot.
@@ -146,11 +147,7 @@ export default class ShadowRoot extends DocumentFragment {
 	 * @param html HTML.
 	 */
 	public set innerHTML(html: string) {
-		const childNodes = this[PropertySymbol.nodeArray];
-
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 
 		new HTMLParser(this[PropertySymbol.window]).parse(html, this);
 	}
@@ -218,11 +215,7 @@ export default class ShadowRoot extends DocumentFragment {
 	public setHTMLUnsafe(html: string): void {
 		// TODO: Implement support for declarative shadow roots
 
-		const childNodes = this[PropertySymbol.nodeArray];
-
-		while (childNodes.length) {
-			this.removeChild(childNodes[0]);
-		}
+		ParentNodeUtility.clearChildren(this);
 
 		new HTMLParser(this[PropertySymbol.window]).parse(html, this);
 	}


### PR DESCRIPTION
Fixes #1888

This PR introduces a fast path for clearing all children from a parent node in `O(n)` time and wires it into hot code paths (`innerHTML`, `textContent`, `replaceChildren`, `ShadowRoot.setHTMLUnsafe`, and `Document.open`). It also optimizes cleanup in `Node#[PropertySymbol.cloneNode]` using the same technique. The change improves spec compliance for `MutationObserver` semantics while significantly reducing time and allocations for large subtree clears.

## Motivation

Several core DOM APIs in happy-dom clear a node by repeatedly calling `removeChild(childNodes[0])` in a loop. Each removal from index 0 shifts the array, leading to `O(n²)` behavior and extra GC pressure for large trees. This PR replaces those loops with a single-pass algorithm.

## Design overview

### New utility: `ParentNodeUtility.clearChildren(parent)`

- Detaches and cleans all children in a single sweep.
- Preserves `NodeList` reference identity by truncating arrays (`length = 0`) rather than reassigning them.
- Clears `elementArray` in one step.
- Ensures correct lifecycle transitions (connected/disconnected) and cache invalidations.
- Unobserves subtree mutation observers from removed subtrees as before.

### `Node#[PropertySymbol.cloneNode]` cleanup

Replaces the previous `while (childNodes.length) removeChild(childNodes[0])` pattern with a local fast-detach that snapshots children, truncates arrays (`length = 0`), and then clears parent links/cache and dispatches disconnects per child.

## MutationObserver behavior change (spec compliance)

This PR changes `MutationObserver` behavior to match the DOM specification's ["replace all" algorithm](https://dom.spec.whatwg.org/#concept-node-replace-all).

**Before:** When clearing children (e.g., setting `innerHTML = ''`), happy-dom emitted one `MutationRecord` per removed child node:

```js
// 3 children removed → 3 separate MutationRecords
[
  { removedNodes: [a], nextSibling: b },
  { removedNodes: [b], nextSibling: c },
  { removedNodes: [c], nextSibling: null }
]
```

**After:** A single `MutationRecord` is emitted containing all removed nodes, matching browser behavior per the DOM spec:

```js
// 3 children removed → 1 MutationRecord
[
  { removedNodes: [a, b, c], previousSibling: null, nextSibling: null }
]
```

This is both more spec-compliant and more efficient (one record allocation instead of N).

## Other improvements

- **Type safety:** Reduced `<any>` casts by using proper TypeScript types for internal properties (`IMutationListener`, `Node` properties)
- **Edge case handling:** `clearChildren` returns early with no mutation emitted when the parent has no children
- **Operation order fix:** Ensured `nodeArray` is cleared before calling `disconnectedFromNode()` on removed nodes, matching the order of operations in `removeChild`. This fixes a timing issue that could cause test failures on Node.js 20.