### PR TITLE
fix: [#1913] Make CSSStyleRule.selectorText settable per CSSOM spec

### DIFF
--- a/packages/happy-dom/src/css/rules/CSSStyleRule.ts
+++ b/packages/happy-dom/src/css/rules/CSSStyleRule.ts
@@ -55,6 +55,16 @@ export default class CSSStyleRule extends CSSGroupingRule {
 	}
 
 	/**
+	 * Sets selector text.
+	 *
+	 * @see https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext
+	 * @param selectorText Selector text.
+	 */
+	public set selectorText(selectorText: string) {
+		this[PropertySymbol.selectorText] = selectorText;
+	}
+
+	/**
 	 * Returns style.
 	 *
 	 * @returns Style.


### PR DESCRIPTION
Fixes #1913 - `CSSStyleRule.selectorText` is now writable, restoring behavior that was present in v18 and aligning with the [CSSOM specification](https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext).

## Problem

In v19, `CSSStyleRule.selectorText` was changed to a getter-only property. This broke code that relies on modifying CSS selectors via the CSSOM, such as scoping CSS selectors programmatically:

```ts
// This worked in v18 but threw in v19:
// TypeError: Cannot set property selectorText of #<CSSStyleRule> which has only a getter
rule.selectorText = `.scope ${rule.selectorText}`;
```

## Solution

Added a setter for `selectorText` that updates the internal `PropertySymbol.selectorText` value.

## Changes

- `packages/happy-dom/src/css/rules/CSSStyleRule.ts`: Added `set selectorText()` method
- `packages/happy-dom/test/css/rules/CSSStyleRule.test.ts`: Added test cases for the setter

## Testing

Added two test cases:
1. Basic setter functionality test
2. Real-world use case from issue #1913 (scoping CSS selectors via CSSOM)
