### PR TITLE
feat: [#1920] Add BroadcastChannel support

### DIFF
--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -611,6 +611,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	// Other classes that has to be bound to the Window context (populated by WindowContextClassExtender)
 	public declare readonly MutationObserver: typeof MutationObserver;
 	public declare readonly MessagePort: typeof MessagePort;
+	public declare readonly BroadcastChannel: typeof BroadcastChannel;
 	public declare readonly CSSStyleSheet: typeof CSSStyleSheet;
 	public declare readonly DOMException: typeof DOMException;
 	public declare readonly Headers: typeof Headers;

--- a/packages/happy-dom/src/window/WindowContextClassExtender.ts
+++ b/packages/happy-dom/src/window/WindowContextClassExtender.ts
@@ -102,6 +102,9 @@ export default class WindowContextClassExtender {
 		MessagePort.prototype[PropertySymbol.window] = window;
 		(<typeof MessagePort>window.MessagePort) = MessagePort;
 
+		// BroadcastChannel (use Node.js native implementation)
+		(<typeof BroadcastChannel>window.BroadcastChannel) = BroadcastChannel;
+
 		// CSSStyleSheet
 		class CSSStyleSheet extends CSSStyleSheetImplementation {}
 		CSSStyleSheet.prototype[PropertySymbol.window] = window;

--- a/packages/happy-dom/test/window/Window.test.ts
+++ b/packages/happy-dom/test/window/Window.test.ts
@@ -393,4 +393,34 @@ describe('Window', () => {
 			expect(included).toEqual(expected);
 		});
 	});
+
+	describe('BroadcastChannel', () => {
+		it('Exposes BroadcastChannel on the window object.', () => {
+			expect(window.BroadcastChannel).toBe(BroadcastChannel);
+		});
+
+		it('Can create a BroadcastChannel instance.', () => {
+			const channel = new window.BroadcastChannel('test-channel');
+			expect(channel).toBeInstanceOf(BroadcastChannel);
+			expect(channel.name).toBe('test-channel');
+			channel.close();
+		});
+
+		it('Can send and receive messages between channels.', async () => {
+			const channel1 = new window.BroadcastChannel('test-channel');
+			const channel2 = new window.BroadcastChannel('test-channel');
+
+			const receivedMessage = await new Promise<string>((resolve) => {
+				channel2.onmessage = (event) => {
+					resolve(event.data);
+				};
+				channel1.postMessage('hello');
+			});
+
+			expect(receivedMessage).toBe('hello');
+
+			channel1.close();
+			channel2.close();
+		});
+	});
 });


### PR DESCRIPTION
Fixes #1920

This PR adds `BroadcastChannel` support to happy-dom by exposing Node.js's native `BroadcastChannel` implementation on the window object.

## Changes

- Added `BroadcastChannel` declaration to `BrowserWindow.ts`
- Exposed native `BroadcastChannel` in `WindowContextClassExtender.ts`
- Added tests verifying:
  - `BroadcastChannel` is exposed on the window object
  - Instances can be created with channel names
  - Messages can be sent and received between channels

## Implementation Notes

Since Node.js 18+ includes a native `BroadcastChannel` implementation (available globally), this PR simply exposes that native implementation on the happy-dom window object.