### PR TITLE
fix: [#1895] EventTarget should not call arbitrary on* properties (take two)

### DIFF
--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -319,29 +319,48 @@ export default class EventTarget {
 		}
 
 		if (event.eventPhase !== EventPhaseEnum.capturing) {
+			// Only call on* handlers if they are defined as part of the class interface (via
+			// propertyEventListeners or as an own property on a non-EventTarget class), not arbitrary
+			// properties assigned at runtime on plain EventTarget instances. (issue #1895)
 			const onEventName = 'on' + event.type.toLowerCase();
-			const eventListener = (<any>this)[onEventName];
+			const propertyEventListeners = (<any>this)[PropertySymbol.propertyEventListeners];
 
-			if (typeof eventListener === 'function') {
-				// We can end up in a never ending loop if the listener for the error event on Window also throws an error.
-				if (
-					window &&
-					(this !== <EventTarget>window || event.type !== 'error') &&
-					!browserSettings?.disableErrorCapturing &&
-					browserSettings?.errorCapture === BrowserErrorCaptureEnum.tryAndCatch
-				) {
-					let result: any;
-					try {
-						result = eventListener(event);
-					} catch (error) {
-						window[PropertySymbol.dispatchError](<Error>error);
-					}
+			// Check if this on* handler is defined as part of the class interface:
+			// 1. Via propertyEventListeners Map (used by Element, Document, etc.)
+			//    For these classes, we always try to get the listener since the getter handles
+			//    lazy evaluation of attribute-based event listeners.
+			// 2. As an own property on a subclass of EventTarget that defines on* handlers
+			//    (used by MediaQueryList, AbortSignal, etc.)
+			//    Plain EventTarget instances should not have arbitrary on* properties called.
+			const hasClassDefinedHandler =
+				!propertyEventListeners &&
+				Object.hasOwn(this, onEventName) &&
+				this.constructor.name !== 'EventTarget';
 
-					if (result instanceof Promise) {
-						result.catch((error) => window[PropertySymbol.dispatchError](error));
+			if (propertyEventListeners || hasClassDefinedHandler) {
+				const eventListener = propertyEventListeners?.get(onEventName) ?? (<any>this)[onEventName];
+
+				if (typeof eventListener === 'function') {
+					// We can end up in a never ending loop if the listener for the error event on Window also throws an error.
+					if (
+						window &&
+						(this !== <EventTarget>window || event.type !== 'error') &&
+						!browserSettings?.disableErrorCapturing &&
+						browserSettings?.errorCapture === BrowserErrorCaptureEnum.tryAndCatch
+					) {
+						let result: any;
+						try {
+							result = eventListener(event);
+						} catch (error) {
+							window[PropertySymbol.dispatchError](<Error>error);
+						}
+
+						if (result instanceof Promise) {
+							result.catch((error) => window[PropertySymbol.dispatchError](error));
+						}
+					} else {
+						eventListener(event);
 					}
-				} else {
-					eventListener(event);
 				}
 			}
 		}

--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequestEventTarget.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequestEventTarget.ts
@@ -1,5 +1,6 @@
 import ProgressEvent from '../event/events/ProgressEvent.js';
 import EventTarget from '../event/EventTarget.js';
+import * as PropertySymbol from '../PropertySymbol.js';
 
 export type ProgressEventListener = (event: ProgressEvent) => void;
 
@@ -7,11 +8,81 @@ export type ProgressEventListener = (event: ProgressEvent) => void;
  * References: https://xhr.spec.whatwg.org/#xmlhttprequesteventtarget.
  */
 export default class XMLHttpRequestEventTarget extends EventTarget {
-	public onloadstart: ProgressEventListener | null = null;
-	public onprogress: ProgressEventListener | null = null;
-	public onabort: ((event: ProgressEvent) => void) | null = null;
-	public onerror: ProgressEventListener | null = null;
-	public onload: ProgressEventListener | null = null;
-	public ontimeout: ProgressEventListener | null = null;
-	public onloadend: ProgressEventListener | null = null;
+	// Internal properties
+	public [PropertySymbol.propertyEventListeners]: Map<string, ProgressEventListener | null> =
+		new Map();
+
+	/* eslint-disable jsdoc/require-jsdoc */
+
+	public get onloadstart(): ProgressEventListener | null {
+		return <ProgressEventListener | null>(
+			(this[PropertySymbol.propertyEventListeners].get('onloadstart') ?? null)
+		);
+	}
+
+	public set onloadstart(value: ProgressEventListener | null) {
+		this[PropertySymbol.propertyEventListeners].set('onloadstart', value);
+	}
+
+	public get onprogress(): ProgressEventListener | null {
+		return <ProgressEventListener | null>(
+			(this[PropertySymbol.propertyEventListeners].get('onprogress') ?? null)
+		);
+	}
+
+	public set onprogress(value: ProgressEventListener | null) {
+		this[PropertySymbol.propertyEventListeners].set('onprogress', value);
+	}
+
+	public get onabort(): ((event: ProgressEvent) => void) | null {
+		return <((event: ProgressEvent) => void) | null>(
+			(this[PropertySymbol.propertyEventListeners].get('onabort') ?? null)
+		);
+	}
+
+	public set onabort(value: ((event: ProgressEvent) => void) | null) {
+		this[PropertySymbol.propertyEventListeners].set('onabort', value);
+	}
+
+	public get onerror(): ProgressEventListener | null {
+		return <ProgressEventListener | null>(
+			(this[PropertySymbol.propertyEventListeners].get('onerror') ?? null)
+		);
+	}
+
+	public set onerror(value: ProgressEventListener | null) {
+		this[PropertySymbol.propertyEventListeners].set('onerror', value);
+	}
+
+	public get onload(): ProgressEventListener | null {
+		return <ProgressEventListener | null>(
+			(this[PropertySymbol.propertyEventListeners].get('onload') ?? null)
+		);
+	}
+
+	public set onload(value: ProgressEventListener | null) {
+		this[PropertySymbol.propertyEventListeners].set('onload', value);
+	}
+
+	public get ontimeout(): ProgressEventListener | null {
+		return <ProgressEventListener | null>(
+			(this[PropertySymbol.propertyEventListeners].get('ontimeout') ?? null)
+		);
+	}
+
+	public set ontimeout(value: ProgressEventListener | null) {
+		this[PropertySymbol.propertyEventListeners].set('ontimeout', value);
+	}
+
+	public get onloadend(): ProgressEventListener | null {
+		return <ProgressEventListener | null>(
+			(this[PropertySymbol.propertyEventListeners].get('onloadend') ?? null)
+		);
+	}
+
+	public set onloadend(value: ProgressEventListener | null) {
+		this[PropertySymbol.propertyEventListeners].set('onloadend', value);
+	}
+
+	/* eslint-enable jsdoc/require-jsdoc */
 }

--- a/packages/happy-dom/test/event/EventTarget.test.ts
+++ b/packages/happy-dom/test/event/EventTarget.test.ts
@@ -160,7 +160,9 @@ describe('EventTarget', () => {
 	});
 
 	describe('dispatchEvent()', () => {
-		it('Triggers listener properties with "on" as prefix.', () => {
+		it('Triggers listener properties with "on" as prefix on DOM elements.', () => {
+			// on* handlers should work on DOM elements (which have propertyEventListeners)
+			const element = window.document.createElement('div');
 			let recievedEvent: Event | null = null;
 			let recievedTarget: EventTarget | null = null;
 			let recievedCurrentTarget: EventTarget | null = null;
@@ -170,12 +172,12 @@ describe('EventTarget', () => {
 				recievedCurrentTarget = event.currentTarget;
 			};
 			const dispatchedEvent = new Event(EVENT_TYPE);
-			eventTarget[`on${EVENT_TYPE}`] = listener;
-			eventTarget.dispatchEvent(dispatchedEvent);
+			element[`on${EVENT_TYPE}`] = listener;
+			element.dispatchEvent(dispatchedEvent);
 			expect(recievedEvent).toBe(dispatchedEvent);
-			expect(recievedTarget).toBe(eventTarget);
-			expect(recievedCurrentTarget).toBe(eventTarget);
-			expect(dispatchedEvent.target).toBe(eventTarget);
+			expect(recievedTarget).toBe(element);
+			expect(recievedCurrentTarget).toBe(element);
+			expect(dispatchedEvent.target).toBe(element);
 			expect(dispatchedEvent.currentTarget).toBe(null);
 			expect(dispatchedEvent.defaultPrevented).toBe(false);
 			expect(dispatchedEvent[PropertySymbol.dispatching]).toBe(false);
@@ -286,6 +288,74 @@ describe('EventTarget', () => {
 			eventTarget.dispatchEvent(dispatchedEvent);
 
 			expect(count).toBe(0);
+		});
+	});
+
+	describe('dispatchEvent()', () => {
+		it('Does not call arbitrary on* properties set on EventTarget (issue #1895).', () => {
+			const calls: string[] = [];
+
+			(<any>eventTarget).onopen = () => calls.push('onopen property');
+			eventTarget.addEventListener('open', () => calls.push('open listener'));
+
+			eventTarget.dispatchEvent(new Event('open'));
+
+			expect(calls).toEqual(['open listener']);
+		});
+
+		it('Does not call on* properties that are not defined as event handlers.', () => {
+			const calls: string[] = [];
+
+			(<any>eventTarget).onclick = () => calls.push('onclick property');
+			eventTarget.addEventListener('click', () => calls.push('click listener'));
+
+			eventTarget.dispatchEvent(new Event('click'));
+
+			// EventTarget base class should not call on* properties
+			// Only DOM elements with defined on* IDL attributes should call them
+			expect(calls).toEqual(['click listener']);
+		});
+
+		it('Calls on* handlers on subclasses that define them as class properties.', () => {
+			// MediaQueryList defines onchange as a class property
+			const mediaQueryList = window.matchMedia('(min-width: 100px)');
+			let called = false;
+			mediaQueryList.onchange = () => {
+				called = true;
+			};
+			mediaQueryList.dispatchEvent(new Event('change'));
+			expect(called).toBe(true);
+		});
+
+		it('Calls on* handlers on MediaStream.', () => {
+			const mediaStream = new window.MediaStream();
+			let addTrackCalled = false;
+			let removeTrackCalled = false;
+
+			mediaStream.onaddtrack = () => {
+				addTrackCalled = true;
+			};
+			mediaStream.onremovetrack = () => {
+				removeTrackCalled = true;
+			};
+
+			mediaStream.dispatchEvent(new Event('addtrack'));
+			mediaStream.dispatchEvent(new Event('removetrack'));
+
+			expect(addTrackCalled).toBe(true);
+			expect(removeTrackCalled).toBe(true);
+		});
+
+		it('Calls onabort handler on AbortSignal.', () => {
+			const controller = new window.AbortController();
+			let called = false;
+
+			controller.signal.onabort = () => {
+				called = true;
+			};
+			controller.abort();
+
+			expect(called).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #1895

## Problem

Setting `on*` properties on a plain `EventTarget` instance incorrectly causes those functions to be called when dispatching events:

```javascript
const t = new EventTarget();
t.onopen = () => console.log("onopen function");
t.addEventListener('open', () => console.log("onopen event"));
t.dispatchEvent(new Event('open'));

// Expected: "onopen event"
// Actual: "onopen function" AND "onopen event"
```

This breaks libraries like [msw](https://github.com/mswjs/interceptors) that extend `EventTarget` and use `on*` properties for other purposes.

## Root Cause

In browsers, `on*` event handler IDL attributes are only defined on specific interfaces (`HTMLElement`, `Document`, `Window`, etc. via the `GlobalEventHandlers` mixin), not on the base `EventTarget` class.

Happy-dom was checking for any `on*` property on the object and calling it as an event handler, regardless of whether the object was a DOM element with defined event handler attributes.

## Solution

Modified `EventTarget.#callDispatchEventListeners` to distinguish between three cases:

1. **Classes with `propertyEventListeners`** (Element, Document, ShadowRoot, XMLHttpRequestEventTarget) - always check for `on*` handlers since the getters handle lazy evaluation of attribute-based event listeners like `onclick="..."`

2. **Subclasses that define `on*` as class properties** (MediaQueryList, AbortSignal, MediaStream, PermissionStatus, etc.) - call handlers if the property exists as an own property and the class is not a plain EventTarget

3. **Plain EventTarget instances** - do not call arbitrary `on*` properties

The key check is `this.constructor.name !== 'EventTarget'`, which identifies plain EventTarget instances (including the window-extended version) while allowing all subclasses that define `on*` handlers to work correctly.

## Testing

- Updated existing test to use a DOM element instead of plain EventTarget
- Added tests verifying that plain EventTarget does not call `on*` properties
- Added tests verifying that subclasses (MediaQueryList, MediaStream, AbortSignal) still have their `on*` handlers called correctly

## Changes

- `packages/happy-dom/src/event/EventTarget.ts` - Modified `#callDispatchEventListeners` to check class type before calling `on*` handlers
- `packages/happy-dom/src/xml-http-request/XMLHttpRequestEventTarget.ts` - Converted to use `propertyEventListeners` Map with getters/setters (consistent with Element pattern)
- `packages/happy-dom/test/event/EventTarget.test.ts` - Added comprehensive tests for the fix
