### PR TITLE
fix: [#1938] Prevent util.inspect from throwing on href getters

### DIFF
--- a/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
+++ b/packages/happy-dom/src/nodes/html-anchor-element/HTMLAnchorElement.ts
@@ -7,6 +7,26 @@ import HTMLHyperlinkElementUtility from '../html-hyperlink-element/HTMLHyperlink
 import IHTMLHyperlinkElement from '../html-hyperlink-element/IHTMLHyperlinkElement.js';
 import MouseEvent from '../../event/events/MouseEvent.js';
 
+// Used for caching the utility instance - module-scoped symbol to avoid prototype issues
+const HYPERLINK_UTILITY = Symbol('hyperlinkUtility');
+
+/**
+ * Returns the hyperlink utility for an element, creating it if necessary.
+ * Returns null if called on a non-instance (e.g., prototype).
+ *
+ * @param element The element to get the utility for.
+ * @returns The hyperlink utility or null.
+ */
+function getHyperlinkUtility(element: HTMLAnchorElement): HTMLHyperlinkElementUtility | null {
+	if (!(element instanceof HTMLAnchorElement)) {
+		return null;
+	}
+	if (!element[HYPERLINK_UTILITY]) {
+		element[HYPERLINK_UTILITY] = new HTMLHyperlinkElementUtility(element);
+	}
+	return element[HYPERLINK_UTILITY];
+}
+
 /**
  * HTML Anchor Element.
  *
@@ -15,7 +35,7 @@ import MouseEvent from '../../event/events/MouseEvent.js';
  */
 export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyperlinkElement {
 	public [PropertySymbol.relList]: DOMTokenList | null = null;
-	#htmlHyperlinkElementUtility = new HTMLHyperlinkElementUtility(this);
+	public declare [HYPERLINK_UTILITY]: HTMLHyperlinkElementUtility;
 
 	/**
 	 * Returns download.
@@ -41,7 +61,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Hash.
 	 */
 	public get hash(): string {
-		return this.#htmlHyperlinkElementUtility.getHash();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHash() : '';
 	}
 
 	/**
@@ -50,7 +71,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param hash Hash.
 	 */
 	public set hash(hash: string) {
-		this.#htmlHyperlinkElementUtility.setHash(hash);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHash(hash);
 	}
 
 	/**
@@ -59,7 +81,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Href.
 	 */
 	public get href(): string {
-		return this.#htmlHyperlinkElementUtility.getHref();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHref() : '';
 	}
 
 	/**
@@ -68,7 +91,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param href Href.
 	 */
 	public set href(href: string) {
-		this.#htmlHyperlinkElementUtility.setHref(href);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHref(href);
 	}
 
 	/**
@@ -95,7 +119,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Origin.
 	 */
 	public get origin(): string {
-		return this.#htmlHyperlinkElementUtility.getOrigin();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getOrigin() : '';
 	}
 
 	/**
@@ -122,7 +147,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Protocol.
 	 */
 	public get protocol(): string {
-		return this.#htmlHyperlinkElementUtility.getProtocol();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getProtocol() : '';
 	}
 
 	/**
@@ -131,7 +157,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param protocol Protocol.
 	 */
 	public set protocol(protocol: string) {
-		this.#htmlHyperlinkElementUtility.setProtocol(protocol);
+		const utility = getHyperlinkUtility(this);
+		utility?.setProtocol(protocol);
 	}
 
 	/**
@@ -140,7 +167,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Username.
 	 */
 	public get username(): string {
-		return this.#htmlHyperlinkElementUtility.getUsername();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getUsername() : '';
 	}
 
 	/**
@@ -149,7 +177,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param username Username.
 	 */
 	public set username(username: string) {
-		this.#htmlHyperlinkElementUtility.setUsername(username);
+		const utility = getHyperlinkUtility(this);
+		utility?.setUsername(username);
 	}
 
 	/**
@@ -158,7 +187,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Password.
 	 */
 	public get password(): string {
-		return this.#htmlHyperlinkElementUtility.getPassword();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getPassword() : '';
 	}
 
 	/**
@@ -167,7 +197,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param password Password.
 	 */
 	public set password(password: string) {
-		this.#htmlHyperlinkElementUtility.setPassword(password);
+		const utility = getHyperlinkUtility(this);
+		utility?.setPassword(password);
 	}
 
 	/**
@@ -176,7 +207,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Pathname.
 	 */
 	public get pathname(): string {
-		return this.#htmlHyperlinkElementUtility.getPathname();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getPathname() : '';
 	}
 
 	/**
@@ -185,7 +217,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param pathname Pathname.
 	 */
 	public set pathname(pathname: string) {
-		this.#htmlHyperlinkElementUtility.setPathname(pathname);
+		const utility = getHyperlinkUtility(this);
+		utility?.setPathname(pathname);
 	}
 
 	/**
@@ -194,7 +227,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Port.
 	 */
 	public get port(): string {
-		return this.#htmlHyperlinkElementUtility.getPort();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getPort() : '';
 	}
 
 	/**
@@ -203,7 +237,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param port Port.
 	 */
 	public set port(port: string) {
-		this.#htmlHyperlinkElementUtility.setPort(port);
+		const utility = getHyperlinkUtility(this);
+		utility?.setPort(port);
 	}
 
 	/**
@@ -212,7 +247,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Host.
 	 */
 	public get host(): string {
-		return this.#htmlHyperlinkElementUtility.getHost();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHost() : '';
 	}
 
 	/**
@@ -221,7 +257,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param host Host.
 	 */
 	public set host(host: string) {
-		this.#htmlHyperlinkElementUtility.setHost(host);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHost(host);
 	}
 
 	/**
@@ -230,7 +267,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Hostname.
 	 */
 	public get hostname(): string {
-		return this.#htmlHyperlinkElementUtility.getHostname();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHostname() : '';
 	}
 
 	/**
@@ -239,7 +277,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param hostname Hostname.
 	 */
 	public set hostname(hostname: string) {
-		this.#htmlHyperlinkElementUtility.setHostname(hostname);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHostname(hostname);
 	}
 
 	/**
@@ -309,7 +348,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @returns Search.
 	 */
 	public get search(): string {
-		return this.#htmlHyperlinkElementUtility.getSearch();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getSearch() : '';
 	}
 
 	/**
@@ -318,7 +358,8 @@ export default class HTMLAnchorElement extends HTMLElement implements IHTMLHyper
 	 * @param search Search.
 	 */
 	public set search(search: string) {
-		this.#htmlHyperlinkElementUtility.setSearch(search);
+		const utility = getHyperlinkUtility(this);
+		utility?.setSearch(search);
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-area-element/HTMLAreaElement.ts
+++ b/packages/happy-dom/src/nodes/html-area-element/HTMLAreaElement.ts
@@ -7,6 +7,26 @@ import Event from '../../event/Event.js';
 import EventPhaseEnum from '../../event/EventPhaseEnum.js';
 import MouseEvent from '../../event/events/MouseEvent.js';
 
+// Used for caching the utility instance - module-scoped symbol to avoid prototype issues
+const HYPERLINK_UTILITY = Symbol('hyperlinkUtility');
+
+/**
+ * Returns the hyperlink utility for an element, creating it if necessary.
+ * Returns null if called on a non-instance (e.g., prototype).
+ *
+ * @param element The element to get the utility for.
+ * @returns The hyperlink utility or null.
+ */
+function getHyperlinkUtility(element: HTMLAreaElement): HTMLHyperlinkElementUtility | null {
+	if (!(element instanceof HTMLAreaElement)) {
+		return null;
+	}
+	if (!element[HYPERLINK_UTILITY]) {
+		element[HYPERLINK_UTILITY] = new HTMLHyperlinkElementUtility(element);
+	}
+	return element[HYPERLINK_UTILITY];
+}
+
 /**
  * HTMLAreaElement
  *
@@ -14,7 +34,7 @@ import MouseEvent from '../../event/events/MouseEvent.js';
  */
 export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperlinkElement {
 	public [PropertySymbol.relList]: DOMTokenList | null = null;
-	#htmlHyperlinkElementUtility = new HTMLHyperlinkElementUtility(this);
+	public declare [HYPERLINK_UTILITY]: HTMLHyperlinkElementUtility;
 
 	/**
 	 * Returns alt.
@@ -191,7 +211,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Origin.
 	 */
 	public get origin(): string {
-		return this.#htmlHyperlinkElementUtility.getOrigin();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getOrigin() : '';
 	}
 
 	/**
@@ -200,7 +221,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Href.
 	 */
 	public get href(): string {
-		return this.#htmlHyperlinkElementUtility.getHref();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHref() : '';
 	}
 
 	/**
@@ -209,7 +231,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param href Href.
 	 */
 	public set href(href: string) {
-		this.#htmlHyperlinkElementUtility.setHref(href);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHref(href);
 	}
 
 	/**
@@ -218,7 +241,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Protocol.
 	 */
 	public get protocol(): string {
-		return this.#htmlHyperlinkElementUtility.getProtocol();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getProtocol() : '';
 	}
 
 	/**
@@ -227,7 +251,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param protocol Protocol.
 	 */
 	public set protocol(protocol: string) {
-		this.#htmlHyperlinkElementUtility.setProtocol(protocol);
+		const utility = getHyperlinkUtility(this);
+		utility?.setProtocol(protocol);
 	}
 
 	/**
@@ -236,7 +261,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Username.
 	 */
 	public get username(): string {
-		return this.#htmlHyperlinkElementUtility.getUsername();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getUsername() : '';
 	}
 
 	/**
@@ -245,7 +271,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param username Username.
 	 */
 	public set username(username: string) {
-		this.#htmlHyperlinkElementUtility.setUsername(username);
+		const utility = getHyperlinkUtility(this);
+		utility?.setUsername(username);
 	}
 
 	/**
@@ -254,7 +281,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Password.
 	 */
 	public get password(): string {
-		return this.#htmlHyperlinkElementUtility.getPassword();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getPassword() : '';
 	}
 
 	/**
@@ -263,7 +291,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param password Password.
 	 */
 	public set password(password: string) {
-		this.#htmlHyperlinkElementUtility.setPassword(password);
+		const utility = getHyperlinkUtility(this);
+		utility?.setPassword(password);
 	}
 
 	/**
@@ -272,7 +301,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Host.
 	 */
 	public get host(): string {
-		return this.#htmlHyperlinkElementUtility.getHost();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHost() : '';
 	}
 
 	/**
@@ -281,7 +311,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param host Host.
 	 */
 	public set host(host: string) {
-		this.#htmlHyperlinkElementUtility.setHost(host);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHost(host);
 	}
 
 	/**
@@ -290,7 +321,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Hostname.
 	 */
 	public get hostname(): string {
-		return this.#htmlHyperlinkElementUtility.getHostname();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHostname() : '';
 	}
 
 	/**
@@ -299,7 +331,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param hostname Hostname.
 	 */
 	public set hostname(hostname: string) {
-		this.#htmlHyperlinkElementUtility.setHostname(hostname);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHostname(hostname);
 	}
 
 	/**
@@ -308,7 +341,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Port.
 	 */
 	public get port(): string {
-		return this.#htmlHyperlinkElementUtility.getPort();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getPort() : '';
 	}
 
 	/**
@@ -317,7 +351,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param port Port.
 	 */
 	public set port(port: string) {
-		this.#htmlHyperlinkElementUtility.setPort(port);
+		const utility = getHyperlinkUtility(this);
+		utility?.setPort(port);
 	}
 
 	/**
@@ -326,7 +361,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Pathname.
 	 */
 	public get pathname(): string {
-		return this.#htmlHyperlinkElementUtility.getPathname();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getPathname() : '';
 	}
 
 	/**
@@ -335,7 +371,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param pathname Pathname.
 	 */
 	public set pathname(pathname: string) {
-		this.#htmlHyperlinkElementUtility.setPathname(pathname);
+		const utility = getHyperlinkUtility(this);
+		utility?.setPathname(pathname);
 	}
 
 	/**
@@ -344,7 +381,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Search.
 	 */
 	public get search(): string {
-		return this.#htmlHyperlinkElementUtility.getSearch();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getSearch() : '';
 	}
 
 	/**
@@ -353,7 +391,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param search Search.
 	 */
 	public set search(search: string) {
-		this.#htmlHyperlinkElementUtility.setSearch(search);
+		const utility = getHyperlinkUtility(this);
+		utility?.setSearch(search);
 	}
 
 	/**
@@ -362,7 +401,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @returns Hash.
 	 */
 	public get hash(): string {
-		return this.#htmlHyperlinkElementUtility.getHash();
+		const utility = getHyperlinkUtility(this);
+		return utility ? utility.getHash() : '';
 	}
 
 	/**
@@ -371,7 +411,8 @@ export default class HTMLAreaElement extends HTMLElement implements IHTMLHyperli
 	 * @param hash Hash.
 	 */
 	public set hash(hash: string) {
-		this.#htmlHyperlinkElementUtility.setHash(hash);
+		const utility = getHyperlinkUtility(this);
+		utility?.setHash(hash);
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-base-element/HTMLBaseElement.ts
+++ b/packages/happy-dom/src/nodes/html-base-element/HTMLBaseElement.ts
@@ -16,6 +16,10 @@ export default class HTMLBaseElement extends HTMLElement {
 	 * @returns Href.
 	 */
 	public get href(): string {
+		// Return empty string if called on prototype (e.g., during util.inspect)
+		if (!(this instanceof HTMLBaseElement)) {
+			return '';
+		}
 		if (!this.hasAttribute('href')) {
 			return this[PropertySymbol.ownerDocument].location.href;
 		}

--- a/packages/happy-dom/src/nodes/html-link-element/HTMLLinkElement.ts
+++ b/packages/happy-dom/src/nodes/html-link-element/HTMLLinkElement.ts
@@ -125,6 +125,10 @@ export default class HTMLLinkElement extends HTMLElement {
 	 * @returns Href.
 	 */
 	public get href(): string {
+		// Return empty string if called on prototype (e.g., during util.inspect)
+		if (!(this instanceof HTMLLinkElement)) {
+			return '';
+		}
 		if (!this.hasAttribute('href')) {
 			return '';
 		}


### PR DESCRIPTION
Fixes #1938

## Problem

When logging a `Response.headers` instance with `util.inspect(value, true)` or `console.log('%o', value)`, Node.js throws:

```
TypeError: Cannot read private member #htmlHyperlinkElementUtility from an object whose class did not declare it
```

This happens because Node.js's `util.inspect` with `showHidden: true` traverses the entire object graph and checks if objects are URLs by accessing their `href` property. When it encounters `HTMLAnchorElement.prototype` or `HTMLAreaElement.prototype`, it calls the `href` getter which uses a private field (`#htmlHyperlinkElementUtility`). Since the getter is called on the prototype (not an instance), the private field access fails.

## Solution

Changed `HTMLAnchorElement` and `HTMLAreaElement` to use a module-scoped Symbol for storing the utility instance instead of a private field. Added an `instanceof` check in the getter to return an empty string when called on non-instances (like the prototype).

Also fixed `HTMLBaseElement` and `HTMLLinkElement` which had similar issues with their `href` getters accessing instance properties when called on the prototype.

## Changes

- `HTMLAnchorElement.ts`: Replace `#htmlHyperlinkElementUtility` private field with Symbol-based storage and add `instanceof` check
- `HTMLAreaElement.ts`: Same fix as HTMLAnchorElement
- `HTMLBaseElement.ts`: Add `instanceof` check to `href` getter
- `HTMLLinkElement.ts`: Add `instanceof` check to `href` getter

## Testing

```javascript
import { Window } from 'happy-dom';
import util from 'node:util';

const window = new Window({ url: 'https://github.com' });

// These now work without throwing:
util.inspect(window.HTMLAnchorElement.prototype, { showHidden: true });
util.inspect(window.HTMLAreaElement.prototype, { showHidden: true });

// Anchor elements still work correctly:
const anchor = window.document.createElement('a');
anchor.href = 'https://example.com/path?query=1#hash';
console.log(anchor.href);      // https://example.com/path?query=1#hash
console.log(anchor.protocol);  // https:
console.log(anchor.hostname);  // example.com
```