### PR TITLE
fix: Use internal PropertySymbol.location in BrowserFrameURL to avoid mock interference

### DIFF
--- a/packages/happy-dom/src/browser/utilities/BrowserFrameURL.ts
+++ b/packages/happy-dom/src/browser/utilities/BrowserFrameURL.ts
@@ -1,5 +1,6 @@
 import IBrowserFrame from '../types/IBrowserFrame.js';
 import { URL } from 'url';
+import * as PropertySymbol from '../../PropertySymbol.js';
 
 /**
  * Browser frame URL utility.
@@ -20,7 +21,8 @@ export default class BrowserFrameURL {
 		}
 
 		try {
-			return new URL(url, frame.window.location.href);
+			// Use internal PropertySymbol.location to avoid being affected by mocks on window.location
+			return new URL(url, frame.window[PropertySymbol.location].href);
 		} catch (e) {
 			return new URL('about:blank');
 		}

--- a/packages/happy-dom/test/browser/utilities/BrowserFrameURL.test.ts
+++ b/packages/happy-dom/test/browser/utilities/BrowserFrameURL.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import Browser from '../../../src/browser/Browser';
+import BrowserFrameURL from '../../../src/browser/utilities/BrowserFrameURL';
+import * as PropertySymbol from '../../../src/PropertySymbol';
+
+describe('BrowserFrameURL', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('getRelativeURL()', () => {
+		it('Returns URL resolved against frame location.', () => {
+			const browser = new Browser();
+			const page = browser.defaultContext.newPage();
+			page.mainFrame.url = 'http://localhost:3000/path/';
+
+			const result = BrowserFrameURL.getRelativeURL(page.mainFrame, '/test');
+
+			expect(result.href).toBe('http://localhost:3000/test');
+			expect(result.origin).toBe('http://localhost:3000');
+
+			browser.close();
+		});
+
+		it('Returns about:blank URL for about: protocol.', () => {
+			const browser = new Browser();
+			const page = browser.defaultContext.newPage();
+
+			const result = BrowserFrameURL.getRelativeURL(page.mainFrame, 'about:blank');
+
+			expect(result.href).toBe('about:blank');
+
+			browser.close();
+		});
+
+		it('Returns about:blank URL for javascript: protocol.', () => {
+			const browser = new Browser();
+			const page = browser.defaultContext.newPage();
+
+			const result = BrowserFrameURL.getRelativeURL(page.mainFrame, 'javascript:void(0)');
+
+			expect(result.href).toBe('javascript:void(0)');
+
+			browser.close();
+		});
+
+		it('Returns about:blank when url is null or undefined.', () => {
+			const browser = new Browser();
+			const page = browser.defaultContext.newPage();
+
+			expect(BrowserFrameURL.getRelativeURL(page.mainFrame, null).href).toBe('about:blank');
+			expect(BrowserFrameURL.getRelativeURL(page.mainFrame, undefined).href).toBe('about:blank');
+
+			browser.close();
+		});
+
+		it('Returns correct URL when window.location getter is mocked with partial mock.', () => {
+			const browser = new Browser();
+			const page = browser.defaultContext.newPage();
+			page.mainFrame.url = 'http://localhost:3000/path/';
+
+			// Mock window.location getter with a partial mock (missing href, origin, etc.)
+			// This simulates what testing frameworks like Jest do when mocking window.location
+			const mockLocation = {
+				reload: vi.fn()
+			};
+
+			Object.defineProperty(page.mainFrame.window, 'location', {
+				get: () => mockLocation,
+				configurable: true
+			});
+
+			// Verify the mock is in place - window.location should return our mock
+			expect(page.mainFrame.window.location).toBe(mockLocation);
+			expect(page.mainFrame.window.location.href).toBeUndefined();
+
+			// But internal PropertySymbol.location should still return the real location
+			expect(page.mainFrame.window[PropertySymbol.location].href).toBe(
+				'http://localhost:3000/path/'
+			);
+
+			// getRelativeURL should still work correctly using internal location
+			const result = BrowserFrameURL.getRelativeURL(page.mainFrame, '/test');
+
+			expect(result.href).toBe('http://localhost:3000/test');
+			expect(result.origin).toBe('http://localhost:3000');
+
+			browser.close();
+		});
+	});
+});


### PR DESCRIPTION
## Problem

  When tests mock `window.location` with a partial mock (e.g., `jest.spyOn(window, 'location', 'get').mockReturnValue({ reload: jest.fn() })`), the `BrowserFrameURL.getRelativeURL` method fails because `location.href` is undefined from the mock.

  This causes:
  1. URL resolution falls back to `about:blank` (which has `origin: null`)
  2. Origin comparison in `History.pushState\ fails: `null !== 'http://localhost'`
  3. SecurityError thrown, `history` library tries fallback to `window.location.assign()`
  4. Mock doesn't have `assign`, causing confusing errors

  ## Solution

  Use `frame.window[PropertySymbol.location].href` instead of `frame.window.location.href`. This accesses the internal Location object via Symbol property, which isn't affected by mocks on the public getter.

  ## Testing

  Tested against a large React test suite (~26,000 tests) that was failing with this issue. After the fix, tests pass successfully.