### PR TITLE
fix: [#1989] Optimize DOMTokenList add/remove with Set for O(1) lookups

### DIFF
--- a/packages/happy-dom/src/dom/DOMTokenList.ts
+++ b/packages/happy-dom/src/dom/DOMTokenList.ts
@@ -254,10 +254,11 @@ export default class DOMTokenList {
 	 */
 	public add(...tokens: string[]): void {
 		const list = this[PropertySymbol.getTokenList]().slice();
+		const existingTokens = new Set(list);
 
 		for (const token of tokens) {
-			const index = list.indexOf(token);
-			if (index === -1) {
+			if (!existingTokens.has(token)) {
+				existingTokens.add(token);
 				list.push(token);
 			}
 		}
@@ -274,18 +275,13 @@ export default class DOMTokenList {
 	 * @param tokens Tokens.
 	 */
 	public remove(...tokens: string[]): void {
-		const list = this[PropertySymbol.getTokenList]().slice();
-
-		for (const token of tokens) {
-			const index = list.indexOf(token);
-			if (index !== -1) {
-				list.splice(index, 1);
-			}
-		}
+		const list = this[PropertySymbol.getTokenList]();
+		const tokensToRemove = new Set(tokens);
+		const newList = list.filter((item) => !tokensToRemove.has(item));
 
 		this[PropertySymbol.ownerElement].setAttribute(
 			this[PropertySymbol.attributeName],
-			list.join(' ')
+			newList.join(' ')
 		);
 	}
 


### PR DESCRIPTION
Fixes #1989

## Summary

This PR optimizes the `add()` and `remove()` methods in `DOMTokenList` by using `Set` for O(1) token lookups instead of `Array.indexOf()` which is O(n).

## Changes

### `add()` method

**Before:**
```typescript
for (const token of tokens) {
  const index = list.indexOf(token);  // O(n) per token
  if (index === -1) {
    list.push(token);
  }
}
```

**After:**
```typescript
const existingTokens = new Set(list);
for (const token of tokens) {
  if (!existingTokens.has(token)) {   // O(1)
    existingTokens.add(token);
    list.push(token);
  }
}
```

### `remove()` method

**Before:**
```typescript
for (const token of tokens) {
  const index = list.indexOf(token);  // O(n) per token
  if (index !== -1) {
    list.splice(index, 1);            // O(n) shift
  }
}
```

**After:**
```typescript
const tokensToRemove = new Set(tokens);
const newList = list.filter((item) => !tokensToRemove.has(item));  // O(n) total
```

## Complexity improvement

| Method | Before | After |
|--------|--------|-------|
| `add()` | O(n × m) | O(n + m) |
| `remove()` | O(n × m) | O(n + m) |

Where n = existing tokens, m = tokens being added/removed.
