### PR TITLE
fix: [#1875] Initialize Attr.value as empty string per DOM spec

### DIFF
--- a/packages/happy-dom/src/nodes/attr/Attr.ts
+++ b/packages/happy-dom/src/nodes/attr/Attr.ts
@@ -17,7 +17,7 @@ export default class Attr extends Node implements Attr {
 	public [PropertySymbol.name]: string | null = null;
 	public [PropertySymbol.localName]: string | null = null;
 	public [PropertySymbol.prefix]: string | null = null;
-	public [PropertySymbol.value]: string | null = null;
+	public [PropertySymbol.value]: string = '';
 	public [PropertySymbol.specified] = true;
 	public [PropertySymbol.ownerElement]: Element | null = null;
 
@@ -45,7 +45,7 @@ export default class Attr extends Node implements Attr {
 	 *
 	 * @returns Value.
 	 */
-	public get value(): string | null {
+	public get value(): string {
 		return this[PropertySymbol.value];
 	}
 
@@ -54,8 +54,8 @@ export default class Attr extends Node implements Attr {
 	 *
 	 * @param value Value.
 	 */
-	public set value(value: string) {
-		this[PropertySymbol.value] = value;
+	public set value(value: string | null) {
+		this[PropertySymbol.value] = value === null ? 'null' : String(value);
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/attr/Attr.test.ts
+++ b/packages/happy-dom/test/nodes/attr/Attr.test.ts
@@ -58,6 +58,25 @@ describe('Attr', () => {
 			attr[PropertySymbol.value] = 'value';
 			expect(attr.value).toBe('value');
 		});
+
+		it('Returns empty string by default per DOM spec.', () => {
+			const attr = document.createAttribute('test');
+			expect(attr.value).toBe('');
+		});
+	});
+
+	describe('set value()', () => {
+		it('Sets value.', () => {
+			const attr = document.createAttribute('test');
+			attr.value = 'newValue';
+			expect(attr.value).toBe('newValue');
+		});
+
+		it('Converts null to string "null" per browser behavior.', () => {
+			const attr = document.createAttribute('test');
+			attr.value = <string>(<unknown>null);
+			expect(attr.value).toBe('null');
+		});
 	});
 
 	describe('get specified()', () => {

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1277,7 +1277,7 @@ describe('Document', () => {
 
 			expect(attribute instanceof window.Attr).toBe(true);
 
-			expect(attribute.value).toBe(null);
+			expect(attribute.value).toBe('');
 			expect(attribute.name).toBe('key1');
 			expect(attribute.namespaceURI).toBe(null);
 			expect(attribute.specified).toBe(true);
@@ -1292,7 +1292,7 @@ describe('Document', () => {
 
 			expect(attribute instanceof Attr).toBe(true);
 
-			expect(attribute.value).toBe(null);
+			expect(attribute.value).toBe('');
 			expect(attribute.name).toBe('KEY1');
 			expect(attribute.namespaceURI).toBe(NamespaceURI.html);
 			expect(attribute.specified).toBe(true);
@@ -1304,7 +1304,7 @@ describe('Document', () => {
 			const attribute = document.createAttributeNS(NamespaceURI.svg, 'KEY1');
 			expect(attribute instanceof Attr).toBe(true);
 
-			expect(attribute.value).toBe(null);
+			expect(attribute.value).toBe('');
 			expect(attribute.name).toBe('KEY1');
 			expect(attribute.namespaceURI).toBe(NamespaceURI.svg);
 			expect(attribute.specified).toBe(true);


### PR DESCRIPTION
Fixes #1875

## Problem

`Attr.value` was initialized as `null`, which is against the DOM Standard. Per the [spec](https://dom.spec.whatwg.org/#concept-attribute):

> Unless explicitly given when an attribute is created, its value is set to the empty string.

```javascript
// Before (incorrect)
const attr = document.createAttribute("foo")
attr.value // null

// Browser behavior (correct)
const attr = document.createAttribute("foo")
attr.value // ''
```

Additionally, setting `attr.value = null` should convert to the string `'null'`, matching browser behavior.

## Solution

- Changed `Attr[PropertySymbol.value]` initialization from `null` to `''`
- Updated getter return type from `string | null` to `string`
- Updated setter to convert `null` to the string `'null'` per browser behavior