### PR TITLE
fix: [#1897] Add which property to KeyboardEvent

### DIFF
--- a/packages/happy-dom/src/event/events/IKeyboardEventInit.ts
+++ b/packages/happy-dom/src/event/events/IKeyboardEventInit.ts
@@ -15,4 +15,9 @@ export default interface IKeyboardEventInit extends IUIEventInit {
 	 * @deprecated
 	 */
 	keyCode?: number;
+
+	/**
+	 * @deprecated
+	 */
+	which?: number;
 }

--- a/packages/happy-dom/src/event/events/KeyboardEvent.ts
+++ b/packages/happy-dom/src/event/events/KeyboardEvent.ts
@@ -25,6 +25,11 @@ export default class KeyboardEvent extends UIEvent {
 	public readonly keyCode: number;
 
 	/**
+	 * @deprecated
+	 */
+	public readonly which: number;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param type Event type.
@@ -43,6 +48,7 @@ export default class KeyboardEvent extends UIEvent {
 		this.repeat = eventInit?.repeat ?? false;
 		this.shiftKey = eventInit?.shiftKey ?? false;
 		this.keyCode = eventInit?.keyCode ?? 0;
+		this.which = eventInit?.which ?? eventInit?.keyCode ?? 0;
 	}
 
 	/**

--- a/packages/happy-dom/test/event/events/KeyboardEvent.test.ts
+++ b/packages/happy-dom/test/event/events/KeyboardEvent.test.ts
@@ -2,6 +2,29 @@ import KeyboardEvent from '../../../src/event/events/KeyboardEvent.js';
 import { describe, it, expect } from 'vitest';
 
 describe('KeyboardEvent', () => {
+	describe('constructor()', () => {
+		it('Sets the "which" property from eventInit (issue #1897).', () => {
+			const event = new KeyboardEvent('keydown', { keyCode: 13, which: 13 });
+			expect(event.which).toBe(13);
+		});
+
+		it('Defaults "which" to keyCode when not specified.', () => {
+			const event = new KeyboardEvent('keydown', { keyCode: 65 });
+			expect(event.which).toBe(65);
+		});
+
+		it('Defaults "which" to 0 when neither which nor keyCode is specified.', () => {
+			const event = new KeyboardEvent('keydown', {});
+			expect(event.which).toBe(0);
+		});
+
+		it('Uses "which" value even when different from keyCode.', () => {
+			const event = new KeyboardEvent('keydown', { keyCode: 13, which: 65 });
+			expect(event.which).toBe(65);
+			expect(event.keyCode).toBe(13);
+		});
+	});
+
 	describe('getModifierState()', () => {
 		it('Returns true when Alt key is pressed', () => {
 			const event = new KeyboardEvent('keydown', { altKey: true });


### PR DESCRIPTION
Fixes #1897

## Problem

The deprecated `which` property was missing from `KeyboardEvent`. In browsers:

```javascript
new KeyboardEvent("keydown", { keyCode: 13, which: 13 }).which // Returns 13
```

In happy-dom, this returned `undefined`.

## Solution

Added the `which` property to:
- `IKeyboardEventInit` interface
- `KeyboardEvent` class

The property falls back to `keyCode` if `which` is not explicitly specified, matching browser behavior.

## Testing

Added test cases for:
- Setting `which` explicitly via eventInit
- Defaulting to `keyCode` when `which` is not specified
- Defaulting to `0` when neither is specified
- Using different values for `which` and `keyCode`
