### PR TITLE
fix: [#1914] InnerText behavior to match browsers

### DIFF
--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -702,7 +702,8 @@ export default class HTMLElement extends Element {
 					}
 				}
 			} else if (childNode[PropertySymbol.nodeType] === NodeTypeEnum.textNode) {
-				result += childNode.textContent.replace(/[\n\r]/, '');
+				// Replace newlines with spaces per spec (\r\n matched first as single break)
+				result += childNode.textContent.replace(/\r\n|\n|\r/g, ' ');
 			}
 		}
 
@@ -722,7 +723,12 @@ export default class HTMLElement extends Element {
 			this.removeChild(childNodes[0]);
 		}
 
-		const texts = text.split(/[\n\r]/);
+		// Empty string should clear all children without adding any nodes
+		if (text === '') {
+			return;
+		}
+
+		const texts = text.split(/\r\n|\n|\r/);
 		const ownerDocument = this[PropertySymbol.ownerDocument];
 
 		for (let i = 0, max = texts.length; i < max; i++) {
@@ -756,7 +762,7 @@ export default class HTMLElement extends Element {
 			);
 		}
 
-		const texts = text.split(/[\n\r]/);
+		const texts = text.split(/\r\n|\n|\r/);
 
 		for (let i = 0, max = texts.length; i < max; i++) {
 			if (i !== 0) {

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -310,6 +310,14 @@ describe('HTMLElement', () => {
 			element.innerHTML = '<div><span><svg>Test</svg></span>123<div>';
 			expect(element.innerText).toBe('123');
 		});
+
+		// Issue #1914: innerText should replace newlines with spaces when connected
+		it('Replaces newlines and carriage returns with spaces when connected.', () => {
+			const div = document.createElement('div');
+			div.replaceChildren(document.createTextNode('hello\n\nworld\r\ntest'));
+			document.body.replaceChildren(div);
+			expect(document.body.innerText).toBe('hello  world test');
+		});
 	});
 
 	describe('set innerText()', () => {
@@ -328,6 +336,14 @@ describe('HTMLElement', () => {
 			expect(element.innerText).toBe(element.textContent);
 			expect(element.childNodes.length).toBe(1);
 			expect(element.childNodes[0].textContent).toBe('new_text');
+		});
+
+		// Issue #1914: Setting innerText to empty string should clear all children
+		it('Clears all children when set to empty string.', () => {
+			element.innerHTML = '<div><span>Hello</span></div>';
+			element.innerText = '';
+			expect(element.innerHTML).toBe('');
+			expect(element.childNodes.length).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
Fixes #1914

## Problem

The `innerText` property had three behaviors that differed from browsers:

1. **Getter**: Newlines in text nodes were removed instead of replaced with spaces, and only the first occurrence was affected (missing global flag)
   ```javascript
   const div = document.createElement('div');
   div.replaceChildren(document.createTextNode('hello\nworld'));
   document.body.replaceChildren(div);
   console.log(document.body.innerText);
   // happy-dom (before): 'helloworld'
   // browsers (Firefox, Chrome): 'hello world'
   ```

2. **Setter**: Setting `innerText = ''` left an empty text node instead of clearing all children
   ```javascript
   element.innerHTML = '<div><span>Hello</span></div>';
   element.innerText = '';
   console.log(element.childNodes.length);
   // happy-dom (before): 1 (empty text node)
   // browsers: 0
   ```

3. **Setter (`innerText` and `outerText`)**: `\r\n` was split into two line breaks instead of one, because the split regex `[\n\r]` matches `\r` and `\n` individually
   ```javascript
   element.innerText = 'hello\r\nworld';
   console.log(element.innerHTML);
   // happy-dom (before): 'hello<br><br>world'
   // browsers: 'hello<br>world'
   ```

## Solution

### Getter fix
- Changed regex from `/[\n\r]/` to `/\r\n|\n|\r/g`
- Replaces newlines with spaces instead of removing them
- Handles `\r\n` as a single line break via alternation order
- Uses global flag to replace all occurrences

### Setter fix (`innerText` and `outerText`)
- Added early return in `set innerText` when text is empty string, clearing all children without adding any nodes
- Changed split regex from `/[\n\r]/` to `/\r\n|\n|\r/` in both `set innerText` and `set outerText` so that `\r\n` produces a single `<br>` instead of two

## Testing

Added 2 new test cases:
- Getter: newline, consecutive newline, and `\r\n` replacement with spaces when element is connected
- Setter: empty string clears all children
