### PR TITLE
fix: [#1896] Call disconnectedFromNode on children in disconnectedFromNode

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -1036,7 +1036,7 @@ export default class Node extends EventTarget {
 
 		const childNodes = this[PropertySymbol.nodeArray];
 		for (let i = 0, max = childNodes.length; i < max; i++) {
-			childNodes[i][PropertySymbol.connectedToNode]();
+			childNodes[i][PropertySymbol.disconnectedFromNode]();
 		}
 
 		// eslint-disable-next-line

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -636,6 +636,31 @@ describe('Node', () => {
 			expect(removed).toEqual(child);
 		});
 
+		it('Disconnects nested children when parent is removed from document.', () => {
+			const parent = document.createElement('div');
+			const child = document.createElement('span');
+			const grandchild = document.createElement('a');
+			const text = document.createTextNode('text');
+
+			parent.appendChild(child);
+			child.appendChild(grandchild);
+			grandchild.appendChild(text);
+
+			document.body.appendChild(parent);
+
+			expect(parent.isConnected).toBe(true);
+			expect(child.isConnected).toBe(true);
+			expect(grandchild.isConnected).toBe(true);
+			expect(text.isConnected).toBe(true);
+
+			document.body.removeChild(parent);
+
+			expect(parent.isConnected).toBe(false);
+			expect(child.isConnected).toBe(false);
+			expect(grandchild.isConnected).toBe(false);
+			expect(text.isConnected).toBe(false);
+		});
+
 		it('Supports Node.prototype.removeChild.call(element).', () => {
 			expect(Node.prototype.removeChild).toBe(HTMLElement.prototype.removeChild);
 


### PR DESCRIPTION
Fixes #1896

## Problem

In `Node.disconnectedFromNode()`, child nodes were incorrectly calling `connectedToNode()` instead of `disconnectedFromNode()`.

```typescript
// Before (incorrect)
const childNodes = this[PropertySymbol.nodeArray];
for (let i = 0, max = childNodes.length; i < max; i++) {
    childNodes[i][PropertySymbol.connectedToNode]();  // Wrong!
}
```

This bug caused nested children to not be properly disconnected when their parent was removed from the document, leaving `isConnected` as `true` for grandchildren and deeper descendants.

## Solution

Changed the call from `connectedToNode()` to `disconnectedFromNode()`:

```typescript
// After (correct)
const childNodes = this[PropertySymbol.nodeArray];
for (let i = 0, max = childNodes.length; i < max; i++) {
    childNodes[i][PropertySymbol.disconnectedFromNode]();
}
```

I've added test coverage to prevent future regressions.