### PR TITLE
fix: [#1985] Use parseFloat for Cache-Control max-age parsing

### DIFF
--- a/packages/happy-dom/src/fetch/cache/response/ResponseCache.ts
+++ b/packages/happy-dom/src/fetch/cache/response/ResponseCache.ts
@@ -154,7 +154,7 @@ export default class ResponseCache implements IResponseCache {
 				switch (key) {
 					case 'max-age':
 						cachedResponse.expires =
-							Date.now() + parseInt(value) * 1000 - (age ? parseInt(age) * 1000 : 0);
+							Date.now() + parseFloat(value) * 1000 - (age ? parseFloat(age) * 1000 : 0);
 						break;
 					case 'no-cache':
 					case 'no-store':


### PR DESCRIPTION
This PR fixes a bug in the response cache implementation where `parseInt()` was used to parse the `max-age` value from `Cache-Control` headers. This caused decimal values like `0.0001` to be truncated to `0`, leading to flaky test behavior.

Fixes #1985

## Problem

The cache implementation in `ResponseCache.ts` used `parseInt()` to parse max-age values:

```typescript
cachedResponse.expires = Date.now() + parseInt(value) * 1000 - (age ? parseInt(age) * 1000 : 0);
```

When `max-age=0.0001` was set, `parseInt('0.0001')` returned `0`, making the cache expire immediately at `Date.now()`. Due to timing variations, the strict less-than check (`entry.expires < Date.now()`) would sometimes fail when both timestamps were equal, causing the cache to return stale responses instead of triggering revalidation.

## Solution

Changed `parseInt()` to `parseFloat()` to properly handle decimal max-age values:

```typescript
cachedResponse.expires = Date.now() + parseFloat(value) * 1000 - (age ? parseFloat(age) * 1000 : 0);
```

This correctly calculates sub-second expiration times, which is valid per HTTP caching specifications.