### PR TITLE
chore: [#1867] Add regression test for TreeWalker sibling traversal

### DIFF
--- a/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
+++ b/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
@@ -141,6 +141,35 @@ describe('TreeWalker', () => {
 			]);
 		});
 
+		it('Traverses sibling nodes after deeply nested children (#1867).', () => {
+			const div = document.createElement('div');
+			div.innerHTML = `
+				<div>
+					<form>
+						<div>
+							<label>Label 1</label>
+						</div>
+					</form>
+					<div class="sibling">
+						<label>Label 2</label>
+					</div>
+				</div>
+			`;
+
+			const treeWalker = document.createTreeWalker(div, NodeFilter.SHOW_ELEMENT, {
+				acceptNode: () => NodeFilter.FILTER_ACCEPT
+			});
+
+			const tagNames: string[] = [];
+			while (treeWalker.nextNode()) {
+				const element = <Element>treeWalker.currentNode;
+				const className = element.className ? `.${element.className}` : '';
+				tagNames.push(`${element.tagName.toLowerCase()}${className}`);
+			}
+
+			expect(tagNames).toEqual(['div', 'form', 'div', 'label', 'div.sibling', 'label']);
+		});
+
 		it('Walks into each HTMLElement in the DOM tree when whatToShow is set to NodeFilter.SHOW_ELEMENT.', () => {
 			const treeWalker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
 			const html: string[] = [];


### PR DESCRIPTION
Closes #1867

#1867 reported that `TreeWalker.nextNode()` stops traversing when it should continue to sibling nodes of parent elements. 

**This issue is already fixed**. The fix was included in v17.1.4 (PR #1737) which addressed issue #1605.

This PR adds an explicit regression test for the exact scenario reported in #1867.

## Test Case Added

The new test verifies that TreeWalker correctly traverses this structure:
```html
<div>
  <form>
    <div>
      <label>Label 1</label>
    </div>
  </form>
  <div class="sibling">
    <label>Label 2</label>
  </div>
</div>
```

Expected traversal order: `div`, `form`, `div`, `label`, `div.sibling`, `label`
