### PR TITLE
fix: [#1890] Fixes XMLHttpRequest `responseText` on partial response

### DIFF
--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
@@ -49,6 +49,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	#response: Response | ISyncResponse | null = null;
 	#responseType: XMLHttpResponseTypeEnum | '' = '';
 	#responseBody: ArrayBuffer | Blob | Document | object | string | null = null;
+	#accumulatedData: Buffer = Buffer.from([]);
 	#readyState: XMLHttpRequestReadyStateEnum = XMLHttpRequestReadyStateEnum.unsent;
 	#overriddenMimeType: string | null = null;
 
@@ -109,7 +110,21 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 				DOMExceptionNameEnum.invalidStateError
 			);
 		}
-		return <string>this.#responseBody ?? '';
+
+		// If response is complete, use the final response body
+		if (this.#responseBody !== null) {
+			return <string>this.#responseBody;
+		}
+
+		// If we're in loading state and have accumulated data, process it
+		if (
+			this.readyState === XMLHttpRequestReadyStateEnum.headersRecieved ||
+			this.readyState === XMLHttpRequestReadyStateEnum.loading
+		) {
+			return <string>this.#accumulatedData.toString() ?? '';
+		}
+
+		return '';
 	}
 
 	/**
@@ -212,6 +227,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#aborted = false;
 		this.#response = null;
 		this.#responseBody = null;
+		this.#accumulatedData = Buffer.from([]);
 		this.#abortController = new window.AbortController();
 		this.#request = new window.Request(url, {
 			method,
@@ -423,13 +439,13 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		const contentLengthNumber =
 			contentLength !== null && !isNaN(Number(contentLength)) ? Number(contentLength) : null;
 		let loaded = 0;
-		let data = Buffer.from([]);
 
 		if (this.#response.body) {
 			let eventError: Error;
 			try {
 				for await (const chunk of this.#response.body) {
-					data = Buffer.concat([data, typeof chunk === 'string' ? Buffer.from(chunk) : chunk]);
+					const chunkBuffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+					this.#accumulatedData = Buffer.concat([this.#accumulatedData, chunkBuffer]);
 					loaded += chunk.length;
 					// We need to re-throw the error as we don't want it to be caught by the try/catch.
 					try {
@@ -457,13 +473,14 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#responseBody = XMLHttpRequestResponseDataParser.parse({
 			window: window,
 			responseType: this.#responseType,
-			data,
+			data: this.#accumulatedData,
 			contentType:
 				this.#overriddenMimeType ||
 				this.#response.headers.get('Content-Type') ||
 				this.#request!.headers.get('Content-Type')
 		});
 		this.#readyState = XMLHttpRequestReadyStateEnum.done;
+		this.#accumulatedData = Buffer.from([]);
 
 		asyncTaskManager.endTask(taskID);
 

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -416,6 +416,51 @@ describe('XMLHttpRequest', () => {
 				`Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was '${XMLHttpResponseTypeEnum.json}').`
 			);
 		});
+
+		it('Should return responseText with correct length during streaming in progress event', async () => {
+			await new Promise((resolve, reject) => {
+				const responseText = 'This is a streaming response';
+
+				vi.spyOn(Fetch.prototype, 'send').mockImplementation(
+					async () =>
+						<Response>{
+							headers: <Headers>new Headers({
+								'Content-Length': String(responseText.length)
+							}),
+							body: new ReadableStream({
+								start(controller) {
+									controller.enqueue(responseText);
+									controller.close();
+								}
+							})
+						}
+				);
+
+				request.open('GET', REQUEST_URL, true);
+
+				let progressTriggered = false;
+
+				request.addEventListener('progress', (event) => {
+					progressTriggered = true;
+					const progressEvent = <ProgressEvent>event;
+					try {
+						expect(request.responseText.length).toBe(progressEvent.loaded);
+						expect(request.responseText).toBe(responseText);
+						resolve(null);
+					} catch (error) {
+						reject(error);
+					}
+				});
+
+				request.addEventListener('load', () => {
+					if (!progressTriggered) {
+						reject(new Error('Progress event was never triggered'));
+					}
+				});
+
+				request.send();
+			});
+		});
 	});
 
 	describe('set responseType()', () => {


### PR DESCRIPTION
Fixes #1890.

Instead of accumulating data to a local variable within `sendAsync`, we move it to a private class property that can be read from `responseText`. Once the response is complete, we reuse and return the complete value - but while streaming the response, we can access the partial response by concatenating the received buffers.