### PR TITLE
fix: [#1951] Decode named HTML entities correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5542,7 +5542,6 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -13877,6 +13876,7 @@
 				"@types/node": "^20.0.0",
 				"@types/whatwg-mimetype": "^3.0.2",
 				"@types/ws": "^8.18.1",
+				"entities": "^4.5.0",
 				"whatwg-mimetype": "^3.0.0",
 				"ws": "^8.18.3"
 			},

--- a/packages/happy-dom/package.json
+++ b/packages/happy-dom/package.json
@@ -33,11 +33,12 @@
 		"test:debug": "vitest run --inspect-brk --no-file-parallelism"
 	},
 	"dependencies": {
-		"whatwg-mimetype": "^3.0.0",
-		"ws": "^8.18.3",
-		"@types/ws": "^8.18.1",
+		"@types/node": "^20.0.0",
 		"@types/whatwg-mimetype": "^3.0.2",
-		"@types/node": "^20.0.0"
+		"@types/ws": "^8.18.1",
+		"entities": "^4.5.0",
+		"whatwg-mimetype": "^3.0.0",
+		"ws": "^8.18.3"
 	},
 	"devDependencies": {
 		"@vitest/ui": "^3.2.3",

--- a/packages/happy-dom/src/utilities/XMLEncodeUtility.ts
+++ b/packages/happy-dom/src/utilities/XMLEncodeUtility.ts
@@ -1,3 +1,5 @@
+import { decodeHTML } from 'entities';
+
 /**
  * Utility for encoding.
  */
@@ -109,6 +111,8 @@ export default class XMLEncodeUtility {
 	/**
 	 * Decodes HTML entities.
 	 *
+	 * Uses the 'entities' library for comprehensive HTML5 named character reference support.
+	 *
 	 * @param value Value.
 	 * @returns Decoded value.
 	 */
@@ -117,15 +121,7 @@ export default class XMLEncodeUtility {
 			return '';
 		}
 
-		return value
-			.replace(/&lt;/gu, '<')
-			.replace(/&gt;/gu, '>')
-			.replace(/&nbsp;/gu, String.fromCharCode(160))
-			.replace(/&quot;/gu, '"')
-			.replace(/&apos;/gu, "'")
-			.replace(/&#(\d+);/gu, (_match, dec) => String.fromCharCode(parseInt(dec, 10)))
-			.replace(/&#x([A-Fa-f\d]+);/gu, (_match, hex) => String.fromCharCode(parseInt(hex, 16)))
-			.replace(/&amp;/gu, '&');
+		return decodeHTML(value);
 	}
 
 	/**

--- a/packages/happy-dom/test/html-parser/HTMLParser.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.test.ts
@@ -1973,6 +1973,25 @@ describe('HTMLParser', () => {
 			);
 		});
 
+		it('Decodes named HTML entities correctly for #1951', () => {
+			const div = document.createElement('div');
+			div.innerHTML = '<p>Hello test &ndash; end test</p>';
+
+			// The entity should be decoded to the actual character
+			expect(div.textContent).toBe('Hello test – end test');
+
+			// When serialized back, the character should remain as the actual character (not re-encoded as entity)
+			expect(div.innerHTML).toBe('<p>Hello test – end test</p>');
+		});
+
+		it('Decodes various named HTML entities for #1951', () => {
+			const div = document.createElement('div');
+			div.innerHTML = '<p>&mdash; &copy; &reg; &trade; &euro; &pound; &yen;</p>';
+
+			// All entities should be decoded
+			expect(div.textContent).toBe('— © ® ™ € £ ¥');
+		});
+
 		it('Handles attributes with [] in the name for #1638', () => {
 			const result = new HTMLParser(window).parse(`<div [innerHTML]="'TEST'"></div>`);
 


### PR DESCRIPTION
Fixes #1951

## Problem

Named HTML entities like `&ndash;`, `&mdash;`, `&copy;`, etc. were not being decoded when parsing HTML. This caused entities to be double-encoded when reading `innerHTML`:

```javascript
const dom = new Window({});
dom.document.body.innerHTML = '<p>Hello test &ndash; end test</p>';
console.log(dom.document.body.innerHTML);
// Actual: <p>Hello test &amp;ndash; end test</p>
// Expected: <p>Hello test – end test</p>
```

## Solution

Uses the [`entities`](https://www.npmjs.com/package/entities) library for comprehensive HTML5 named character reference support. This library:
- Is actively maintained (benchmarked September 2025)
- Is the fastest HTML entity decoder available
- Supports all standardized named character references as per HTML spec
- Handles edge cases properly
- Has TypeScript types included

## Changes

- `packages/happy-dom/package.json` - Added `entities` dependency
- `packages/happy-dom/src/utilities/XMLEncodeUtility.ts` - Updated `decodeHTMLEntities()` to use `decodeHTML()` from entities
- `packages/happy-dom/test/html-parser/HTMLParser.test.ts` - Added tests for named entity decoding

## Testing

I've added new test cases for HTML with named entities.
