### PR TITLE
feat: [#1862] Replace custom CSS parser with css-tree library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3133,6 +3133,13 @@
 				"@types/deep-eql": "*"
 			}
 		},
+		"node_modules/@types/css-tree": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.11.tgz",
+			"integrity": "sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5174,6 +5181,19 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.12.2",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/csstype": {
@@ -9376,6 +9396,12 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/mdn-data": {
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"license": "CC0-1.0"
+		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -11080,7 +11106,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -13876,11 +13901,13 @@
 				"@types/node": ">=20.0.0",
 				"@types/whatwg-mimetype": "^3.0.2",
 				"@types/ws": "^8.18.1",
+				"css-tree": "^3.1.0",
 				"entities": "^4.5.0",
 				"whatwg-mimetype": "^3.0.0",
 				"ws": "^8.18.3"
 			},
 			"devDependencies": {
+				"@types/css-tree": "^2.3.11",
 				"@vitest/ui": "^3.2.3",
 				"@webref/css": "6.6.2",
 				"typescript": "^5.8.3",

--- a/packages/happy-dom/package.json
+++ b/packages/happy-dom/package.json
@@ -33,14 +33,16 @@
 		"test:debug": "vitest run --inspect-brk --no-file-parallelism"
 	},
 	"dependencies": {
-		"@types/whatwg-mimetype": "^3.0.2",
 		"@types/node": ">=20.0.0",
+		"@types/whatwg-mimetype": "^3.0.2",
 		"@types/ws": "^8.18.1",
+		"css-tree": "^3.1.0",
 		"entities": "^4.5.0",
 		"whatwg-mimetype": "^3.0.0",
 		"ws": "^8.18.3"
 	},
 	"devDependencies": {
+		"@types/css-tree": "^2.3.11",
 		"@vitest/ui": "^3.2.3",
 		"@webref/css": "6.6.2",
 		"typescript": "^5.8.3",

--- a/packages/happy-dom/src/PropertySymbol.ts
+++ b/packages/happy-dom/src/PropertySymbol.ts
@@ -411,3 +411,4 @@ export const validateJavaScriptExecutionEnvironment = Symbol(
 export const currentNode = Symbol('currentNode');
 export const openWebSockets = Symbol('openWebSockets');
 export const webSocket = Symbol('webSocket');
+export const nameList = Symbol('nameList');

--- a/packages/happy-dom/src/css/CSSRuleTypeEnum.ts
+++ b/packages/happy-dom/src/css/CSSRuleTypeEnum.ts
@@ -12,7 +12,9 @@ enum CSSRuleTypeEnum {
 	supportsRule = 12,
 	documentRule = 13,
 	fontFeatureValuesRule = 14,
-	regionStyleRule = 16
+	regionStyleRule = 16,
+	layerBlockRule = 17,
+	layerStatementRule = 18
 }
 
 export default CSSRuleTypeEnum;

--- a/packages/happy-dom/src/css/rules/CSSLayerBlockRule.ts
+++ b/packages/happy-dom/src/css/rules/CSSLayerBlockRule.ts
@@ -1,0 +1,41 @@
+import * as PropertySymbol from '../../PropertySymbol.js';
+import CSSGroupingRule from './CSSGroupingRule.js';
+import CSSRuleTypeEnum from '../CSSRuleTypeEnum.js';
+
+/**
+ * CSSLayerBlockRule interface.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSLayerBlockRule
+ */
+export default class CSSLayerBlockRule extends CSSGroupingRule {
+	public [PropertySymbol.name] = '';
+
+	/**
+	 * @override
+	 */
+	public override get type(): CSSRuleTypeEnum {
+		return CSSRuleTypeEnum.layerBlockRule;
+	}
+
+	/**
+	 * @override
+	 */
+	public override get cssText(): string {
+		let cssText = '';
+		for (const cssRule of this[PropertySymbol.cssRules]) {
+			cssText += '\n  ' + cssRule.cssText;
+		}
+		cssText += cssText ? '\n' : '';
+		const name = this[PropertySymbol.name];
+		return `@layer${name ? ` ${name}` : ''} {${cssText}}`;
+	}
+
+	/**
+	 * Returns the name of the layer.
+	 *
+	 * @returns Layer name.
+	 */
+	public get name(): string {
+		return this[PropertySymbol.name];
+	}
+}

--- a/packages/happy-dom/src/css/rules/CSSLayerStatementRule.ts
+++ b/packages/happy-dom/src/css/rules/CSSLayerStatementRule.ts
@@ -1,0 +1,35 @@
+import CSSRule from '../CSSRule.js';
+import * as PropertySymbol from '../../PropertySymbol.js';
+import CSSRuleTypeEnum from '../CSSRuleTypeEnum.js';
+
+/**
+ * CSSLayerStatementRule interface.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSLayerStatementRule
+ */
+export default class CSSLayerStatementRule extends CSSRule {
+	public [PropertySymbol.nameList]: string[] = [];
+
+	/**
+	 * @override
+	 */
+	public override get type(): CSSRuleTypeEnum {
+		return CSSRuleTypeEnum.layerStatementRule;
+	}
+
+	/**
+	 * @override
+	 */
+	public override get cssText(): string {
+		return `@layer ${this[PropertySymbol.nameList].join(', ')};`;
+	}
+
+	/**
+	 * Returns the list of layer names.
+	 *
+	 * @returns Layer name list.
+	 */
+	public get nameList(): string[] {
+		return this[PropertySymbol.nameList];
+	}
+}

--- a/packages/happy-dom/src/css/utilities/CSSParser.ts
+++ b/packages/happy-dom/src/css/utilities/CSSParser.ts
@@ -1,3 +1,4 @@
+import * as csstree from 'css-tree';
 import CSSRule from '../CSSRule.js';
 import * as PropertySymbol from '../../PropertySymbol.js';
 import CSSStyleSheet from '../CSSStyleSheet.js';
@@ -8,14 +9,17 @@ import CSSMediaRule from '../rules/CSSMediaRule.js';
 import CSSContainerRule from '../rules/CSSContainerRule.js';
 import CSSSupportsRule from '../rules/CSSSupportsRule.js';
 import CSSFontFaceRule from '../rules/CSSFontFaceRule.js';
-import SelectorParser from '../../query-selector/SelectorParser.js';
-import CSSRuleTypeEnum from '../CSSRuleTypeEnum.js';
 import CSSScopeRule from '../rules/CSSScopeRule.js';
+import CSSLayerBlockRule from '../rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from '../rules/CSSLayerStatementRule.js';
+import BrowserWindow from '../../window/BrowserWindow.js';
+import SelectorParser from '../../query-selector/SelectorParser.js';
 
-const COMMENT_REGEXP = /\/\*[\s\S]*?\*\//gm;
+// Regex to add space after colon in CSS conditions (e.g., "min-width:36rem" -> "min-width: 36rem")
+const COLON_SPACE_REGEXP = /:(?=[^\s])/g;
 
 /**
- * CSS parser.
+ * CSS parser using css-tree.
  */
 export default class CSSParser {
 	#parentStyleSheet: CSSStyleSheet;
@@ -28,269 +32,533 @@ export default class CSSParser {
 	constructor(parentStyleSheet: CSSStyleSheet) {
 		this.#parentStyleSheet = parentStyleSheet;
 	}
+
 	/**
-	 * Parses HTML and returns a root element.
+	 * Parses CSS text and returns CSS rules.
 	 *
 	 * @param cssText CSS code.
 	 * @returns CSS rules.
 	 */
 	public parseFromString(cssText: string): CSSRule[] {
-		const parentStyleSheet = this.#parentStyleSheet;
-		const window = parentStyleSheet[PropertySymbol.window];
-		const css = cssText.replace(COMMENT_REGEXP, '');
-		const cssRules = [];
-		const regExp = /{|}/gm;
-		const stack: CSSRule[] = [];
-		let parentRule: CSSRule | null = null;
-		let lastIndex = 0;
-		let match: RegExpMatchArray | null;
+		const ast = <csstree.StyleSheet>csstree.parse(cssText, {
+			parseAtrulePrelude: true,
+			parseRulePrelude: true,
+			parseValue: false,
+			parseCustomProperty: false
+		});
 
-		while ((match = regExp.exec(css))) {
-			if (match[0] === '{') {
-				const selectorText = css.substring(lastIndex, match.index).trim();
+		return this.convertStyleSheet(ast);
+	}
 
-				if (selectorText[0] === '@') {
-					const ruleParts = selectorText.split(' ');
-					const ruleType = ruleParts[0];
-					const ruleParameters = ruleParts.slice(1).join(' ').trim();
+	/**
+	 * Converts a css-tree StyleSheet AST to CSSOM rules.
+	 *
+	 * @param ast StyleSheet AST node.
+	 * @returns Array of CSSRule objects.
+	 */
+	private convertStyleSheet(ast: csstree.StyleSheet): CSSRule[] {
+		const rules: CSSRule[] = [];
 
-					switch (ruleType) {
-						case '@keyframes':
-						case '@-webkit-keyframes':
-							const keyframesRule = new CSSKeyframesRule(
-								PropertySymbol.illegalConstructor,
-								window,
-								this
-							);
-
-							keyframesRule[PropertySymbol.rulePrefix] =
-								ruleType === '@-webkit-keyframes' ? '-webkit-' : '';
-							keyframesRule[PropertySymbol.name] = ruleParameters;
-							keyframesRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-							if (parentRule) {
-								if (
-									parentRule.type === CSSRuleTypeEnum.mediaRule ||
-									parentRule.type === CSSRuleTypeEnum.containerRule ||
-									parentRule.type === CSSRuleTypeEnum.supportsRule
-								) {
-									(<CSSMediaRule>parentRule).cssRules.push(keyframesRule);
-								}
-							} else {
-								cssRules.push(keyframesRule);
-							}
-							parentRule = keyframesRule;
-							break;
-						case '@media':
-							const mediums = ruleParameters.split(',');
-							const mediaRule = new CSSMediaRule(PropertySymbol.illegalConstructor, window, this);
-
-							for (const medium of mediums) {
-								mediaRule.media.appendMedium(medium.trim());
-							}
-
-							mediaRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-							if (parentRule) {
-								if (
-									parentRule.type === CSSRuleTypeEnum.mediaRule ||
-									parentRule.type === CSSRuleTypeEnum.containerRule ||
-									parentRule.type === CSSRuleTypeEnum.supportsRule
-								) {
-									(<CSSMediaRule>parentRule).cssRules.push(mediaRule);
-								}
-							} else {
-								cssRules.push(mediaRule);
-							}
-							parentRule = mediaRule;
-							break;
-						case '@container':
-						case '@-webkit-container':
-							const containerRule = new CSSContainerRule(
-								PropertySymbol.illegalConstructor,
-								window,
-								this
-							);
-							containerRule[PropertySymbol.rulePrefix] =
-								ruleType === '@-webkit-container' ? '-webkit-' : '';
-							containerRule[PropertySymbol.conditionText] = ruleParameters;
-							containerRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-
-							if (parentRule) {
-								if (
-									parentRule.type === CSSRuleTypeEnum.mediaRule ||
-									parentRule.type === CSSRuleTypeEnum.containerRule ||
-									parentRule.type === CSSRuleTypeEnum.supportsRule
-								) {
-									(<CSSMediaRule>parentRule).cssRules.push(containerRule);
-								}
-							} else {
-								cssRules.push(containerRule);
-							}
-
-							parentRule = containerRule;
-							break;
-						case '@supports':
-						case '@-webkit-supports':
-							const supportsRule = new CSSSupportsRule(
-								PropertySymbol.illegalConstructor,
-								window,
-								this
-							);
-
-							supportsRule[PropertySymbol.rulePrefix] =
-								ruleType === '@-webkit-supports' ? '-webkit-' : '';
-							supportsRule[PropertySymbol.conditionText] = ruleParameters;
-							supportsRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-							if (parentRule) {
-								if (
-									parentRule.type === CSSRuleTypeEnum.mediaRule ||
-									parentRule.type === CSSRuleTypeEnum.containerRule ||
-									parentRule.type === CSSRuleTypeEnum.supportsRule
-								) {
-									(<CSSMediaRule>parentRule).cssRules.push(supportsRule);
-								}
-							} else {
-								cssRules.push(supportsRule);
-							}
-							parentRule = supportsRule;
-							break;
-						case '@font-face':
-							const fontFaceRule = new CSSFontFaceRule(
-								PropertySymbol.illegalConstructor,
-								window,
-								this
-							);
-
-							fontFaceRule[PropertySymbol.cssText] = ruleParameters;
-							fontFaceRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-							if (parentRule) {
-								if (
-									parentRule.type === CSSRuleTypeEnum.mediaRule ||
-									parentRule.type === CSSRuleTypeEnum.containerRule ||
-									parentRule.type === CSSRuleTypeEnum.supportsRule
-								) {
-									(<CSSMediaRule>parentRule).cssRules.push(fontFaceRule);
-								}
-							} else {
-								cssRules.push(fontFaceRule);
-							}
-							parentRule = fontFaceRule;
-							break;
-						case '@scope':
-						case '@-webkit-scope':
-							const scopeRule = new CSSScopeRule(PropertySymbol.illegalConstructor, window, this);
-
-							scopeRule[PropertySymbol.rulePrefix] =
-								ruleType === '@-webkit-scope' ? '-webkit-' : '';
-							scopeRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-
-							if (ruleParameters) {
-								const scopeRuleParts = ruleParameters.split(/\s+to\s+/);
-								if (
-									scopeRuleParts[0] &&
-									scopeRuleParts[0][0] === '(' &&
-									scopeRuleParts[0][scopeRuleParts[0].length - 1] === ')'
-								) {
-									scopeRule[PropertySymbol.start] = scopeRuleParts[0].slice(1, -1);
-								}
-								if (
-									scopeRuleParts[1] &&
-									scopeRuleParts[1][0] === '(' &&
-									scopeRuleParts[1][scopeRuleParts[1].length - 1] === ')'
-								) {
-									scopeRule[PropertySymbol.end] = scopeRuleParts[1].slice(1, -1);
-								}
-							}
-
-							if (parentRule) {
-								if (
-									parentRule.type === CSSRuleTypeEnum.mediaRule ||
-									parentRule.type === CSSRuleTypeEnum.containerRule ||
-									parentRule.type === CSSRuleTypeEnum.supportsRule
-								) {
-									(<CSSMediaRule>parentRule).cssRules.push(scopeRule);
-								}
-							} else {
-								cssRules.push(scopeRule);
-							}
-							parentRule = scopeRule;
-							break;
-						default:
-							// Unknown rule.
-							// We will create a new rule to let it grab its content, but we will not add it to the cssRules array.
-							const newRule = new CSSStyleRule(PropertySymbol.illegalConstructor, window, this);
-							newRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-							parentRule = newRule;
-							break;
-					}
-				} else if (parentRule && parentRule.type === CSSRuleTypeEnum.keyframesRule) {
-					const newRule = new CSSKeyframeRule(PropertySymbol.illegalConstructor, window, this);
-					let keyText = selectorText.trim();
-					if (keyText === 'from') {
-						keyText = '0%';
-					} else if (keyText === 'to') {
-						keyText = '100%';
-					}
-					newRule[PropertySymbol.keyText] = keyText;
-					newRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-					newRule[PropertySymbol.parentRule] = parentRule;
-
-					(<CSSKeyframesRule>parentRule).cssRules.push(<CSSKeyframeRule>newRule);
-					parentRule = newRule;
-				} else if (
-					parentRule &&
-					(parentRule.type === CSSRuleTypeEnum.mediaRule ||
-						parentRule.type === CSSRuleTypeEnum.containerRule ||
-						parentRule.type === CSSRuleTypeEnum.supportsRule)
-				) {
-					if (this.validateSelectorText(selectorText)) {
-						const newRule = new CSSStyleRule(PropertySymbol.illegalConstructor, window, this);
-						newRule[PropertySymbol.selectorText] = selectorText;
-						newRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-						newRule[PropertySymbol.parentRule] = parentRule;
-						(<CSSMediaRule>parentRule).cssRules.push(newRule);
-						parentRule = newRule;
-					}
-				} else {
-					if (this.validateSelectorText(selectorText)) {
-						const newRule = new CSSStyleRule(PropertySymbol.illegalConstructor, window, this);
-						newRule[PropertySymbol.selectorText] = selectorText;
-						newRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
-						newRule[PropertySymbol.parentRule] = parentRule;
-
-						if (!parentRule) {
-							cssRules.push(newRule);
-						}
-
-						parentRule = newRule;
-					}
+		if (ast.children) {
+			for (const node of ast.children) {
+				const rule = this.convertNode(node);
+				if (rule) {
+					rules.push(rule);
 				}
-
-				if (parentRule) {
-					stack.push(parentRule);
-				}
-			} else {
-				if (parentRule) {
-					const cssText = css
-						.substring(lastIndex, match.index)
-						.trim()
-						.replace(/([^;])$/, '$1;'); // Ensure last semicolon
-					switch (parentRule.type) {
-						case CSSRuleTypeEnum.fontFaceRule:
-						case CSSRuleTypeEnum.keyframeRule:
-						case CSSRuleTypeEnum.styleRule:
-							(<CSSStyleRule>parentRule)[PropertySymbol.cssText] = cssText;
-							break;
-					}
-				}
-
-				stack.pop();
-				parentRule = stack[stack.length - 1] || null;
 			}
-
-			lastIndex = match.index! + 1;
 		}
 
-		return cssRules;
+		return rules;
+	}
+
+	/**
+	 * Converts a css-tree AST node to a CSSOM rule.
+	 *
+	 * @param node AST node.
+	 * @param parentRule Optional parent rule.
+	 * @returns CSSRule or null.
+	 */
+	private convertNode(node: csstree.CssNode, parentRule?: CSSRule): CSSRule | null {
+		const window = this.#parentStyleSheet[PropertySymbol.window];
+
+		switch (node.type) {
+			case 'Rule':
+				return this.convertStyleRule(node, window, parentRule);
+			case 'Atrule':
+				return this.convertAtRule(node, window, parentRule);
+			default:
+				return null;
+		}
+	}
+
+	/**
+	 * Converts a css-tree Rule node to CSSStyleRule.
+	 *
+	 * @param node Rule AST node.
+	 * @param window Browser window.
+	 * @param parentRule Optional parent rule.
+	 * @returns CSSStyleRule or null if selector is invalid.
+	 */
+	private convertStyleRule(
+		node: csstree.Rule,
+		window: BrowserWindow,
+		parentRule?: CSSRule
+	): CSSStyleRule | null {
+		// Get selector text
+		let selectorText = '';
+		if (node.prelude) {
+			selectorText = csstree.generate(node.prelude);
+		}
+
+		// Validate selector
+		if (!this.validateSelectorText(selectorText)) {
+			return null;
+		}
+
+		const rule = new CSSStyleRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+		rule[PropertySymbol.selectorText] = selectorText;
+
+		// Get declarations as CSS text
+		if (node.block) {
+			rule[PropertySymbol.cssText] = this.extractDeclarations(node.block);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a css-tree Atrule node to the appropriate CSSOM rule.
+	 *
+	 * @param node Atrule AST node.
+	 * @param window Browser window.
+	 * @param parentRule Optional parent rule.
+	 * @returns CSSRule or null.
+	 */
+	private convertAtRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		parentRule?: CSSRule
+	): CSSRule | null {
+		const atRuleName = node.name.toLowerCase();
+		const isWebkitPrefixed = atRuleName.startsWith('-webkit-');
+		const normalizedName = isWebkitPrefixed ? atRuleName.slice(8) : atRuleName;
+
+		switch (normalizedName) {
+			case 'media':
+				return this.convertMediaRule(node, window, isWebkitPrefixed, parentRule);
+			case 'keyframes':
+				return this.convertKeyframesRule(node, window, isWebkitPrefixed, parentRule);
+			case 'supports':
+				return this.convertSupportsRule(node, window, isWebkitPrefixed, parentRule);
+			case 'container':
+				return this.convertContainerRule(node, window, isWebkitPrefixed, parentRule);
+			case 'font-face':
+				return this.convertFontFaceRule(node, window, parentRule);
+			case 'scope':
+				return this.convertScopeRule(node, window, isWebkitPrefixed, parentRule);
+			case 'layer':
+				return this.convertLayerRule(node, window, parentRule);
+			default:
+				// Unknown at-rule - skip it
+				return null;
+		}
+	}
+
+	/**
+	 * Converts a @media rule.
+	 * @param node
+	 * @param window
+	 * @param _isWebkitPrefixed
+	 * @param parentRule
+	 */
+	private convertMediaRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		_isWebkitPrefixed: boolean,
+		parentRule?: CSSRule
+	): CSSMediaRule {
+		const rule = new CSSMediaRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+
+		// Parse media query list
+		if (node.prelude) {
+			const mediaText = this.normalizeConditionText(csstree.generate(node.prelude));
+			const mediums = mediaText.split(',');
+			for (const medium of mediums) {
+				rule.media.appendMedium(medium.trim());
+			}
+		}
+
+		// Parse nested rules
+		if (node.block) {
+			this.parseNestedRules(node.block, rule);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a @keyframes rule.
+	 * @param node
+	 * @param window
+	 * @param isWebkitPrefixed
+	 * @param parentRule
+	 */
+	private convertKeyframesRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		isWebkitPrefixed: boolean,
+		parentRule?: CSSRule
+	): CSSKeyframesRule {
+		const rule = new CSSKeyframesRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+		rule[PropertySymbol.rulePrefix] = isWebkitPrefixed ? '-webkit-' : '';
+
+		// Get keyframes name
+		if (node.prelude) {
+			rule[PropertySymbol.name] = csstree.generate(node.prelude).trim();
+		}
+
+		// Parse keyframe rules
+		if (node.block && node.block.children) {
+			for (const child of node.block.children) {
+				if (child.type === 'Rule') {
+					const keyframeRule = this.convertKeyframeRule(child, window, rule);
+					if (keyframeRule) {
+						rule[PropertySymbol.cssRules].push(keyframeRule);
+					}
+				}
+			}
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a keyframe rule (e.g., "from", "to", "50%").
+	 * @param node
+	 * @param window
+	 * @param parentRule
+	 */
+	private convertKeyframeRule(
+		node: csstree.Rule,
+		window: BrowserWindow,
+		parentRule: CSSKeyframesRule
+	): CSSKeyframeRule {
+		const rule = new CSSKeyframeRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule;
+
+		// Get key text (from, to, percentage)
+		if (node.prelude) {
+			let keyText = csstree.generate(node.prelude).trim();
+			if (keyText === 'from') {
+				keyText = '0%';
+			} else if (keyText === 'to') {
+				keyText = '100%';
+			}
+			rule[PropertySymbol.keyText] = keyText;
+		}
+
+		// Get declarations
+		if (node.block) {
+			rule[PropertySymbol.cssText] = this.extractDeclarations(node.block);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a @supports rule.
+	 * @param node
+	 * @param window
+	 * @param isWebkitPrefixed
+	 * @param parentRule
+	 */
+	private convertSupportsRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		isWebkitPrefixed: boolean,
+		parentRule?: CSSRule
+	): CSSSupportsRule {
+		const rule = new CSSSupportsRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+		rule[PropertySymbol.rulePrefix] = isWebkitPrefixed ? '-webkit-' : '';
+
+		// Get condition text
+		if (node.prelude) {
+			rule[PropertySymbol.conditionText] = this.normalizeConditionText(
+				csstree.generate(node.prelude)
+			);
+		}
+
+		// Parse nested rules
+		if (node.block) {
+			this.parseNestedRules(node.block, rule);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a @container rule.
+	 * @param node
+	 * @param window
+	 * @param isWebkitPrefixed
+	 * @param parentRule
+	 */
+	private convertContainerRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		isWebkitPrefixed: boolean,
+		parentRule?: CSSRule
+	): CSSContainerRule {
+		const rule = new CSSContainerRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+		rule[PropertySymbol.rulePrefix] = isWebkitPrefixed ? '-webkit-' : '';
+
+		// Get condition text
+		if (node.prelude) {
+			rule[PropertySymbol.conditionText] = this.normalizeConditionText(
+				csstree.generate(node.prelude)
+			);
+		}
+
+		// Parse nested rules
+		if (node.block) {
+			this.parseNestedRules(node.block, rule);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a @font-face rule.
+	 * @param node
+	 * @param window
+	 * @param parentRule
+	 */
+	private convertFontFaceRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		parentRule?: CSSRule
+	): CSSFontFaceRule {
+		const rule = new CSSFontFaceRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+
+		// Get declarations
+		if (node.block) {
+			rule[PropertySymbol.cssText] = this.extractDeclarations(node.block);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a @scope rule.
+	 * @param node
+	 * @param window
+	 * @param isWebkitPrefixed
+	 * @param parentRule
+	 */
+	private convertScopeRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		isWebkitPrefixed: boolean,
+		parentRule?: CSSRule
+	): CSSScopeRule {
+		const rule = new CSSScopeRule(PropertySymbol.illegalConstructor, window, this);
+
+		rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+		rule[PropertySymbol.parentRule] = parentRule || null;
+		rule[PropertySymbol.rulePrefix] = isWebkitPrefixed ? '-webkit-' : '';
+
+		// Parse scope prelude: @scope (start) to (end)
+		if (node.prelude) {
+			const preludeText = csstree.generate(node.prelude);
+			const scopeParts = preludeText.split(/\s+to\s+/i);
+
+			if (scopeParts[0]) {
+				const startMatch = scopeParts[0].trim();
+				if (startMatch.startsWith('(') && startMatch.endsWith(')')) {
+					rule[PropertySymbol.start] = startMatch.slice(1, -1);
+				}
+			}
+
+			if (scopeParts[1]) {
+				const endMatch = scopeParts[1].trim();
+				if (endMatch.startsWith('(') && endMatch.endsWith(')')) {
+					rule[PropertySymbol.end] = endMatch.slice(1, -1);
+				}
+			}
+		}
+
+		// Parse nested rules
+		if (node.block) {
+			this.parseNestedRules(node.block, rule);
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Converts a @layer rule (block or statement).
+	 * @param node
+	 * @param window
+	 * @param parentRule
+	 */
+	private convertLayerRule(
+		node: csstree.Atrule,
+		window: BrowserWindow,
+		parentRule?: CSSRule
+	): CSSLayerBlockRule | CSSLayerStatementRule {
+		// If there's a block, it's a layer block rule
+		if (node.block) {
+			const rule = new CSSLayerBlockRule(PropertySymbol.illegalConstructor, window, this);
+
+			rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+			rule[PropertySymbol.parentRule] = parentRule || null;
+
+			// Get layer name from prelude
+			if (node.prelude) {
+				rule[PropertySymbol.name] = this.extractLayerName(node.prelude);
+			}
+
+			// Parse nested rules
+			this.parseNestedRules(node.block, rule);
+
+			return rule;
+		} else {
+			// No block means it's a layer statement rule
+			const rule = new CSSLayerStatementRule(PropertySymbol.illegalConstructor, window, this);
+
+			rule[PropertySymbol.parentStyleSheet] = this.#parentStyleSheet;
+			rule[PropertySymbol.parentRule] = parentRule || null;
+
+			// Get layer names from prelude
+			if (node.prelude) {
+				rule[PropertySymbol.nameList] = this.extractLayerNames(node.prelude);
+			}
+
+			return rule;
+		}
+	}
+
+	/**
+	 * Extracts a single layer name from a prelude.
+	 * @param prelude
+	 */
+	private extractLayerName(prelude: csstree.AtrulePrelude | csstree.Raw): string {
+		if (prelude.type === 'Raw') {
+			return prelude.value.trim();
+		}
+
+		// Look for Layer or LayerList nodes
+		let name = '';
+		csstree.walk(prelude, (node: csstree.CssNode) => {
+			if (!name && node.type === 'Identifier' && 'name' in node) {
+				name = node.name;
+			}
+		});
+
+		if (!name) {
+			// Fallback to generating the prelude text
+			name = csstree.generate(prelude).trim();
+		}
+
+		return name;
+	}
+
+	/**
+	 * Extracts layer names from a prelude (for layer statement rules).
+	 * @param prelude
+	 */
+	private extractLayerNames(prelude: csstree.AtrulePrelude | csstree.Raw): string[] {
+		if (prelude.type === 'Raw') {
+			return prelude.value.split(',').map((n: string) => n.trim());
+		}
+
+		const names: string[] = [];
+		csstree.walk(prelude, (node: csstree.CssNode) => {
+			if (node.type === 'Identifier' && 'name' in node) {
+				names.push(node.name);
+			}
+		});
+
+		if (names.length === 0) {
+			// Fallback to parsing the generated text
+			const text = csstree.generate(prelude);
+			return text.split(',').map((n: string) => n.trim());
+		}
+
+		return names;
+	}
+
+	/**
+	 * Parses nested rules from a block into a parent grouping rule.
+	 * @param block
+	 * @param parentRule
+	 */
+	private parseNestedRules(block: csstree.Block, parentRule: CSSRule): void {
+		if (!block.children) {
+			return;
+		}
+
+		const cssRules = (<{ [PropertySymbol.cssRules]: CSSRule[] }>(<unknown>parentRule))[
+			PropertySymbol.cssRules
+		];
+
+		for (const child of block.children) {
+			const rule = this.convertNode(child, parentRule);
+			if (rule) {
+				cssRules.push(rule);
+			}
+		}
+	}
+
+	/**
+	 * Extracts declarations from a block as CSS text.
+	 * @param block
+	 */
+	private extractDeclarations(block: csstree.Block): string {
+		const declarations: string[] = [];
+
+		if (block.children) {
+			for (const child of block.children) {
+				if (child.type === 'Declaration') {
+					const value = csstree.generate(child.value);
+					const important = child.important ? ' !important' : '';
+					declarations.push(`${child.property}: ${value}${important}`);
+				}
+			}
+		}
+
+		return declarations.join('; ') + (declarations.length ? ';' : '');
+	}
+
+	/**
+	 * Normalizes condition text by adding spaces after colons.
+	 * css-tree generates "min-width:36rem" but browsers use "min-width: 36rem".
+	 *
+	 * @param text Condition text.
+	 * @returns Normalized condition text.
+	 */
+	private normalizeConditionText(text: string): string {
+		return text.replace(COLON_SPACE_REGEXP, ': ');
 	}
 
 	/**

--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -27,6 +27,8 @@ import CSSFontFaceRule from './css/rules/CSSFontFaceRule.js';
 import CSSGroupingRule from './css/rules/CSSGroupingRule.js';
 import CSSKeyframeRule from './css/rules/CSSKeyframeRule.js';
 import CSSKeyframesRule from './css/rules/CSSKeyframesRule.js';
+import CSSLayerBlockRule from './css/rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from './css/rules/CSSLayerStatementRule.js';
 import CSSMediaRule from './css/rules/CSSMediaRule.js';
 import CSSScopeRule from './css/rules/CSSScopeRule.js';
 import CSSStyleRule from './css/rules/CSSStyleRule.js';
@@ -279,6 +281,8 @@ export {
 	CSSKeyframeRule,
 	CSSKeyframesRule,
 	CSSKeywordValue,
+	CSSLayerBlockRule,
+	CSSLayerStatementRule,
 	CSSMediaRule,
 	CSSRule,
 	CSSScopeRule,

--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -20,6 +20,8 @@ import CSSContainerRule from '../css/rules/CSSContainerRule.js';
 import CSSFontFaceRule from '../css/rules/CSSFontFaceRule.js';
 import CSSKeyframeRule from '../css/rules/CSSKeyframeRule.js';
 import CSSKeyframesRule from '../css/rules/CSSKeyframesRule.js';
+import CSSLayerBlockRule from '../css/rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from '../css/rules/CSSLayerStatementRule.js';
 import CSSMediaRule from '../css/rules/CSSMediaRule.js';
 import CSSStyleRule from '../css/rules/CSSStyleRule.js';
 import CSSSupportsRule from '../css/rules/CSSSupportsRule.js';
@@ -654,6 +656,8 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	public readonly CSSFontFaceRule = CSSFontFaceRule;
 	public readonly CSSKeyframeRule = CSSKeyframeRule;
 	public readonly CSSKeyframesRule = CSSKeyframesRule;
+	public readonly CSSLayerBlockRule = CSSLayerBlockRule;
+	public readonly CSSLayerStatementRule = CSSLayerStatementRule;
 	public readonly CSSMediaRule = CSSMediaRule;
 	public readonly CSSStyleRule = CSSStyleRule;
 	public readonly CSSSupportsRule = CSSSupportsRule;

--- a/packages/happy-dom/test/css/rules/CSSLayerBlockRule.test.ts
+++ b/packages/happy-dom/test/css/rules/CSSLayerBlockRule.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as PropertySymbol from '../../../src/PropertySymbol.js';
+import Window from '../../../src/window/Window.js';
+import CSSStyleSheet from '../../../src/css/CSSStyleSheet.js';
+import CSSRuleTypeEnum from '../../../src/css/CSSRuleTypeEnum.js';
+import CSSLayerBlockRule from '../../../src/css/rules/CSSLayerBlockRule.js';
+
+describe('CSSLayerBlockRule', () => {
+	let styleSheet: CSSStyleSheet;
+
+	beforeEach(() => {
+		styleSheet = new new Window().CSSStyleSheet();
+	});
+
+	it('Parses named @layer block rule with nested rules', () => {
+		styleSheet.insertRule('@layer utilities { .test { color: red; } }');
+
+		const rule = <CSSLayerBlockRule>styleSheet.cssRules[0];
+		expect(rule).toBeInstanceOf(CSSLayerBlockRule);
+		expect(rule.type).toBe(CSSRuleTypeEnum.layerBlockRule);
+		expect(rule.name).toBe('utilities');
+		expect(rule.cssRules.length).toBe(1);
+		expect(rule.cssText).toBe('@layer utilities {\n  .test { color: red; }\n}');
+	});
+
+	it('Parses anonymous @layer block rule', () => {
+		styleSheet.insertRule('@layer { .test { color: red; } }');
+
+		const rule = <CSSLayerBlockRule>styleSheet.cssRules[0];
+		expect(rule.name).toBe('');
+		expect(rule.cssText).toBe('@layer {\n  .test { color: red; }\n}');
+	});
+
+	it('Supports insertRule() for nested rules', () => {
+		styleSheet.insertRule('@layer utilities {}');
+		const rule = <CSSLayerBlockRule>styleSheet.cssRules[0];
+
+		rule.insertRule('.foo { color: blue; }');
+		expect(rule.cssRules.length).toBe(1);
+	});
+});

--- a/packages/happy-dom/test/css/rules/CSSLayerStatementRule.test.ts
+++ b/packages/happy-dom/test/css/rules/CSSLayerStatementRule.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Window from '../../../src/window/Window.js';
+import CSSStyleSheet from '../../../src/css/CSSStyleSheet.js';
+import CSSRuleTypeEnum from '../../../src/css/CSSRuleTypeEnum.js';
+import CSSLayerStatementRule from '../../../src/css/rules/CSSLayerStatementRule.js';
+
+describe('CSSLayerStatementRule', () => {
+	let styleSheet: CSSStyleSheet;
+
+	beforeEach(() => {
+		styleSheet = new new Window().CSSStyleSheet();
+	});
+
+	it('Parses @layer statement with multiple layers', () => {
+		styleSheet.insertRule('@layer theme, utilities, components;');
+
+		const rule = <CSSLayerStatementRule>styleSheet.cssRules[0];
+		expect(rule).toBeInstanceOf(CSSLayerStatementRule);
+		expect(rule.type).toBe(CSSRuleTypeEnum.layerStatementRule);
+		expect(rule.nameList).toEqual(['theme', 'utilities', 'components']);
+		expect(rule.cssText).toBe('@layer theme, utilities, components;');
+	});
+
+	it('Parses @layer statement with single layer', () => {
+		styleSheet.insertRule('@layer base;');
+
+		const rule = <CSSLayerStatementRule>styleSheet.cssRules[0];
+		expect(rule.nameList).toEqual(['base']);
+		expect(rule.cssText).toBe('@layer base;');
+	});
+});

--- a/packages/happy-dom/test/nodes/html-style-element/HTMLStyleElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-style-element/HTMLStyleElement.test.ts
@@ -247,7 +247,7 @@ describe('HTMLStyleElement', () => {
             `;
 
 			expect(scopeCssSelectors(html, '.scope'))
-				.toEqual(`<style>.scope #document h1,.scope  #document h2 { background: red; }
+				.toEqual(`<style>.scope #document h1,.scope #document h2 { background: red; }
 .scope h3 { color: white; }</style>
                 
         


### PR DESCRIPTION
Fixes #1862

This PR replaces the custom regex-based CSS parser with the [css-tree](https://github.com/csstree/csstree) library, a battle-tested CSS parser used by Chrome DevTools and other major tools.

### Benefits
- More spec-compliant CSS parsing
- Support for modern CSS features like `@layer` rules (#1862)
- Better handling of nested at-rules
- Reduced maintenance burden for custom parsing code
- Handles edge cases we may not have considered

### Changes

**New Files:**
- `packages/happy-dom/src/css/rules/CSSLayerBlockRule.ts` - Implements `CSSLayerBlockRule` for `@layer name { ... }` blocks
- `packages/happy-dom/src/css/rules/CSSLayerStatementRule.ts` - Implements `CSSLayerStatementRule` for `@layer a, b, c;` statements
- `packages/happy-dom/test/css/rules/CSSLayerBlockRule.test.ts` - Tests for CSSLayerBlockRule
- `packages/happy-dom/test/css/rules/CSSLayerStatementRule.test.ts` - Tests for CSSLayerStatementRule

**Modified Files:**
- `packages/happy-dom/src/css/utilities/CSSParser.ts` - Completely rewritten to use css-tree
- `packages/happy-dom/src/css/CSSRuleTypeEnum.ts` - Added `layerBlockRule` (17) and `layerStatementRule` (18)
- `packages/happy-dom/src/PropertySymbol.ts` - Added `nameList` symbol
- `packages/happy-dom/src/index.ts` - Exported new classes
- `packages/happy-dom/src/window/BrowserWindow.ts` - Added CSSLayerBlockRule and CSSLayerStatementRule
- `packages/happy-dom/package.json` - Added css-tree dependency

### Implementation Details

The new parser:
1. Uses css-tree to parse CSS into an AST
2. Converts the AST to CSSOM objects (CSSStyleRule, CSSMediaRule, etc.)
3. Validates selectors using the existing SelectorParser
4. Normalizes whitespace in condition text for consistency with browser behavior

### Supported @layer Syntax

```css
/* Named layer block */
@layer utilities {
  .test { color: red; }
}

/* Anonymous layer block */
@layer {
  .test { color: blue; }
}

/* Layer statement (ordering) */
@layer theme, utilities, components;

/* Single layer statement */
@layer base;
```