### PR TITLE
fix: Normalize DataTransfer format strings according to HTML spec

### DIFF
--- a/packages/happy-dom/src/event/DataTransfer.ts
+++ b/packages/happy-dom/src/event/DataTransfer.ts
@@ -79,14 +79,42 @@ export default class DataTransfer {
 	 * @returns Data.
 	 */
 	public getData(format: string): string {
+		// Normalize format according to the spec
+		// https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata
+		const normalizedFormat = this.#normalizeFormat(format);
+
 		for (let i = 0, max = this.items.length; i < max; i++) {
-			if (this.items[i].type === format) {
+			const itemFormat = this.#normalizeFormat(this.items[i].type);
+			if (itemFormat === normalizedFormat) {
 				let data = '';
 				this.items[i].getAsString((s) => (data = s));
 				return data;
 			}
 		}
 		return '';
+	}
+
+	/**
+	 * Normalizes the format according to the HTML spec.
+	 *
+	 * @param format Format to normalize.
+	 * @returns Normalized format.
+	 */
+	#normalizeFormat(format: string): string {
+		// Convert to lowercase as per spec
+		const lowercaseFormat = format.toLowerCase();
+
+		// "text" is a shorthand for "text/plain"
+		if (lowercaseFormat === 'text') {
+			return 'text/plain';
+		}
+
+		// "url" is a shorthand for "text/uri-list"
+		if (lowercaseFormat === 'url') {
+			return 'text/uri-list';
+		}
+
+		return lowercaseFormat;
 	}
 
 	/**

--- a/packages/happy-dom/test/event/DataTransfer.test.ts
+++ b/packages/happy-dom/test/event/DataTransfer.test.ts
@@ -103,6 +103,27 @@ describe('DataTransfer', () => {
 			expect(dataTransfer.getData('text/html')).toBe('test2');
 			expect(dataTransfer.getData('text/xml')).toBe('');
 		});
+
+		it('Normalizes format "text" to "text/plain".', () => {
+			dataTransfer.setData('text/plain', 'test1');
+
+			expect(dataTransfer.getData('text')).toBe('test1');
+			expect(dataTransfer.getData('TEXT')).toBe('test1');
+		});
+
+		it('Normalizes format "text" when set as item type.', () => {
+			dataTransfer.items.add('test1', 'text');
+
+			expect(dataTransfer.getData('text/plain')).toBe('test1');
+			expect(dataTransfer.getData('text')).toBe('test1');
+		});
+
+		it('Normalizes format "url" to "text/uri-list".', () => {
+			dataTransfer.setData('text/uri-list', 'https://example.com');
+
+			expect(dataTransfer.getData('url')).toBe('https://example.com');
+			expect(dataTransfer.getData('URL')).toBe('https://example.com');
+		});
 	});
 
 	describe('setDragImage()', () => {


### PR DESCRIPTION
## Problem

`DataTransfer.getData()` performs exact string matching on format types. However, according to the HTML spec, format strings should be normalized:
- `"text"` should be treated as `"text/plain"`
- `"url"` should be treated as `"text/uri-list"`
- Format comparison should be case-insensitive

This causes issues when testing libraries (like `@testing-library/user-event`) use shorthand format names. For example, `user.paste('data')` adds data with type `"text"`, but application code calling `evt.clipboardData.getData('text/plain')` returns an empty string.

## Solution

Added format normalization in `getData()` that:
1. Converts formats to lowercase
2. Maps `"text"` → `"text/plain"`
3. Maps `"url"` → `"text/uri-list"`

## Reference

https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata

## Testing

Added tests for format normalization behavior.