### PR TITLE
fix: [#1916] Object.keys/Reflect.ownKeys return custom properties on HTMLSelectElement

### DIFF
--- a/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.ownKeys.test.ts
+++ b/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.ownKeys.test.ts
@@ -1,0 +1,80 @@
+import Window from '../../../src/window/Window.js';
+import type Document from '../../../src/nodes/document/Document.js';
+import type HTMLSelectElement from '../../../src/nodes/html-select-element/HTMLSelectElement.js';
+import { beforeEach, describe, it, expect } from 'vitest';
+
+describe('HTMLSelectElement', () => {
+	let window: Window;
+	let document: Document;
+	let element: HTMLSelectElement;
+
+	beforeEach(() => {
+		window = new Window();
+		document = window.document;
+		element = <HTMLSelectElement>document.createElement('select');
+	});
+
+	describe('Object.keys()', () => {
+		it('Returns an empty array when there are no options.', () => {
+			expect(Object.keys(element)).toEqual([]);
+		});
+
+		it('Returns only option indices when no custom properties are set.', () => {
+			element.appendChild(document.createElement('option'));
+			element.appendChild(document.createElement('option'));
+
+			expect(Object.keys(element)).toEqual(['0', '1']);
+		});
+
+		it('Returns option indices and custom string properties.', () => {
+			element.appendChild(document.createElement('option'));
+			element.appendChild(document.createElement('option'));
+			(<any>element).foo = 42;
+
+			expect(Object.keys(element)).toEqual(['0', '1', 'foo']);
+		});
+
+		it('Does not include a deleted custom property.', () => {
+			element.appendChild(document.createElement('option'));
+			(<any>element).foo = 42;
+
+			expect(Object.keys(element)).toEqual(['0', 'foo']);
+
+			delete (<any>element).foo;
+
+			expect(Object.keys(element)).toEqual(['0']);
+		});
+	});
+
+	describe('Object.getOwnPropertySymbols()', () => {
+		it('Returns custom symbol properties.', () => {
+			const barSymbol = Symbol('bar');
+			(<any>element)[barSymbol] = 43;
+
+			expect(Object.getOwnPropertySymbols(element)).toEqual([barSymbol]);
+		});
+	});
+
+	describe('Object.getOwnPropertyDescriptor()', () => {
+		it('Returns descriptor for option index properties.', () => {
+			element.appendChild(document.createElement('option'));
+
+			const descriptor = Object.getOwnPropertyDescriptor(element, '0');
+
+			expect(descriptor).toBeDefined();
+			expect(descriptor!.value).toBe(element.options[0]);
+			expect(descriptor!.enumerable).toBe(true);
+			expect(descriptor!.configurable).toBe(true);
+		});
+
+		it('Returns descriptor for custom symbol properties.', () => {
+			const barSymbol = Symbol('bar');
+			(<any>element)[barSymbol] = 43;
+
+			const descriptor = Object.getOwnPropertyDescriptor(element, barSymbol);
+
+			expect(descriptor).toBeDefined();
+			expect(descriptor!.value).toBe(43);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1916 - `Object.keys`, `Object.getOwnPropertyNames`, `Object.getOwnPropertySymbols`, and `Object.getOwnPropertyDescriptors` now correctly return only option indices and custom properties set on `HTMLSelectElement` instances.

## Problem

The `HTMLSelectElement` uses a Proxy to support indexed access to options (e.g., `select[0]`). However, the `ownKeys` trap only returned numeric indices from the options collection, ignoring any custom string or symbol properties set on the element.

```js
const select = document.createElement('select');
select.appendChild(document.createElement('option'));
select.appendChild(document.createElement('option'));
select.foo = 42;
select[Symbol('bar')] = 43;

// Before fix:
Object.keys(select);                    // ['0', '1'] - missing 'foo'
Object.getOwnPropertySymbols(select);   // [] - missing Symbol(bar)
```

Additionally, the `getOwnPropertyDescriptor` trap would return `undefined` for custom string properties not already on the target, and the `defineProperty` trap would throw a `TypeError` when called with a symbol property (because `Number(symbol)` throws).

## Solution

Updated the Proxy traps in `HTMLSelectElement`:

1. **`ownKeys`** - A `customProperties` Set tracks user-set string and symbol properties. The `set`, `defineProperty`, and `deleteProperty` traps maintain this set, only adding properties that don't already exist on the target (avoiding internal/built-in properties). `ownKeys` returns option indices merged with the custom properties set.

2. **`getOwnPropertyDescriptor`** - Added early handling for symbol properties to prevent `Number(symbol)` from throwing. Reordered logic to check numeric indices first, then fall back to the target's own property descriptor.

3. **`defineProperty`** - Added early handling for symbol properties (same `Number(symbol)` crash fix). Tracks newly defined properties in the custom properties set.

## Testing

Added 7 tests covering:
- `Object.keys()` with no options, with options only, with options + custom properties, and after deleting a custom property
- `Object.getOwnPropertySymbols()` with a custom symbol property
- `Object.getOwnPropertyDescriptor()` for option indices and custom symbol properties
