### PR TITLE
feat: [#1925] Add PromiseRejectionEvent support

### DIFF
--- a/packages/happy-dom/src/event/events/IPromiseRejectionEventInit.ts
+++ b/packages/happy-dom/src/event/events/IPromiseRejectionEventInit.ts
@@ -1,0 +1,6 @@
+import IEventInit from '../IEventInit.js';
+
+export default interface IPromiseRejectionEventInit extends IEventInit {
+	promise: Promise<unknown>;
+	reason?: unknown;
+}

--- a/packages/happy-dom/src/event/events/PromiseRejectionEvent.ts
+++ b/packages/happy-dom/src/event/events/PromiseRejectionEvent.ts
@@ -1,0 +1,25 @@
+import Event from '../Event.js';
+import IPromiseRejectionEventInit from './IPromiseRejectionEventInit.js';
+
+/**
+ * PromiseRejectionEvent.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent
+ */
+export default class PromiseRejectionEvent extends Event {
+	public readonly promise: Promise<unknown>;
+	public readonly reason: unknown;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type Event type.
+	 * @param [eventInit] Event init.
+	 */
+	constructor(type: string, eventInit: IPromiseRejectionEventInit) {
+		super(type, eventInit);
+
+		this.promise = eventInit.promise;
+		this.reason = eventInit.reason;
+	}
+}

--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -60,6 +60,7 @@ import MouseEvent from './event/events/MouseEvent.js';
 import PointerEvent from './event/events/PointerEvent.js';
 import PopStateEvent from './event/events/PopStateEvent.js';
 import ProgressEvent from './event/events/ProgressEvent.js';
+import PromiseRejectionEvent from './event/events/PromiseRejectionEvent.js';
 import SubmitEvent from './event/events/SubmitEvent.js';
 import TouchEvent from './event/events/TouchEvent.js';
 import WheelEvent from './event/events/WheelEvent.js';
@@ -217,6 +218,7 @@ import type IKeyboardEventInit from './event/events/IKeyboardEventInit.js';
 import type IMediaQueryListInit from './event/events/IMediaQueryListInit.js';
 import type IMouseEventInit from './event/events/IMouseEventInit.js';
 import type IProgressEventInit from './event/events/IProgressEventInit.js';
+import type IPromiseRejectionEventInit from './event/events/IPromiseRejectionEventInit.js';
 import type ISubmitEventInit from './event/events/ISubmitEventInit.js';
 import type ITouchEventInit from './event/events/ITouchEventInit.js';
 import type IWheelEventInit from './event/events/IWheelEventInit.js';
@@ -244,6 +246,7 @@ export type {
 	IOptionalBrowserSettings,
 	IOptionalCookie,
 	IProgressEventInit,
+	IPromiseRejectionEventInit,
 	ISubmitEventInit,
 	ISyncResponse,
 	ITouchEventInit,
@@ -410,6 +413,7 @@ export {
 	PopStateEvent,
 	ProcessingInstruction,
 	ProgressEvent,
+	PromiseRejectionEvent,
 	PropertySymbol,
 	Range,
 	RemotePlayback,

--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -46,6 +46,7 @@ import MessageEvent from '../event/events/MessageEvent.js';
 import MouseEvent from '../event/events/MouseEvent.js';
 import PointerEvent from '../event/events/PointerEvent.js';
 import ProgressEvent from '../event/events/ProgressEvent.js';
+import PromiseRejectionEvent from '../event/events/PromiseRejectionEvent.js';
 import StorageEvent from '../event/events/StorageEvent.js';
 import SubmitEvent from '../event/events/SubmitEvent.js';
 import TouchEvent from '../event/events/TouchEvent.js';
@@ -563,6 +564,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	public readonly StorageEvent = StorageEvent;
 	public readonly SubmitEvent = SubmitEvent;
 	public readonly ProgressEvent = ProgressEvent;
+	public readonly PromiseRejectionEvent = PromiseRejectionEvent;
 	public readonly MediaQueryListEvent = MediaQueryListEvent;
 	public readonly HashChangeEvent = HashChangeEvent;
 	public readonly ClipboardEvent = ClipboardEvent;

--- a/packages/happy-dom/test/event/events/PromiseRejectionEvent.test.ts
+++ b/packages/happy-dom/test/event/events/PromiseRejectionEvent.test.ts
@@ -1,0 +1,40 @@
+import PromiseRejectionEvent from '../../../src/event/events/PromiseRejectionEvent.js';
+import { Window } from '../../../src/index.js';
+import { describe, it, expect } from 'vitest';
+
+describe('PromiseRejectionEvent', () => {
+	describe('constructor()', () => {
+		it('Creates a PromiseRejectionEvent with promise and reason', () => {
+			const promise = Promise.reject('test error').catch(() => {});
+			const reason = new Error('Something went wrong');
+			const event = new PromiseRejectionEvent('unhandledrejection', {
+				promise,
+				reason,
+				bubbles: true,
+				cancelable: true
+			});
+
+			expect(event.type).toBe('unhandledrejection');
+			expect(event.promise).toBe(promise);
+			expect(event.reason).toBe(reason);
+			expect(event.bubbles).toBe(true);
+			expect(event.cancelable).toBe(true);
+		});
+
+		it('Creates a PromiseRejectionEvent without reason', () => {
+			const promise = Promise.reject('test').catch(() => {});
+			const event = new PromiseRejectionEvent('rejectionhandled', { promise });
+
+			expect(event.type).toBe('rejectionhandled');
+			expect(event.promise).toBe(promise);
+			expect(event.reason).toBeUndefined();
+		});
+	});
+
+	describe('Window.PromiseRejectionEvent', () => {
+		it('Is available on the Window object', () => {
+			const window = new Window();
+			expect(window.PromiseRejectionEvent).toBe(PromiseRejectionEvent);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #1925

This PR implements the `PromiseRejectionEvent` interface, which represents events fired when JavaScript Promises are rejected. This event is used with the `unhandledrejection` and `rejectionhandled` window events.

## Changes

- Added `PromiseRejectionEvent` class extending `Event` with `promise` and `reason` properties
- Added `IPromiseRejectionEventInit` interface defining the event initialization options
- Registered `PromiseRejectionEvent` on `BrowserWindow` so it's available as `window.PromiseRejectionEvent`
- Exported both the class and interface from the package index

## Usage

```javascript
import { Window } from "happy-dom";

const window = new Window();

// PromiseRejectionEvent is now available on the window object
console.log(window.PromiseRejectionEvent); // [class PromiseRejectionEvent]

// Create a PromiseRejectionEvent
const promise = Promise.reject('error').catch(() => {});
const event = new window.PromiseRejectionEvent('unhandledrejection', {
  promise,
  reason: new Error('Something went wrong'),
  bubbles: true,
  cancelable: true
});

console.log(event.type);    // 'unhandledrejection'
console.log(event.promise); // Promise
console.log(event.reason);  // Error: Something went wrong
```
