### PR TITLE
fix: [#1910] Replace custom CSS selector parser with parsel-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9963,6 +9963,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/parsel-js": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.2.tgz",
+			"integrity": "sha512-AVJMlwQ4bL2Y0VvYJGk+Fp7eX4SCH2uFoNApmn4yKWACUewZ+alwW3tyoe1r5Z3aLYQTuAuPZIyGghMfO/Tlxw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/LeaVerou"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/leaverou"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -13855,6 +13871,7 @@
 				"@types/whatwg-mimetype": "^3.0.2",
 				"@types/ws": "^8.18.1",
 				"entities": "^4.5.0",
+				"parsel-js": "^1.2.2",
 				"whatwg-mimetype": "^3.0.0",
 				"ws": "^8.18.3"
 			},

--- a/packages/happy-dom/package.json
+++ b/packages/happy-dom/package.json
@@ -33,10 +33,11 @@
 		"test:debug": "vitest run --inspect-brk --no-file-parallelism"
 	},
 	"dependencies": {
-		"@types/whatwg-mimetype": "^3.0.2",
 		"@types/node": ">=20.0.0",
+		"@types/whatwg-mimetype": "^3.0.2",
 		"@types/ws": "^8.18.1",
 		"entities": "^4.5.0",
+		"parsel-js": "^1.2.2",
 		"whatwg-mimetype": "^3.0.0",
 		"ws": "^8.18.3"
 	},

--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -2,37 +2,15 @@ import SelectorItem from './SelectorItem.js';
 import SelectorCombinatorEnum from './SelectorCombinatorEnum.js';
 import DOMException from '../exception/DOMException.js';
 import ISelectorPseudo from './ISelectorPseudo.js';
+import ISelectorAttribute from './ISelectorAttribute.js';
 import Element from '../nodes/element/Element.js';
 import DocumentFragment from '../nodes/document-fragment/DocumentFragment.js';
+import { parse, type AST } from 'parsel-js';
 
 /**
- * Selector RegExp.
- *
- * Group 1: All (e.g. "*")
- * Group 2: Tag name (e.g. "div")
- * Group 3: ID (e.g. "#id")
- * Group 4: Class (e.g. ".class")
- * Group 5: Attribute name when no value (e.g. "attr1")
- * Group 6: Attribute name when there is a value using apostrophe (e.g. "attr1")
- * Group 7: Attribute operator when using apostrophe (e.g. "~")
- * Group 8: Attribute value when using apostrophe (e.g. "value1")
- * Group 9: Attribute modifier when using apostrophe (e.g. "i" or "s")
- * Group 10: Attribute name when threre is a value not using apostrophe (e.g. "attr1")
- * Group 11: Attribute operator when not using apostrophe (e.g. "~")
- * Group 12: Attribute value when notusing apostrophe (e.g. "value1")
- * Group 13: Pseudo name when arguments (e.g. "nth-child")
- * Group 14: Arguments of pseudo (e.g. "2n + 1")
- * Group 15: Pseudo name when no arguments (e.g. "empty")
- * Group 16: Pseudo element (e.g. "::after", "::-webkit-inner-spin-button").
- * Group 17: Combinator.
+ * Escaped Character RegExp - matches backslash followed by any character.
  */
-const SELECTOR_REGEXP =
-	/(\*)|([a-zA-Z0-9-]+)|#((?:[a-zA-Z0-9-_«»]|\\.)+)|\.((?:[a-zA-Z0-9-_«»]|\\.)+)|\[([a-zA-Z0-9-_\\:]+)\]|\[([a-zA-Z0-9-_\\:]+)\s*([~|^$*]{0,1})\s*=\s*["']{1}([^"']*)["']{1}\s*(s|i){0,1}\]|\[([a-zA-Z0-9-_]+)\s*([~|^$*]{0,1})\s*=\s*([^\]]*)\]|:([a-zA-Z-]+)\s*\(((?:[^()]|\[[^\]]*\]|\([^()]*\))*)\){0,1}|:([a-zA-Z-]+)|::([a-zA-Z-]+)|([\s,+>~]*)/gm;
-
-/**
- * Escaped Character RegExp.
- */
-const ESCAPED_CHARACTER_REGEXP = /\\/g;
+const ESCAPED_CHARACTER_REGEXP = /\\(.)/g;
 
 /**
  * Attribute Escape RegExp.
@@ -54,26 +32,28 @@ const NTH_FUNCTION = {
 const SPACE_REGEXP = / /g;
 
 /**
- * Simple Selector RegExp.
- *
- * Group 1: Tag name (e.g. "div")
- * Group 2: Class (e.g. ".classA.classB")
- * Group 3: ID (e.g. "#id")
+ * Placeholder for escaped characters that parsel-js can't handle.
+ * Using a unique string that won't appear in normal selectors.
  */
