### PR TITLE
fix: [#1952] Fix Document nodes rejected as boundary points in Selection API

### DIFF
--- a/packages/happy-dom/src/selection/Selection.ts
+++ b/packages/happy-dom/src/selection/Selection.ts
@@ -256,7 +256,10 @@ export default class Selection {
 			);
 		}
 
-		if (node[PropertySymbol.ownerDocument] !== this.#ownerDocument) {
+		if (
+			node !== this.#ownerDocument &&
+			node[PropertySymbol.ownerDocument] !== this.#ownerDocument
+		) {
 			return;
 		}
 
@@ -378,7 +381,10 @@ export default class Selection {
 	 * @param offset Offset.
 	 */
 	public extend(node: Node, offset: number): void {
-		if (node[PropertySymbol.ownerDocument] !== this.#ownerDocument) {
+		if (
+			node !== this.#ownerDocument &&
+			node[PropertySymbol.ownerDocument] !== this.#ownerDocument
+		) {
 			return;
 		}
 
@@ -441,7 +447,10 @@ export default class Selection {
 			);
 		}
 
-		if (node[PropertySymbol.ownerDocument] !== this.#ownerDocument) {
+		if (
+			node !== this.#ownerDocument &&
+			node[PropertySymbol.ownerDocument] !== this.#ownerDocument
+		) {
 			return;
 		}
 
@@ -482,8 +491,10 @@ export default class Selection {
 		}
 
 		if (
-			anchorNode[PropertySymbol.ownerDocument] !== this.#ownerDocument ||
-			focusNode[PropertySymbol.ownerDocument] !== this.#ownerDocument
+			(anchorNode !== this.#ownerDocument &&
+				anchorNode[PropertySymbol.ownerDocument] !== this.#ownerDocument) ||
+			(focusNode !== this.#ownerDocument &&
+				focusNode[PropertySymbol.ownerDocument] !== this.#ownerDocument)
 		) {
 			return;
 		}

--- a/packages/happy-dom/test/selection/Selection.test.ts
+++ b/packages/happy-dom/test/selection/Selection.test.ts
@@ -329,6 +329,19 @@ describe('Selection', () => {
 				expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 				expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 			});
+
+			it('Accepts Document node.', () => {
+				selection[method](document, 0);
+
+				expect(selection.rangeCount).toBe(1);
+
+				const newRange = selection.getRangeAt(0);
+
+				expect(newRange.startContainer).toBe(document);
+				expect(newRange.startOffset).toBe(0);
+				expect(newRange.endContainer).toBe(document);
+				expect(newRange.endOffset).toBe(0);
+			});
 		});
 	}
 
@@ -569,6 +582,19 @@ describe('Selection', () => {
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
+
+		it('Accepts Document node.', () => {
+			const text = document.createTextNode('text');
+
+			document.body.appendChild(text);
+
+			selection.collapse(text, 0);
+			selection.extend(document, 0);
+
+			expect(selection.rangeCount).toBe(1);
+			expect(selection.focusNode).toBe(document);
+			expect(selection.focusOffset).toBe(0);
+		});
 	});
 
 	describe('selectAllChildren()', () => {
@@ -590,6 +616,19 @@ describe('Selection', () => {
 			expect(newRange.startOffset).toBe(0);
 			expect(newRange.endContainer).toBe(container);
 			expect(newRange.endOffset).toBe(3);
+		});
+
+		it('Accepts Document node.', () => {
+			selection.selectAllChildren(document);
+
+			expect(selection.rangeCount).toBe(1);
+
+			const newRange = selection.getRangeAt(0);
+
+			expect(newRange.startContainer).toBe(document);
+			expect(newRange.startOffset).toBe(0);
+			expect(newRange.endContainer).toBe(document);
+			expect(newRange.endOffset).toBe(document.childNodes.length);
 		});
 
 		it(`Throws error if node type is ${NodeTypeEnum.documentTypeNode}.`, () => {
@@ -656,6 +695,21 @@ describe('Selection', () => {
 			expect(newRange.endOffset).toBe(2);
 
 			expect(selection.anchorNode).toBe(newRange.endContainer);
+		});
+
+		it('Accepts Document node as boundary point.', () => {
+			const text = document.createTextNode('text');
+
+			document.body.appendChild(text);
+
+			selection.setBaseAndExtent(document, 0, text, 2);
+
+			expect(selection.rangeCount).toBe(1);
+
+			const newRange = selection.getRangeAt(0);
+
+			expect(newRange.startContainer).toBe(document);
+			expect(newRange.endContainer).toBe(text);
 		});
 
 		it('Throws error if wrong offset.', () => {


### PR DESCRIPTION
Fixes #1952

Selection API methods were rejecting Document nodes as boundary points because `document.ownerDocument` is `null`. The validation now accepts nodes that are either the document itself or have a matching ownerDocument.

**Fixed methods:**
- `collapse()`
- `extend()`
- `selectAllChildren()`
- `setBaseAndExtent()`

**Tests:** Added coverage for all four methods with Document nodes.