### PR TITLE
fix: [#2000] Use waitUntilComplete() for reliable JavaScript URL test timing

### DIFF
--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -2240,7 +2240,7 @@ describe('BrowserWindow', () => {
 			const newWindow = <Window>window.open(`javascript:document.write('Test');`);
 			expect(newWindow).toBeInstanceOf(BrowserWindow);
 			expect(newWindow.location.href).toBe('about:blank');
-			await new Promise((resolve) => setTimeout(resolve, 1));
+			await browser.waitUntilComplete();
 			expect(newWindow.document.body.innerHTML).toBe('Test');
 		});
 
@@ -2250,7 +2250,7 @@ describe('BrowserWindow', () => {
 			newWindow.addEventListener('error', (event) => (errorEvent = <ErrorEvent>event));
 			expect(newWindow).toBeInstanceOf(BrowserWindow);
 			expect(newWindow.location.href).toBe('about:blank');
-			await new Promise((resolve) => setTimeout(resolve, 20));
+			await browser.waitUntilComplete();
 			expect(String((<ErrorEvent>(<unknown>errorEvent)).error)).toBe(
 				'ReferenceError: test is not defined'
 			);


### PR DESCRIPTION
Fixes #2000

## Problem

The test `BrowserWindow > open() > Opens a URL with Javascript` was failing intermittently in CI:

```
AssertionError: expected '' to be 'Test' // Object.is equality
```

The test used a short `setTimeout` to wait for JavaScript URL execution to complete, but this is unreliable because `BrowserFrameNavigator.navigate()` executes `javascript:` URLs using `requestAnimationFrame()` + `setImmediate()`. These scheduling mechanisms have no guaranteed ordering relative to `setTimeout`, especially under CI load.

## Solution

Replace the arbitrary timeout with `browser.waitUntilComplete()`, which properly waits for all async tasks to finish. This pattern is already used elsewhere in the test file.

## Changes

- `packages/happy-dom/test/window/BrowserWindow.test.ts`: Updated two tests to use `browser.waitUntilComplete()` instead of `setTimeout`
