### PR TITLE
fix: [#1924] Wrap SubtleCrypto to handle cross-realm ArrayBuffer in VM contexts

### DIFF
--- a/packages/happy-dom/src/crypto/CryptoWrapper.ts
+++ b/packages/happy-dom/src/crypto/CryptoWrapper.ts
@@ -1,0 +1,55 @@
+import { webcrypto } from 'crypto';
+import SubtleCryptoWrapper from './SubtleCryptoWrapper.js';
+
+type NodeSubtleCrypto = webcrypto.SubtleCrypto;
+
+/**
+ * Wraps Node.js webcrypto to handle cross-realm ArrayBuffer issues.
+ *
+ * When Happy DOM runs in a VM context (e.g., Jest environment), ArrayBuffer
+ * instances created in the VM context are not recognized by Node.js's native
+ * webcrypto implementation because they fail instanceof checks.
+ *
+ * This wrapper provides a SubtleCrypto implementation that converts buffer
+ * arguments to Node.js's realm before passing them to the underlying implementation.
+ *
+ * @see https://github.com/capricorn86/happy-dom/issues/1924
+ */
+export default class CryptoWrapper {
+	readonly #subtle: SubtleCryptoWrapper;
+
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		this.#subtle = new SubtleCryptoWrapper();
+	}
+
+	/**
+	 * Returns the SubtleCrypto interface.
+	 *
+	 * @returns SubtleCrypto interface.
+	 */
+	public get subtle(): NodeSubtleCrypto {
+		return <NodeSubtleCrypto>(<unknown>this.#subtle);
+	}
+
+	/**
+	 * Fills the provided TypedArray with cryptographically secure random values.
+	 *
+	 * @param array Array to fill.
+	 * @returns The input array filled with random values.
+	 */
+	public getRandomValues<T extends ArrayBufferView | null>(array: T): T {
+		return <T>(<unknown>webcrypto.getRandomValues(<Uint8Array>(<unknown>array)));
+	}
+
+	/**
+	 * Generates a random UUID.
+	 *
+	 * @returns A random UUID string.
+	 */
+	public randomUUID(): `${string}-${string}-${string}-${string}-${string}` {
+		return webcrypto.randomUUID();
+	}
+}

--- a/packages/happy-dom/src/crypto/SubtleCryptoWrapper.ts
+++ b/packages/happy-dom/src/crypto/SubtleCryptoWrapper.ts
@@ -1,0 +1,451 @@
+import { webcrypto } from 'crypto';
+
+// Import WebCrypto types from Node.js
+type BufferSource = ArrayBufferView | ArrayBuffer;
+type CryptoKey = webcrypto.CryptoKey;
+type CryptoKeyPair = webcrypto.CryptoKeyPair;
+type SubtleCrypto = webcrypto.SubtleCrypto;
+type AlgorithmIdentifier = webcrypto.AlgorithmIdentifier;
+type KeyFormat = webcrypto.KeyFormat;
+type KeyUsage = webcrypto.KeyUsage;
+type JsonWebKey = webcrypto.JsonWebKey;
+
+// Algorithm parameter types
+type RsaOaepParams = webcrypto.RsaOaepParams;
+type AesCtrParams = webcrypto.AesCtrParams;
+type AesCbcParams = webcrypto.AesCbcParams;
+type AesGcmParams = webcrypto.AesGcmParams;
+type RsaPssParams = webcrypto.RsaPssParams;
+type EcdsaParams = webcrypto.EcdsaParams;
+type RsaHashedKeyGenParams = webcrypto.RsaHashedKeyGenParams;
+type EcKeyGenParams = webcrypto.EcKeyGenParams;
+type AesKeyGenParams = webcrypto.AesKeyGenParams;
+type HmacKeyGenParams = webcrypto.HmacKeyGenParams;
+type Pbkdf2Params = webcrypto.Pbkdf2Params;
+type EcdhKeyDeriveParams = webcrypto.EcdhKeyDeriveParams;
+type HkdfParams = webcrypto.HkdfParams;
+type AesDerivedKeyParams = webcrypto.AesDerivedKeyParams;
+type HmacImportParams = webcrypto.HmacImportParams;
+type RsaHashedImportParams = webcrypto.RsaHashedImportParams;
+type EcKeyImportParams = webcrypto.EcKeyImportParams;
+type AesKeyAlgorithm = webcrypto.AesKeyAlgorithm;
+
+/**
+ * Converts a buffer from any realm to the current Node.js realm.
+ *
+ * This is necessary because when running in VM contexts (like Jest environments),
+ * ArrayBuffer instances from the VM context fail instanceof checks against
+ * Node.js's ArrayBuffer, causing webcrypto methods to reject valid buffers.
+ *
+ * @see https://github.com/capricorn86/happy-dom/issues/1924
+ * @param buffer The buffer to convert.
+ * @returns A buffer in the current Node.js realm.
+ */
+function toNodeRealm(buffer: BufferSource): BufferSource {
+	if (buffer instanceof ArrayBuffer) {
+		// Already in Node's realm
+		return buffer;
+	}
+
+	if (ArrayBuffer.isView(buffer)) {
+		// TypedArray or DataView - check if the underlying buffer needs conversion
+		if (buffer.buffer instanceof ArrayBuffer) {
+			return buffer;
+		}
+		// Convert the underlying ArrayBuffer to Node's realm
+		const nodeBuffer = new Uint8Array(Buffer.from(buffer.buffer)).buffer;
+		if (buffer instanceof DataView) {
+			return new DataView(nodeBuffer, buffer.byteOffset, buffer.byteLength);
+		}
+		// For TypedArrays, create a new view of the same type
+		const TypedArrayConstructor = <
+			new (buffer: ArrayBuffer, byteOffset: number, length: number) => ArrayBufferView
+		>buffer.constructor;
+		return new TypedArrayConstructor(
+			nodeBuffer,
+			buffer.byteOffset,
+			buffer.byteLength / ((<{ BYTES_PER_ELEMENT?: number }>buffer).BYTES_PER_ELEMENT || 1)
+		);
+	}
+
+	// ArrayBuffer from another realm - convert via Buffer
+	return new Uint8Array(Buffer.from(buffer)).buffer;
+}
+
+/**
+ * Wraps Node.js webcrypto.subtle to handle cross-realm ArrayBuffer issues.
+ *
+ * When Happy DOM runs in a VM context (e.g., Jest environment), ArrayBuffer
+ * instances created in the VM context are not recognized by Node.js's native
+ * webcrypto implementation because they fail instanceof checks.
+ *
+ * This wrapper converts buffer arguments to Node.js's realm before passing
+ * them to the underlying SubtleCrypto implementation.
+ *
+ * @see https://github.com/capricorn86/happy-dom/issues/1924
+ * @see https://github.com/nodejs/node/issues/55380
+ */
+export default class SubtleCryptoWrapper implements SubtleCrypto {
+	readonly #subtle: SubtleCrypto;
+
+	/**
+	 * Constructor.
+	 */
+	constructor() {
+		this.#subtle = webcrypto.subtle;
+	}
+
+	/**
+	 * Encrypts data.
+	 *
+	 * @param algorithm Encryption algorithm.
+	 * @param key Encryption key.
+	 * @param data Data to encrypt.
+	 * @returns Encrypted data.
+	 */
+	public async encrypt(
+		algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams,
+		key: CryptoKey,
+		data: BufferSource
+	): Promise<ArrayBuffer> {
+		return this.#subtle.encrypt(algorithm, key, toNodeRealm(data));
+	}
+
+	/**
+	 * Decrypts data.
+	 *
+	 * @param algorithm Decryption algorithm.
+	 * @param key Decryption key.
+	 * @param data Data to decrypt.
+	 * @returns Decrypted data.
+	 */
+	public async decrypt(
+		algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams,
+		key: CryptoKey,
+		data: BufferSource
+	): Promise<ArrayBuffer> {
+		return this.#subtle.decrypt(algorithm, key, toNodeRealm(data));
+	}
+
+	/**
+	 * Signs data.
+	 *
+	 * @param algorithm Signing algorithm.
+	 * @param key Signing key.
+	 * @param data Data to sign.
+	 * @returns Signature.
+	 */
+	public async sign(
+		algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+		key: CryptoKey,
+		data: BufferSource
+	): Promise<ArrayBuffer> {
+		return this.#subtle.sign(algorithm, key, toNodeRealm(data));
+	}
+
+	/**
+	 * Verifies a signature.
+	 *
+	 * @param algorithm Verification algorithm.
+	 * @param key Verification key.
+	 * @param signature Signature to verify.
+	 * @param data Data that was signed.
+	 * @returns Whether the signature is valid.
+	 */
+	public async verify(
+		algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+		key: CryptoKey,
+		signature: BufferSource,
+		data: BufferSource
+	): Promise<boolean> {
+		return this.#subtle.verify(algorithm, key, toNodeRealm(signature), toNodeRealm(data));
+	}
+
+	/**
+	 * Computes a digest.
+	 *
+	 * @param algorithm Digest algorithm.
+	 * @param data Data to digest.
+	 * @returns Digest.
+	 */
+	public async digest(algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer> {
+		return this.#subtle.digest(algorithm, toNodeRealm(data));
+	}
+
+	/**
+	 * Generates a key or key pair.
+	 *
+	 * @param algorithm Key generation algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Generated key or key pair.
+	 */
+	public async generateKey(
+		algorithm: RsaHashedKeyGenParams | EcKeyGenParams,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKeyPair>;
+	/**
+	 * Generates a key or key pair.
+	 *
+	 * @param algorithm Key generation algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Generated key or key pair.
+	 */
+	public async generateKey(
+		algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKey>;
+	/**
+	 * Generates a key or key pair.
+	 *
+	 * @param algorithm Key generation algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Generated key or key pair.
+	 */
+	public async generateKey(
+		algorithm: AlgorithmIdentifier,
+		extractable: boolean,
+		keyUsages: KeyUsage[]
+	): Promise<CryptoKeyPair | CryptoKey>;
+	/**
+	 * Generates a key or key pair.
+	 *
+	 * @param algorithm Key generation algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Generated key or key pair.
+	 */
+	public async generateKey(
+		algorithm: AlgorithmIdentifier,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKeyPair | CryptoKey> {
+		return this.#subtle.generateKey(
+			<RsaHashedKeyGenParams>algorithm,
+			extractable,
+			<KeyUsage[]>keyUsages
+		);
+	}
+
+	/**
+	 * Derives a key from a master key.
+	 *
+	 * @param algorithm Derivation algorithm.
+	 * @param baseKey Base key.
+	 * @param derivedKeyType Derived key type.
+	 * @param extractable Whether the derived key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Derived key.
+	 */
+	public async deriveKey(
+		algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params,
+		baseKey: CryptoKey,
+		derivedKeyType:
+			| AlgorithmIdentifier
+			| AesDerivedKeyParams
+			| HmacImportParams
+			| HkdfParams
+			| Pbkdf2Params,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKey> {
+		return this.#subtle.deriveKey(
+			algorithm,
+			baseKey,
+			derivedKeyType,
+			extractable,
+			<KeyUsage[]>keyUsages
+		);
+	}
+
+	/**
+	 * Derives bits from a master key.
+	 *
+	 * @param algorithm Derivation algorithm.
+	 * @param baseKey Base key.
+	 * @param length Number of bits to derive.
+	 * @returns Derived bits.
+	 */
+	public async deriveBits(
+		algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params,
+		baseKey: CryptoKey,
+		length: number
+	): Promise<ArrayBuffer> {
+		return this.#subtle.deriveBits(algorithm, baseKey, length);
+	}
+
+	/**
+	 * Imports a key.
+	 *
+	 * @param format Key format.
+	 * @param keyData Key data.
+	 * @param algorithm Import algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Imported key.
+	 */
+	public async importKey(
+		format: 'jwk',
+		keyData: JsonWebKey,
+		algorithm:
+			| AlgorithmIdentifier
+			| RsaHashedImportParams
+			| EcKeyImportParams
+			| HmacImportParams
+			| AesKeyAlgorithm,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKey>;
+	/**
+	 * Imports a key.
+	 *
+	 * @param format Key format.
+	 * @param keyData Key data.
+	 * @param algorithm Import algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Imported key.
+	 */
+	public async importKey(
+		format: Exclude<KeyFormat, 'jwk'>,
+		keyData: BufferSource,
+		algorithm:
+			| AlgorithmIdentifier
+			| RsaHashedImportParams
+			| EcKeyImportParams
+			| HmacImportParams
+			| AesKeyAlgorithm,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKey>;
+	/**
+	 * Imports a key.
+	 *
+	 * @param format Key format.
+	 * @param keyData Key data.
+	 * @param algorithm Import algorithm.
+	 * @param extractable Whether the key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Imported key.
+	 */
+	public async importKey(
+		format: KeyFormat,
+		keyData: JsonWebKey | BufferSource,
+		algorithm:
+			| AlgorithmIdentifier
+			| RsaHashedImportParams
+			| EcKeyImportParams
+			| HmacImportParams
+			| AesKeyAlgorithm,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKey> {
+		if (format === 'jwk') {
+			return this.#subtle.importKey(
+				format,
+				<JsonWebKey>keyData,
+				algorithm,
+				extractable,
+				<KeyUsage[]>keyUsages
+			);
+		}
+		return this.#subtle.importKey(
+			format,
+			toNodeRealm(<BufferSource>keyData),
+			algorithm,
+			extractable,
+			<KeyUsage[]>keyUsages
+		);
+	}
+
+	/**
+	 * Exports a key.
+	 *
+	 * @param format Export format.
+	 * @param key Key to export.
+	 * @returns Exported key.
+	 */
+	public async exportKey(format: 'jwk', key: CryptoKey): Promise<JsonWebKey>;
+	/**
+	 * Exports a key.
+	 *
+	 * @param format Export format.
+	 * @param key Key to export.
+	 * @returns Exported key.
+	 */
+	public async exportKey(format: Exclude<KeyFormat, 'jwk'>, key: CryptoKey): Promise<ArrayBuffer>;
+	/**
+	 * Exports a key.
+	 *
+	 * @param format Export format.
+	 * @param key Key to export.
+	 * @returns Exported key.
+	 */
+	public async exportKey(format: KeyFormat, key: CryptoKey): Promise<JsonWebKey | ArrayBuffer> {
+		return this.#subtle.exportKey(<'jwk'>format, key);
+	}
+
+	/**
+	 * Wraps a key.
+	 *
+	 * @param format Key format.
+	 * @param key Key to wrap.
+	 * @param wrappingKey Wrapping key.
+	 * @param wrapAlgorithm Wrap algorithm.
+	 * @returns Wrapped key.
+	 */
+	public async wrapKey(
+		format: KeyFormat,
+		key: CryptoKey,
+		wrappingKey: CryptoKey,
+		wrapAlgorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+	): Promise<ArrayBuffer> {
+		return this.#subtle.wrapKey(format, key, wrappingKey, wrapAlgorithm);
+	}
+
+	/**
+	 * Unwraps a key.
+	 *
+	 * @param format Key format.
+	 * @param wrappedKey Wrapped key.
+	 * @param unwrappingKey Unwrapping key.
+	 * @param unwrapAlgorithm Unwrap algorithm.
+	 * @param unwrappedKeyAlgorithm Unwrapped key algorithm.
+	 * @param extractable Whether the unwrapped key is extractable.
+	 * @param keyUsages Key usages.
+	 * @returns Unwrapped key.
+	 */
+	public async unwrapKey(
+		format: KeyFormat,
+		wrappedKey: BufferSource,
+		unwrappingKey: CryptoKey,
+		unwrapAlgorithm:
+			| AlgorithmIdentifier
+			| RsaOaepParams
+			| AesCtrParams
+			| AesCbcParams
+			| AesGcmParams,
+		unwrappedKeyAlgorithm:
+			| AlgorithmIdentifier
+			| RsaHashedImportParams
+			| EcKeyImportParams
+			| HmacImportParams
+			| AesKeyAlgorithm,
+		extractable: boolean,
+		keyUsages: readonly KeyUsage[]
+	): Promise<CryptoKey> {
+		return this.#subtle.unwrapKey(
+			format,
+			toNodeRealm(wrappedKey),
+			unwrappingKey,
+			unwrapAlgorithm,
+			unwrappedKeyAlgorithm,
+			extractable,
+			<KeyUsage[]>keyUsages
+		);
+	}
+}

--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'buffer';
-import { webcrypto } from 'crypto';
 import { TextEncoder, TextDecoder } from 'util';
 import Stream from 'stream';
 import { ReadableStream } from 'stream/web';
@@ -8,6 +7,7 @@ import VM from 'vm';
 import * as PropertySymbol from '../PropertySymbol.js';
 import Base64 from '../base64/Base64.js';
 import BrowserErrorCaptureEnum from '../browser/enums/BrowserErrorCaptureEnum.js';
+import CryptoWrapper from '../crypto/CryptoWrapper.js';
 import IBrowserFrame from '../browser/types/IBrowserFrame.js';
 import Clipboard from '../clipboard/Clipboard.js';
 import ClipboardItem from '../clipboard/ClipboardItem.js';
@@ -751,7 +751,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	public readonly screenTop: number = 0;
 	public readonly screenX: number = 0;
 	public readonly screenY: number = 0;
-	public readonly crypto: typeof webcrypto = webcrypto;
+	public readonly crypto: CryptoWrapper = new CryptoWrapper();
 	public readonly TextEncoder: typeof TextEncoder = TextEncoder;
 	public readonly TextDecoder: typeof TextDecoder = TextDecoder;
 	public readonly closed = false;

--- a/packages/happy-dom/test/crypto/SubtleCryptoWrapper.test.ts
+++ b/packages/happy-dom/test/crypto/SubtleCryptoWrapper.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import VM from 'vm';
+import Window from '../../src/window/Window.js';
+
+describe('SubtleCryptoWrapper', () => {
+	let window: Window;
+
+	beforeEach(() => {
+		window = new Window();
+	});
+
+	describe('importKey()', () => {
+		it('Imports an Ed25519 public key from SPKI format', async () => {
+			// Valid Ed25519 SPKI public key (44 bytes)
+			const spkiKey = new Uint8Array([
+				0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+				// 32 bytes of public key data
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+				0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
+				0x1f, 0x20
+			]);
+
+			const key = await window.crypto.subtle.importKey('spki', spkiKey.buffer, 'Ed25519', true, [
+				'verify'
+			]);
+
+			expect(key).toBeDefined();
+			expect(key.type).toBe('public');
+			expect(key.algorithm.name).toBe('Ed25519');
+			expect(key.extractable).toBe(true);
+			expect(key.usages).toContain('verify');
+		});
+
+		it('Imports a key from JWK format', async () => {
+			const jwk = {
+				kty: 'oct',
+				k: 'Y0zt37HgOx-BY7SQjYVmrqhPkO44Ii2Jcb9yydUDPfE',
+				alg: 'A256GCM',
+				ext: true
+			};
+
+			const key = await window.crypto.subtle.importKey('jwk', jwk, { name: 'AES-GCM' }, true, [
+				'encrypt',
+				'decrypt'
+			]);
+
+			expect(key).toBeDefined();
+			expect(key.type).toBe('secret');
+			expect(key.algorithm.name).toBe('AES-GCM');
+		});
+	});
+
+	describe('encrypt() and decrypt()', () => {
+		it('Encrypts and decrypts data using AES-GCM', async () => {
+			const key = await window.crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, [
+				'encrypt',
+				'decrypt'
+			]);
+
+			const iv = window.crypto.getRandomValues(new Uint8Array(12));
+			const data = new TextEncoder().encode('Hello, World!');
+
+			const encrypted = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data);
+
+			expect(encrypted).toBeInstanceOf(ArrayBuffer);
+			expect(encrypted.byteLength).toBeGreaterThan(data.byteLength);
+
+			const decrypted = await window.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, encrypted);
+
+			expect(new TextDecoder().decode(decrypted)).toBe('Hello, World!');
+		});
+	});
+
+	describe('sign() and verify()', () => {
+		it('Signs and verifies data using HMAC', async () => {
+			const key = await window.crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, [
+				'sign',
+				'verify'
+			]);
+
+			const data = new TextEncoder().encode('Hello, World!');
+
+			const signature = await window.crypto.subtle.sign('HMAC', key, data);
+
+			expect(signature).toBeInstanceOf(ArrayBuffer);
+
+			const isValid = await window.crypto.subtle.verify('HMAC', key, signature, data);
+
+			expect(isValid).toBe(true);
+		});
+	});
+
+	describe('digest()', () => {
+		it('Computes SHA-256 digest', async () => {
+			const data = new TextEncoder().encode('Hello, World!');
+
+			const digest = await window.crypto.subtle.digest('SHA-256', data);
+
+			expect(digest).toBeInstanceOf(ArrayBuffer);
+			expect(digest.byteLength).toBe(32); // SHA-256 produces 32 bytes
+		});
+	});
+
+	describe('Cross-realm ArrayBuffer handling', () => {
+		it('Handles ArrayBuffer created in a different VM context (issue #1924)', async () => {
+			// Create a VM context to simulate the Jest environment scenario
+			const vmContext = VM.createContext({
+				Uint8Array: Uint8Array,
+				ArrayBuffer: ArrayBuffer
+			});
+
+			// Create an ArrayBuffer in the VM context
+			const vmScript = new VM.Script(`
+				const arr = new Uint8Array([
+					0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+					0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+					0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+					0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
+				]);
+				arr.buffer;
+			`);
+			const vmBuffer = vmScript.runInContext(vmContext);
+
+			// The wrapper should handle buffers from any realm
+			// (In older Node versions, vmBuffer instanceof ArrayBuffer would be false)
+			const key = await window.crypto.subtle.importKey('spki', vmBuffer, 'Ed25519', true, [
+				'verify'
+			]);
+
+			expect(key).toBeDefined();
+			expect(key.type).toBe('public');
+			expect(key.algorithm.name).toBe('Ed25519');
+		});
+
+		it('Handles TypedArray with cross-realm underlying buffer', async () => {
+			const vmContext = VM.createContext({
+				Uint8Array: Uint8Array
+			});
+
+			const vmScript = new VM.Script(`
+				new Uint8Array([
+					0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+					0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+					0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+					0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20
+				]);
+			`);
+			const vmTypedArray = vmScript.runInContext(vmContext);
+
+			// The wrapper should handle this cross-realm TypedArray
+			const key = await window.crypto.subtle.importKey('spki', vmTypedArray, 'Ed25519', true, [
+				'verify'
+			]);
+
+			expect(key).toBeDefined();
+			expect(key.type).toBe('public');
+		});
+	});
+
+	describe('getRandomValues()', () => {
+		it('Fills array with random values', () => {
+			const array = new Uint8Array(16);
+			const result = window.crypto.getRandomValues(array);
+
+			expect(result).toBe(array);
+			// Check that at least some values are non-zero (statistically very likely)
+			expect(array.some((v) => v !== 0)).toBe(true);
+		});
+	});
+
+	describe('randomUUID()', () => {
+		it('Generates a valid UUID', () => {
+			const uuid = window.crypto.randomUUID();
+
+			expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1924 - `crypto.subtle.importKey()` and other SubtleCrypto methods now work correctly in Jest environments using `@happy-dom/jest-environment`.

## Problem

When running tests with Jest using `@happy-dom/jest-environment`, calls to `crypto.subtle` methods that accept buffer arguments (like `importKey`, `encrypt`, `decrypt`, etc.) would fail with:

```
TypeError: Failed to execute 'importKey' on 'SubtleCrypto': 2nd argument is not instance of ArrayBuffer, Buffer, TypedArray, or DataView.
```

This happened because Jest runs tests in a VM context, and ArrayBuffer instances created in that context fail `instanceof` checks against Node.js's native ArrayBuffer. Node's `webcrypto` implementation performs these checks internally, causing valid buffers to be rejected.

The same code works fine when using happy-dom directly (not through Jest) because there's no VM context boundary.

## Solution

Created wrapper classes for `Crypto` and `SubtleCrypto` that convert buffer arguments from any realm to Node.js's realm before passing them to the underlying native implementation.

The `toNodeRealm()` helper function handles:
- `ArrayBuffer` instances from other realms
- `TypedArray` views with cross-realm underlying buffers
- `DataView` instances with cross-realm underlying buffers

## Comparison to jsdom

jsdom doesn't implement `crypto.subtle` at all - it returns `undefined` (see [jsdom#1612](https://github.com/jsdom/jsdom/issues/1612), open since 2016). By contrast, happy-dom already provides full SubtleCrypto support by exposing Node's native webcrypto. This fix ensures that support works correctly in all environments where happy-dom is used.

## Changes

- `packages/happy-dom/src/crypto/SubtleCryptoWrapper.ts` - Wraps all SubtleCrypto methods that accept buffer arguments
- `packages/happy-dom/src/crypto/CryptoWrapper.ts` - Wraps the Crypto interface to use SubtleCryptoWrapper
- `packages/happy-dom/src/window/BrowserWindow.ts` - Uses CryptoWrapper instead of raw webcrypto
- `packages/happy-dom/test/crypto/SubtleCryptoWrapper.test.ts` - Comprehensive tests