### PR TITLE
fix: [#1912] Preserve attribute name case in CSS selectors for XML documents

### DIFF
--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -156,7 +156,7 @@ export default class SelectorParser {
 				} else if (match[5]) {
 					currentSelectorItem.attributes = currentSelectorItem.attributes || [];
 					currentSelectorItem.attributes.push({
-						name: match[5].toLowerCase(),
+						name: match[5],
 						operator: null,
 						value: null,
 						modifier: null,
@@ -165,7 +165,7 @@ export default class SelectorParser {
 				} else if (match[6] && match[8] !== undefined) {
 					currentSelectorItem.attributes = currentSelectorItem.attributes || [];
 					currentSelectorItem.attributes.push({
-						name: match[6].toLowerCase(),
+						name: match[6],
 						operator: match[7] || null,
 						value: match[8].replace(ESCAPED_CHARACTER_REGEXP, ''),
 						modifier: <'s'>match[9] || null,
@@ -178,7 +178,7 @@ export default class SelectorParser {
 				} else if (match[10] && match[12] !== undefined) {
 					currentSelectorItem.attributes = currentSelectorItem.attributes || [];
 					currentSelectorItem.attributes.push({
-						name: match[10].toLowerCase(),
+						name: match[10],
 						operator: match[11] || null,
 						value: match[12].replace(ESCAPED_CHARACTER_REGEXP, ''),
 						modifier: null,

--- a/packages/happy-dom/test/query-selector/QuerySelector.attributeCase.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.attributeCase.test.ts
@@ -1,0 +1,55 @@
+import Window from '../../src/window/Window.js';
+import Document from '../../src/nodes/document/Document.js';
+import { beforeEach, describe, it, expect } from 'vitest';
+
+describe('QuerySelector - Attribute Case Sensitivity', () => {
+	let window: Window;
+	let document: Document;
+
+	beforeEach(() => {
+		window = new Window();
+		document = window.document;
+	});
+
+	describe('Issue #1912: CSS attribute selector with capital letters', () => {
+		it('Should match attribute selectors case-insensitively for HTML elements.', () => {
+			const container = document.createElement('div');
+			container.innerHTML = '<input Name="test" />';
+
+			// All case variations should match the same element in HTML
+			expect(container.querySelectorAll('[Name]').length).toBe(1);
+			expect(container.querySelectorAll('[name]').length).toBe(1);
+			expect(container.querySelectorAll('[NAME]').length).toBe(1);
+			expect(container.querySelectorAll('[Name="test"]').length).toBe(1);
+			expect(container.querySelectorAll('[name="test"]').length).toBe(1);
+			expect(container.querySelector('[Name]')).not.toBeNull();
+			expect(container.querySelector('[name]')).not.toBeNull();
+		});
+
+		it('Should match attribute selectors case-sensitively for XML documents.', () => {
+			// This is the actual issue from #1912 - XML documents should preserve case
+			const xml = '<root><child Name="John">Content</child></root>';
+			const parser = new window.DOMParser();
+			const xmlDoc = parser.parseFromString(xml, 'application/xml');
+
+			// In XML, attribute names are case-sensitive, so [Name] should match Name
+			expect(xmlDoc.querySelectorAll('[Name]').length).toBe(1);
+			expect(xmlDoc.querySelectorAll('[Name="John"]').length).toBe(1);
+
+			// [name] should NOT match Name in XML (case-sensitive)
+			expect(xmlDoc.querySelectorAll('[name]').length).toBe(0);
+		});
+
+		it('Should match both Name and name attributes separately in XML documents.', () => {
+			const xml = '<root><child Name="John" name="jane">Content</child></root>';
+			const parser = new window.DOMParser();
+			const xmlDoc = parser.parseFromString(xml, 'application/xml');
+
+			// Both [Name] and [name] should match their respective attributes
+			expect(xmlDoc.querySelectorAll('[Name]').length).toBe(1);
+			expect(xmlDoc.querySelectorAll('[name]').length).toBe(1);
+			expect(xmlDoc.querySelectorAll('[Name="John"]').length).toBe(1);
+			expect(xmlDoc.querySelectorAll('[name="jane"]').length).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
Fixes issue #1912 where CSS attribute selectors like `[Name]` would not match elements in XML documents when the attribute name contained capital letters.

## Problem

The `SelectorParser` was unconditionally lowercasing attribute names when parsing CSS selectors. This caused attribute selectors to fail matching in XML documents where attribute names are case-sensitive.

For example:
```javascript
const xml = '<root><child Name="John">Content</child></root>';
const parser = new DOMParser();
const xmlDoc = parser.parseFromString(xml, 'application/xml');

// This returned 0 elements instead of 1
xmlDoc.querySelectorAll('[Name]');
```

## Solution

Removed the `.toLowerCase()` calls from attribute name parsing in `SelectorParser.ts`. The case-sensitivity is now correctly handled by `NamedNodeMap.getNamedItem()`, which:
- Performs case-insensitive lookups for HTML documents (as per HTML spec)
- Performs case-sensitive lookups for XML documents (as per XML spec)

## Changes

- `packages/happy-dom/src/query-selector/SelectorParser.ts`: Removed `.toLowerCase()` from attribute name parsing (3 locations)
- `packages/happy-dom/test/query-selector/QuerySelector.attributeCase.test.ts`: Added tests for attribute selector case handling in both HTML and XML documents