### PR TITLE
fix: [#1975] Allow paths in WebSocket URLs

### DIFF
--- a/packages/happy-dom/src/web-socket/WebSocket.ts
+++ b/packages/happy-dom/src/web-socket/WebSocket.ts
@@ -59,11 +59,11 @@ export default class WebSocket extends EventTarget {
 			);
 		}
 
-		if (parsedURL.pathname.length > 1) {
-			throw new window.DOMException(
-				`The URL contains a path name ('${parsedURL.pathname}'). Paths are not allowed in WebSocket URLs.`,
-				DOMExceptionNameEnum.syntaxError
-			);
+		// Note: WebSocket URLs can have paths (e.g., wss://example.com/chat/room1)
+		// The fragment (hash) should be removed per the spec, but paths are valid.
+		if (parsedURL.hash) {
+			// Remove fragment from URL as per WebSocket spec
+			parsedURL.hash = '';
 		}
 
 		const protocolSet = new Set<string>();

--- a/packages/happy-dom/test/web-socket/WebSocket.test.ts
+++ b/packages/happy-dom/test/web-socket/WebSocket.test.ts
@@ -95,6 +95,46 @@ describe('WebSocket', () => {
 	});
 
 	describe('constructor()', () => {
+		it('Connects to web socket with a path in the URL.', async () => {
+			const socket = new window.WebSocket('ws://echo.websocket.org/chat/room1');
+			const ws = <any>socket[PropertySymbol.webSocket];
+
+			expect(ws.internalInit).toEqual({
+				url: new URL('ws://echo.websocket.org/chat/room1'),
+				protocols: [],
+				options: {
+					headers: {
+						'user-agent': window.navigator.userAgent,
+						cookie: '',
+						origin: 'https://localhost:8080'
+					},
+					rejectUnauthorized: true
+				}
+			});
+
+			expect(socket.url).toBe('ws://echo.websocket.org/chat/room1');
+		});
+
+		it('Removes fragment from URL.', async () => {
+			const socket = new window.WebSocket('ws://echo.websocket.org/chat#section');
+			const ws = <any>socket[PropertySymbol.webSocket];
+
+			expect(ws.internalInit).toEqual({
+				url: new URL('ws://echo.websocket.org/chat'),
+				protocols: [],
+				options: {
+					headers: {
+						'user-agent': window.navigator.userAgent,
+						cookie: '',
+						origin: 'https://localhost:8080'
+					},
+					rejectUnauthorized: true
+				}
+			});
+
+			expect(socket.url).toBe('ws://echo.websocket.org/chat');
+		});
+
 		it('Connects to web socket and listens to "open" event.', async () => {
 			window.document.cookie = 'sessionId=abc123';
 


### PR DESCRIPTION
Fixes #1975

## Problem

Since version 20.1.0, WebSocket URLs with paths (e.g., `wss://my-test.server.com/ws` or `wss://my-test.server.com/chat`) were incorrectly rejected with the error:

```
The URL contains a path name ('/ws'). Paths are not allowed in WebSocket URLs.
```

This is incorrect behavior - WebSocket URLs absolutely can have paths according to the WebSocket specification.

## Solution

- Removed the incorrect path validation that rejected URLs with `pathname.length > 1`
- Added fragment (hash) removal per the WebSocket spec - fragments should be stripped from WebSocket URLs

## Changes

- `packages/happy-dom/src/web-socket/WebSocket.ts` - Removed path validation, added fragment removal
- `packages/happy-dom/test/web-socket/WebSocket.test.ts` - Added tests for URLs with paths and fragment removal

## Testing

I've added 2 new test cases to cover this behavior.
