### PR TITLE
fix: [#1876] Use proxy in Node.contains() for HTMLFormElement/HTMLSelectElement

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -336,7 +336,10 @@ export default class Node extends EventTarget {
 		if (otherNode === undefined) {
 			return false;
 		}
-		return NodeUtility.isInclusiveAncestor(this, otherNode);
+		// HTMLFormElement and HTMLSelectElement return a Proxy from their constructor.
+		// We need to use the proxy for comparison to ensure correct behavior.
+		const self = this[PropertySymbol.proxy] || this;
+		return NodeUtility.isInclusiveAncestor(self, otherNode);
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -355,6 +355,39 @@ describe('Node', () => {
 
 			expect(div.contains(<Node>(<unknown>undefined))).toBe(false);
 		});
+
+		it('Returns "true" for HTMLFormElement containing child elements (issue #1876).', () => {
+			const form = document.createElement('form');
+			const input = document.createElement('input');
+
+			form.appendChild(input);
+
+			expect(form.contains(input)).toBe(true);
+			expect(form.contains(form)).toBe(true);
+		});
+
+		it('Returns "true" for HTMLSelectElement containing child elements (issue #1876).', () => {
+			const select = document.createElement('select');
+			const option = document.createElement('option');
+
+			select.appendChild(option);
+
+			expect(select.contains(option)).toBe(true);
+			expect(select.contains(select)).toBe(true);
+		});
+
+		it('Returns "true" for nested elements within HTMLFormElement (issue #1876).', () => {
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+			const input = document.createElement('input');
+
+			div.appendChild(input);
+			form.appendChild(div);
+
+			expect(form.contains(input)).toBe(true);
+			expect(form.contains(div)).toBe(true);
+			expect(div.contains(input)).toBe(true);
+		});
 	});
 
 	describe('getRootNode()', () => {


### PR DESCRIPTION
Fixes #1876

## Problem

`Node.contains()` returns `false` for child elements of `HTMLFormElement` and `HTMLSelectElement`, even when the child is actually contained within the parent.

```javascript
const form = document.createElement('form');
const input = document.createElement('input');
form.appendChild(input);

form.contains(input); // Returns false, should be true
```

## Root Cause

`HTMLFormElement` and `HTMLSelectElement` return a Proxy from their constructors to support indexed access to form controls. When `appendChild()` is called, it correctly sets the child's `parentNode` to the proxy (via `self = this[PropertySymbol.proxy] || this`).

However, `contains()` was passing `this` directly to `isInclusiveAncestor()`. Inside the method, `this` refers to the underlying target object, not the proxy. When `isInclusiveAncestor()` traverses up the DOM tree comparing `ancestorNode === parent`, the comparison fails because one is the target and the other is the proxy.

## Solution

Modified `contains()` to use the proxy when available:

```typescript
public contains(otherNode: Node): boolean {
    if (otherNode === undefined) {
        return false;
    }
    const self = this[PropertySymbol.proxy] || this;
    return NodeUtility.isInclusiveAncestor(self, otherNode);
}
```

This follows the same pattern already used in `appendChild()`, `insertBefore()`, and `compareDocumentPosition()`.

## Testing

Added test cases for:
- `HTMLFormElement` containing direct child elements
- `HTMLSelectElement` containing option elements
- Nested elements within `HTMLFormElement`