-const SIMPLE_SELECTOR_REGEXP = /(^[a-zA-Z0-9-]+$)|(^\.[a-zA-Z0-9-_.]+$)|(^#[a-zA-Z0-9-_]+$)/;
+const ESCAPE_PLACEHOLDER_PREFIX = '__HDOM_ESC_';
+const ESCAPE_PLACEHOLDER_SUFFIX = '__';
 
 /**
- * Utility for parsing a selection string.
+ * RegExp to find escape sequences that need pre-processing.
+ * Matches backslash followed by special characters that parsel-js can't handle.
+ */
+const PROBLEMATIC_ESCAPE_REGEXP = /\\([:#&\[\]])/g;
+
+/**
+ * Utility for parsing a selection string using parsel-js.
  */
 export default class SelectorParser {
 	/**
 	 * Parses a selector string and returns an instance of SelectorItem.
-	 *
-	 * @param selector Selector.
-	 * @param options Options.
-	 * @param [options.scope] Scope.
-	 * @param [options.ignoreErrors] Ignores errors.
-	 * @returns Selector item.
+	 * @param selector
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
 	 */
 	public static getSelectorItem(
 		selector: string,
@@ -87,12 +67,10 @@ export default class SelectorParser {
 
 	/**
 	 * Parses a selector string and returns groups with SelectorItem instances.
-	 *
-	 * @param selector Selector.
-	 * @param options Options.
-	 * @param [options.scope] Scope.
-	 * @param [options.ignoreErrors] Ignores errors.
-	 * @returns Selector groups.
+	 * @param selector
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
 	 */
 	public static getSelectorGroups(
 		selector: string,
@@ -105,166 +83,460 @@ export default class SelectorParser {
 		const ignoreErrors = options?.ignoreErrors;
 		const scope = options?.scope;
 
-		if (selector === '*') {
-			return [[new SelectorItem({ scope, tagName: '*', ignoreErrors })]];
-		}
-
-		const simpleMatch = selector.match(SIMPLE_SELECTOR_REGEXP);
-
-		if (simpleMatch) {
-			if (simpleMatch[1]) {
-				return [[new SelectorItem({ scope, tagName: selector.toUpperCase(), ignoreErrors })]];
-			} else if (simpleMatch[2]) {
-				return [
-					[
-						new SelectorItem({
-							scope,
-							classNames: selector.replace('.', '').split('.'),
-							ignoreErrors
-						})
-					]
-				];
-			} else if (simpleMatch[3]) {
-				return [[new SelectorItem({ scope, id: selector.replace('#', ''), ignoreErrors })]];
-			}
-		}
-
-		const regexp = new RegExp(SELECTOR_REGEXP);
-		let currentSelectorItem: SelectorItem = new SelectorItem({
-			scope,
-			combinator: SelectorCombinatorEnum.descendant,
-			ignoreErrors
-		});
-		let currentGroup: SelectorItem[] = [currentSelectorItem];
-		const groups: Array<Array<SelectorItem>> = [currentGroup];
-		let isValid = false;
-		let match;
-
-		while ((match = regexp.exec(selector))) {
-			if (match[0]) {
-				isValid = true;
-
-				if (match[1]) {
-					currentSelectorItem.tagName = '*';
-				} else if (match[2]) {
-					currentSelectorItem.tagName = match[2].toUpperCase();
-				} else if (match[3]) {
-					currentSelectorItem.id = match[3].replace(ESCAPED_CHARACTER_REGEXP, '');
-				} else if (match[4]) {
-					currentSelectorItem.classNames = currentSelectorItem.classNames || [];
-					currentSelectorItem.classNames.push(match[4].replace(ESCAPED_CHARACTER_REGEXP, ''));
-				} else if (match[5]) {
-					currentSelectorItem.attributes = currentSelectorItem.attributes || [];
-					currentSelectorItem.attributes.push({
-						name: match[5],
-						operator: null,
-						value: null,
-						modifier: null,
-						regExp: null
-					});
-				} else if (match[6] && match[8] !== undefined) {
-					currentSelectorItem.attributes = currentSelectorItem.attributes || [];
-					currentSelectorItem.attributes.push({
-						name: match[6],
-						operator: match[7] || null,
-						value: match[8].replace(ESCAPED_CHARACTER_REGEXP, ''),
-						modifier: <'s'>match[9] || null,
-						regExp: this.getAttributeRegExp({
-							operator: match[7],
-							value: match[8],
-							modifier: match[9]
-						})
-					});
-				} else if (match[10] && match[12] !== undefined) {
-					currentSelectorItem.attributes = currentSelectorItem.attributes || [];
-					currentSelectorItem.attributes.push({
-						name: match[10],
-						operator: match[11] || null,
-						value: match[12].replace(ESCAPED_CHARACTER_REGEXP, ''),
-						modifier: null,
-						regExp: this.getAttributeRegExp({ operator: match[11], value: match[12] })
-					});
-				} else if (match[13] && match[14]) {
-					currentSelectorItem.pseudos = currentSelectorItem.pseudos || [];
-					currentSelectorItem.pseudos.push(this.getPseudo(match[13], match[14], options));
-				} else if (match[15]) {
-					currentSelectorItem.pseudos = currentSelectorItem.pseudos || [];
-					currentSelectorItem.pseudos.push(this.getPseudo(match[15], null, options));
-				} else if (match[16]) {
-					currentSelectorItem.isPseudoElement = true;
-				} else if (match[17]) {
-					switch (match[17].trim()) {
-						case ',':
-							currentSelectorItem = new SelectorItem({
-								scope,
-								combinator: SelectorCombinatorEnum.descendant,
-								ignoreErrors
-							});
-							currentGroup = [currentSelectorItem];
-							groups.push(currentGroup);
-							break;
-						case '>':
-							currentSelectorItem = new SelectorItem({
-								scope,
-								combinator: SelectorCombinatorEnum.child,
-								ignoreErrors
-							});
-							currentGroup.push(currentSelectorItem);
-							break;
-						case '+':
-							currentSelectorItem = new SelectorItem({
-								scope,
-								combinator: SelectorCombinatorEnum.adjacentSibling,
-								ignoreErrors
-							});
-							currentGroup.push(currentSelectorItem);
-							break;
-						case '~':
-							currentSelectorItem = new SelectorItem({
-								scope,
-								combinator: SelectorCombinatorEnum.subsequentSibling,
-								ignoreErrors
-							});
-							currentGroup.push(currentSelectorItem);
-							break;
-						case '':
-							currentSelectorItem = new SelectorItem({
-								scope,
-								combinator: SelectorCombinatorEnum.descendant,
-								ignoreErrors
-							});
-							currentGroup.push(currentSelectorItem);
-							break;
-					}
-				}
-			} else {
-				break;
-			}
-		}
-
-		if (!isValid) {
-			if (options?.ignoreErrors) {
+		if (!selector) {
+			if (ignoreErrors) {
 				return [];
 			}
 			throw new DOMException(`Invalid selector: "${selector}"`);
 		}
 
-		return groups;
+		// Pre-process selector to handle escaped characters that parsel-js can't handle
+		const { processedSelector, escapeMap } = this.preprocessSelector(selector);
+
+		let ast: AST | undefined;
+		try {
+			ast = parse(processedSelector, { recursive: true, list: true });
+		} catch {
+			if (ignoreErrors) {
+				return [];
+			}
+			throw new DOMException(`Invalid selector: "${selector}"`);
+		}
+
+		if (!ast) {
+			if (ignoreErrors) {
+				return [];
+			}
+			throw new DOMException(`Invalid selector: "${selector}"`);
+		}
+
+		if (ast.type === 'list') {
+			const groups: Array<Array<SelectorItem>> = [];
+			for (const item of ast.list) {
+				groups.push(this.astToSelectorItems(item, scope, ignoreErrors, options, escapeMap));
+			}
+			return groups;
+		}
+
+		return [this.astToSelectorItems(ast, scope, ignoreErrors, options, escapeMap)];
+	}
+
+	/**
+	 * Pre-processes a selector to handle escaped characters that parsel-js can't handle.
+	 * @param selector
+	 */
+	private static preprocessSelector(selector: string): {
+		processedSelector: string;
+		escapeMap: Map<string, string>;
+	} {
+		const escapeMap = new Map<string, string>();
+		let counter = 0;
+
+		const processedSelector = selector.replace(PROBLEMATIC_ESCAPE_REGEXP, (_match, char) => {
+			const placeholder = `${ESCAPE_PLACEHOLDER_PREFIX}${counter}${ESCAPE_PLACEHOLDER_SUFFIX}`;
+			escapeMap.set(placeholder, char);
+			counter++;
+			return placeholder;
+		});
+
+		return { processedSelector, escapeMap };
+	}
+
+	/**
+	 * Restores escaped characters from placeholders.
+	 * @param value
+	 * @param escapeMap
+	 */
+	private static restoreEscapedChars(value: string, escapeMap: Map<string, string>): string {
+		let result = value;
+		for (const [placeholder, char] of escapeMap) {
+			result = result.split(placeholder).join(char);
+		}
+		return result;
+	}
+
+	/**
+	 * Converts a parsel AST node to an array of SelectorItems.
+	 * @param ast
+	 * @param scope
+	 * @param ignoreErrors
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
+	 * @param escapeMap
+	 */
+	private static astToSelectorItems(
+		ast: AST,
+		scope: Element | DocumentFragment | undefined,
+		ignoreErrors: boolean | undefined,
+		options: { scope?: Element | DocumentFragment; ignoreErrors?: boolean } | undefined,
+		escapeMap: Map<string, string>
+	): SelectorItem[] {
+		const items: SelectorItem[] = [];
+		this.flattenComplexSelector(
+			ast,
+			items,
+			SelectorCombinatorEnum.descendant,
+			scope,
+			ignoreErrors,
+			options,
+			escapeMap
+		);
+		return items;
+	}
+
+	/**
+	 * Flattens a complex selector AST into an array of SelectorItems.
+	 * @param ast
+	 * @param items
+	 * @param combinator
+	 * @param scope
+	 * @param ignoreErrors
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
+	 * @param escapeMap
+	 */
+	private static flattenComplexSelector(
+		ast: AST,
+		items: SelectorItem[],
+		combinator: SelectorCombinatorEnum,
+		scope: Element | DocumentFragment | undefined,
+		ignoreErrors: boolean | undefined,
+		options: { scope?: Element | DocumentFragment; ignoreErrors?: boolean } | undefined,
+		escapeMap: Map<string, string>
+	): void {
+		if (ast.type === 'complex') {
+			this.flattenComplexSelector(
+				ast.left,
+				items,
+				combinator,
+				scope,
+				ignoreErrors,
+				options,
+				escapeMap
+			);
+			const rightCombinator = this.parselCombinatorToEnum(ast.combinator);
+			this.flattenComplexSelector(
+				ast.right,
+				items,
+				rightCombinator,
+				scope,
+				ignoreErrors,
+				options,
+				escapeMap
+			);
+		} else {
+			items.push(
+				this.astNodeToSelectorItem(ast, combinator, scope, ignoreErrors, options, escapeMap)
+			);
+		}
+	}
+
+	/**
+	 * Converts a parsel combinator string to SelectorCombinatorEnum.
+	 * @param combinator
+	 */
+	private static parselCombinatorToEnum(combinator: string): SelectorCombinatorEnum {
+		switch (combinator.trim()) {
+			case '>':
+				return SelectorCombinatorEnum.child;
+			case '+':
+				return SelectorCombinatorEnum.adjacentSibling;
+			case '~':
+				return SelectorCombinatorEnum.subsequentSibling;
+			default:
+				return SelectorCombinatorEnum.descendant;
+		}
+	}
+
+	/**
+	 * Converts a single AST node to a SelectorItem.
+	 * @param ast
+	 * @param combinator
+	 * @param scope
+	 * @param ignoreErrors
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
+	 * @param escapeMap
+	 */
+	private static astNodeToSelectorItem(
+		ast: AST,
+		combinator: SelectorCombinatorEnum,
+		scope: Element | DocumentFragment | undefined,
+		ignoreErrors: boolean | undefined,
+		options: { scope?: Element | DocumentFragment; ignoreErrors?: boolean } | undefined,
+		escapeMap: Map<string, string>
+	): SelectorItem {
+		const item = new SelectorItem({ scope, combinator, ignoreErrors });
+
+		if (ast.type === 'compound') {
+			for (const token of ast.list) {
+				this.applyTokenToSelectorItem(token, item, options, escapeMap);
+			}
+		} else {
+			this.applyTokenToSelectorItem(ast, item, options, escapeMap);
+		}
+
+		return item;
+	}
+
+	/**
+	 * Extracts the name from a token, handling escaped characters.
+	 * parsel-js returns only the part before escaped characters in `name`,
+	 * but the full content is in `content`. We need to extract the full name.
+	 * @param token
+	 * @param prefix The prefix to remove (e.g., '#' for id, '.' for class)
+	 * @param escapeMap
+	 */
+	private static extractNameFromToken(
+		token: AST,
+		prefix: string,
+		escapeMap: Map<string, string>
+	): string {
+		// Cast to access content and name properties
+		const tokenWithContent = <{ content: string; name: string }>token;
+
+		// Get the content and remove the prefix
+		let name = tokenWithContent.content.startsWith(prefix)
+			? tokenWithContent.content.slice(prefix.length)
+			: tokenWithContent.name;
+
+		// Restore any pre-processed escape placeholders
+		name = this.restoreEscapedChars(name, escapeMap);
+
+		// Remove remaining escape characters (backslash followed by any char becomes just the char)
+		name = name.replace(ESCAPED_CHARACTER_REGEXP, '$1');
+
+		return name;
+	}
+
+	/**
+	 * Applies a token to a SelectorItem.
+	 * @param token
+	 * @param item
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
+	 * @param escapeMap
+	 */
+	private static applyTokenToSelectorItem(
+		token: AST,
+		item: SelectorItem,
+		options: { scope?: Element | DocumentFragment; ignoreErrors?: boolean } | undefined,
+		escapeMap: Map<string, string>
+	): void {
+		switch (token.type) {
+			case 'universal':
+				item.tagName = '*';
+				break;
+			case 'type':
+				item.tagName = token.name.toUpperCase();
+				break;
+			case 'id':
+				item.id = this.extractNameFromToken(token, '#', escapeMap);
+				break;
+			case 'class':
+				item.classNames = item.classNames || [];
+				item.classNames.push(this.extractNameFromToken(token, '.', escapeMap));
+				break;
+			case 'attribute':
+				item.attributes = item.attributes || [];
+				item.attributes.push(this.parseAttribute(token, escapeMap));
+				break;
+			case 'pseudo-class':
+				item.pseudos = item.pseudos || [];
+				item.pseudos.push(this.parsePseudoClass(token, options, escapeMap));
+				break;
+			case 'pseudo-element':
+				item.isPseudoElement = true;
+				break;
+		}
+	}
+
+	/**
+	 * Parses an attribute token into ISelectorAttribute.
+	 * @param token
+	 * @param escapeMap
+	 */
+	private static parseAttribute(token: AST, escapeMap: Map<string, string>): ISelectorAttribute {
+		const attrToken = <
+			{
+				name: string;
+				value?: string;
+				operator?: string;
+				caseSensitive?: string;
+				content: string;
+			}
+		>token;
+
+		// Extract attribute name, handling escaped characters
+		let attrName = this.restoreEscapedChars(attrToken.name, escapeMap);
+		attrName = attrName.replace(ESCAPED_CHARACTER_REGEXP, '$1');
+
+		// Extract attribute value from content if parsel-js parsed it incorrectly
+		let value: string | null = null;
+		if (attrToken.value !== undefined) {
+			// Try to extract value from content for cases where parsel-js fails (e.g., brackets in value)
+			value = this.extractAttributeValue(attrToken.content, escapeMap);
+			if (value === null) {
+				value = attrToken.value;
+				// Restore escape placeholders
+				value = this.restoreEscapedChars(value, escapeMap);
+				// Strip quotes if present
+				if (
+					(value.startsWith('"') && value.endsWith('"')) ||
+					(value.startsWith("'") && value.endsWith("'"))
+				) {
+					value = value.slice(1, -1);
+				}
+				// Remove escape characters
+				value = value.replace(ESCAPED_CHARACTER_REGEXP, '$1');
+			}
+		}
+
+		let operator: string | null = null;
+		if (attrToken.operator) {
+			operator = attrToken.operator.replace('=', '');
+			if (operator === '') {
+				operator = null;
+			}
+		}
+
+		const modifier = <'s' | 'i'>attrToken.caseSensitive?.toLowerCase() ?? null;
+
+		return {
+			name: attrName,
+			operator,
+			value,
+			modifier,
+			regExp: this.getAttributeRegExp({ operator, value, modifier })
+		};
+	}
+
+	/**
+	 * Extracts attribute value from the full content string.
+	 * This handles cases where parsel-js fails to parse values correctly (e.g., brackets).
+	 * @param content
+	 * @param escapeMap
+	 */
+	private static extractAttributeValue(
+		content: string,
+		escapeMap: Map<string, string>
+	): string | null {
+		// Match [name="value"] or [name='value'] or [name=value]
+		// Also handles empty values like [name=""]
+		const match = content.match(/\[[^\]]*?=\s*(['"])?(.*?)\1\s*(?:[iIsS]\s*)?\]$/);
+		if (match) {
+			let value = match[2];
+			value = this.restoreEscapedChars(value, escapeMap);
+			value = value.replace(ESCAPED_CHARACTER_REGEXP, '$1');
+			return value;
+		}
+		return null;
+	}
+
+	/**
+	 * Parses a pseudo-class token into ISelectorPseudo.
+	 * @param token
+	 * @param options
+	 * @param options.scope
+	 * @param options.ignoreErrors
+	 * @param escapeMap
+	 */
+	private static parsePseudoClass(
+		token: AST,
+		options: { scope?: Element | DocumentFragment; ignoreErrors?: boolean } | undefined,
+		escapeMap: Map<string, string>
+	): ISelectorPseudo {
+		const pseudoToken = <{ name: string; argument?: string }>token;
+		const name = pseudoToken.name.toLowerCase();
+		let args = pseudoToken.argument ?? null;
+
+		// Restore escape placeholders in arguments
+		if (args) {
+			args = this.restoreEscapedChars(args, escapeMap);
+		}
+
+		if (!args) {
+			return { name, arguments: null, selectorItems: null, nthFunction: null };
+		}
+
+		switch (name) {
+			case 'nth-last-child':
+			case 'nth-child': {
+				const nthOfIndex = args.indexOf(' of ');
+				const nthFunction = nthOfIndex !== -1 ? args.substring(0, nthOfIndex) : args;
+				const selectorItem =
+					nthOfIndex !== -1
+						? this.getSelectorItem(args.substring(nthOfIndex + 4).trim(), options)
+						: null;
+				return {
+					name,
+					arguments: args,
+					selectorItems: selectorItem ? [selectorItem] : null,
+					nthFunction: this.getPseudoNthFunction(nthFunction)
+				};
+			}
+			case 'nth-of-type':
+			case 'nth-last-of-type':
+				return {
+					name,
+					arguments: args,
+					selectorItems: null,
+					nthFunction: this.getPseudoNthFunction(args)
+				};
+			case 'not': {
+				const notSelectorItems: SelectorItem[] = [];
+				for (const group of this.getSelectorGroups(args, options)) {
+					notSelectorItems.push(group[0]);
+				}
+				return { name, arguments: args, selectorItems: notSelectorItems, nthFunction: null };
+			}
+			case 'is':
+			case 'where': {
+				const selectorItems: SelectorItem[] = [];
+				for (const group of this.getSelectorGroups(args, options)) {
+					selectorItems.push(group[0]);
+				}
+				return { name, arguments: args, selectorItems, nthFunction: null };
+			}
+			case 'has': {
+				const hasSelectorItems: SelectorItem[] = [];
+				// Trim the arguments to handle cases like ":has( +h2)"
+				const trimmedArgs = args.trim();
+				if (!args.includes(':has(')) {
+					let newArgs = trimmedArgs;
+					// Check for combinator at the start (after trimming whitespace)
+					if (newArgs.startsWith('+')) {
+						newArgs = newArgs.slice(1).trim();
+					} else if (newArgs.startsWith('>')) {
+						newArgs = newArgs.slice(1).trim();
+					}
+					for (const group of this.getSelectorGroups(newArgs, options)) {
+						hasSelectorItems.push(group[0]);
+					}
+				}
+				// Store trimmed arguments so SelectorItem can check combinator correctly
+				return { name, arguments: trimmedArgs, selectorItems: hasSelectorItems, nthFunction: null };
+			}
+			default:
+				return { name, arguments: args, selectorItems: null, nthFunction: null };
+		}
 	}
 
 	/**
 	 * Returns attribute RegExp.
-	 *
-	 * @param attribute Attribute.
-	 * @param attribute.value Attribute value.
-	 * @param attribute.operator Attribute operator.
-	 * @param attribute.modifier Attribute modifier.
-	 * @returns Attribute RegExp.
+	 * @param attribute
+	 * @param attribute.value
+	 * @param attribute.operator
+	 * @param attribute.modifier
 	 */
 	private static getAttributeRegExp(attribute: {
-		value?: string;
-		operator?: string;
-		modifier?: string;
+		value?: string | null;
+		operator?: string | null;
+		modifier?: string | null;
 	}): RegExp | null {
 		const modifier = attribute.modifier === 'i' ? 'i' : '';
 
@@ -272,23 +544,17 @@ export default class SelectorParser {
 			return null;
 		}
 
-		// Escape special regex characters in the value
 		const escapedValue = attribute.value.replace(ATTRIBUTE_ESCAPE_REGEXP, '\\$&');
 
 		switch (attribute.operator) {
-			// [attribute~="value"] - Contains a specified word.
 			case '~':
 				return new RegExp(`[- ]${escapedValue}|${escapedValue}[- ]|^${escapedValue}$`, modifier);
-			// [attribute|="value"] - Starts with the specified word.
 			case '|':
 				return new RegExp(`^${escapedValue}[- ]|^${escapedValue}$`, modifier);
-			// [attribute^="value"] - Begins with a specified value.
 			case '^':
 				return new RegExp(`^${escapedValue}`, modifier);
-			// [attribute$="value"] - Ends with a specified value.
 			case '$':
 				return new RegExp(`${escapedValue}$`, modifier);
-			// [attribute*="value"] - Contains a specified value.
 			case '*':
 				return new RegExp(`${escapedValue}`, modifier);
 			default:
@@ -297,116 +563,8 @@ export default class SelectorParser {
 	}
 
 	/**
-	 * Returns pseudo.
-	 *
-	 * @param name Pseudo name.
-	 * @param args Pseudo arguments.
-	 * @param [options] Options.
-	 * @param [options.scope] Scope.
-	 * @param [options.ignoreErrors] Ignores errors.
-	 * @returns Pseudo.
-	 */
-	private static getPseudo(
-		name: string,
-		args: string | null | undefined,
-		options?: {
-			scope?: Element | DocumentFragment;
-			ignoreErrors?: boolean;
-		}
-	): ISelectorPseudo {
-		const lowerName = name.toLowerCase();
-
-		if (args) {
-			args = args.trim();
-		}
-
-		if (!args) {
-			return { name: lowerName, arguments: null, selectorItems: null, nthFunction: null };
-		}
-
-		switch (lowerName) {
-			case 'nth-last-child':
-			case 'nth-child':
-				const nthOfIndex = args.indexOf(' of ');
-				const nthFunction = nthOfIndex !== -1 ? args.substring(0, nthOfIndex) : args;
-				const selectorItem =
-					nthOfIndex !== -1
-						? this.getSelectorItem(args.substring(nthOfIndex + 4).trim(), options)
-						: null;
-				return {
-					name: lowerName,
-					arguments: args,
-					selectorItems: selectorItem ? [selectorItem] : null,
-					nthFunction: this.getPseudoNthFunction(nthFunction)
-				};
-			case 'nth-of-type':
-			case 'nth-last-of-type':
-				return {
-					name: lowerName,
-					arguments: args,
-					selectorItems: null,
-					nthFunction: this.getPseudoNthFunction(args)
-				};
-			case 'not':
-				const notSelectorItems = [];
-				for (const group of this.getSelectorGroups(args, options)) {
-					notSelectorItems.push(group[0]);
-				}
-				return {
-					name: lowerName,
-					arguments: args,
-					selectorItems: notSelectorItems,
-					nthFunction: null
-				};
-			case 'is':
-			case 'where':
-				const selectorItems = [];
-				for (const group of this.getSelectorGroups(args, options)) {
-					selectorItems.push(group[0]);
-				}
-				return {
-					name: lowerName,
-					arguments: args,
-					selectorItems,
-					nthFunction: null
-				};
-			case 'has':
-				const hasSelectorItems = [];
-
-				// The ":has()" pseudo selector doesn't allow for it to be nested inside another ":has()" pseudo selector, as it can lead to cyclic querying.
-				if (!args.includes(':has(')) {
-					let newArgs = args;
-					if (args[0] === '+') {
-						newArgs = args.replace('+', '');
-					} else if (args[0] === '>') {
-						newArgs = args.replace('>', '');
-					}
-					for (const group of this.getSelectorGroups(newArgs, options)) {
-						hasSelectorItems.push(group[0]);
-					}
-				}
-
-				return {
-					name: lowerName,
-					arguments: args || '',
-					selectorItems: hasSelectorItems,
-					nthFunction: null
-				};
-			case 'scope':
-			case 'root':
-			default:
-				return { name: lowerName, arguments: args, selectorItems: null, nthFunction: null };
-		}
-	}
-
-	/**
 	 * Returns pseudo nth function.
-	 *
-	 * Based on:
-	 * https://github.com/dperini/nwsapi/blob/master/src/nwsapi.js
-	 *
-	 * @param args Pseudo arguments.
-	 * @returns Pseudo nth function.
+	 * @param args
 	 */
 	private static getPseudoNthFunction(args?: string): ((n: number) => boolean) | null {
 		if (!args) {


### PR DESCRIPTION
Fixes #1910

## Problem

Complex CSS selectors with deeply nested pseudo-classes were being parsed incorrectly, causing wrong query results. For example:

```css
.emXRrt:not(:has(> tbody > tr:not([data-ignore-row])))>thead>tr>th:nth-child(2)
```

The issue was that the custom regex-based parser only handled one level of nested parentheses.

## Solution

Replaced the custom regex-based CSS selector parser with [parsel-js](https://parsel.verou.me/), a battle-tested CSS selector parser by Lea Verou.

Benefits:
- Handles arbitrarily nested parentheses correctly
- More spec-compliant CSS selector parsing  
- Well-maintained external library (~5KB minified)
- Reduces custom parsing code complexity
- Handles edge cases we may not have considered

## Implementation Details

The new parser:
1. Pre-processes selectors to handle escaped characters that parsel-js can't handle (e.g., `\:`, `\#`, `\&`, `\[`, `\]`)
2. Uses parsel-js to parse the selector into an AST
3. Converts the AST to the existing `SelectorItem` format
4. Restores escaped characters in the final output

Edge cases handled:
- Escaped characters in class names, IDs, and attribute names
- Empty attribute values (`[attr=""]`)
- Brackets in attribute values (`[attr="bracket[]bracket"]`)
- Space before combinators in `:has()` (e.g., `:has( +h2)`)

## Testing

Added two test cases for issue #1910:
1. The exact selector from the issue report with a table structure
2. A simpler test case demonstrating `:not(:has(> .child:not([attr])))` parsing

Updated tests for stricter CSS compliance:
- Invalid selectors (`.before:`, `.before&after`, `button:not([type]`) now throw errors instead of returning empty results
- Fixed test for escaped colon in attribute selector to use correct attribute name

## Changes

- `packages/happy-dom/package.json`: Added `parsel-js` dependency
- `packages/happy-dom/src/query-selector/SelectorParser.ts`: Rewrote to use parsel-js for parsing
- `packages/happy-dom/test/query-selector/QuerySelector.test.ts`: Added tests for issue #1910 and updated edge case tests
