### PR TITLE
fix: [#1951] Prevent double encoding of HTML entities

### DIFF
--- a/packages/happy-dom/src/utilities/XMLEncodeUtility.ts
+++ b/packages/happy-dom/src/utilities/XMLEncodeUtility.ts
@@ -82,7 +82,7 @@ export default class XMLEncodeUtility {
 		}
 
 		return text
-			.replace(/&/gu, '&amp;')
+			.replace(/&(?![a-zA-Z][a-zA-Z0-9]*;|#[0-9]+;|#x[0-9A-Fa-f]+;)/gu, '&amp;')
 			.replace(/\xA0/gu, '&nbsp;')
 			.replace(/</gu, '&lt;')
 			.replace(/>/gu, '&gt;');


### PR DESCRIPTION
## Summary

Fixes #1951

This PR resolves the double encoding issue of HTML entities that occurred in version 16+.

## Solution

Modified `XMLEncodeUtility.encodeTextContent()` to skip encoding `&` when it appears to be part of a valid entity
pattern:

- Named entities: `&[a-zA-Z][a-zA-Z0-9]*;` (e.g., `&ndash;`, `&copy;`, `&ensp;`)
- Numeric entities: `&#[0-9]+;` (e.g., `&#8211;`)
- Hex entities: `&#x[0-9A-Fa-f]+;` (e.g., `&#x2013;`)

This allows entities to be preserved in HTML output, where browsers handle the decoding correctly.

## Changes

- Modified `packages/happy-dom/src/utilities/XMLEncodeUtility.ts:85`
- Changed regex from `/&/gu` to `/&(?![a-zA-Z][a-zA-Z0-9]*;|#[0-9]+;|#x[0-9A-Fa-f]+;)/gu`

## Example

Before (broken)

```javascript
dom.document.body.innerHTML = '<p>Hello &ndash; test</p>';
console.log(dom.document.body.innerHTML);
// Output: <p>Hello &amp;ndash; test</p> ❌
```

After (fixed)

```javascript
dom.document.body.innerHTML = '<p>Hello &ndash; test</p>';
console.log(dom.document.body.innerHTML);
// Output: <p>Hello &ndash; test</p> ✅
```

## Alternative Approach

This PR offers a lightweight alternative to #1999.
Instead of adding the `entities` library dependency, it uses a regex pattern to preserve entity-like patterns during encoding. This maintains zero additional dependencies while solving the double-encoding issue.

### Trade-offs

- ✅ No new dependencies
- ✅ Minimal code change (1 line)
- ⚠️ Entities are preserved but not decoded (browsers handle decoding)

## Notes

This PR is provided as an alternative to #1999 with different trade-offs.
Which approach better fits the project’s direction is ultimately up to the maintainers, and I’m happy to adjust or close this PR accordingly.
