### PR TITLE
fix: [#2045] Replace JSON.parse(JSON.stringify()) with structuredClone()

### DIFF
--- a/packages/happy-dom/src/css/declaration/property-manager/CSSStyleDeclarationPropertyManager.ts
+++ b/packages/happy-dom/src/css/declaration/property-manager/CSSStyleDeclarationPropertyManager.ts
@@ -539,7 +539,7 @@ export default class CSSStyleDeclarationPropertyManager {
 		const _class = <typeof CSSStyleDeclarationPropertyManager>this.constructor;
 		const clone: CSSStyleDeclarationPropertyManager = new _class();
 
-		clone.properties = JSON.parse(JSON.stringify(this.properties));
+		clone.properties = structuredClone(this.properties);
 		clone.definedPropertyNames = Object.assign({}, this.definedPropertyNames);
 
 		return clone;

--- a/packages/happy-dom/src/fetch/Headers.ts
+++ b/packages/happy-dom/src/fetch/Headers.ts
@@ -23,7 +23,7 @@ export default class Headers {
 	constructor(init?: IHeadersInit | null) {
 		if (init) {
 			if (init instanceof Headers) {
-				this[PropertySymbol.entries] = JSON.parse(JSON.stringify(init[PropertySymbol.entries]));
+				this[PropertySymbol.entries] = structuredClone(init[PropertySymbol.entries]);
 			} else if (Array.isArray(init)) {
 				for (const entry of init) {
 					if (entry.length !== 2) {

--- a/packages/happy-dom/src/nodes/html-media-element/MediaStreamTrack.ts
+++ b/packages/happy-dom/src/nodes/html-media-element/MediaStreamTrack.ts
@@ -58,10 +58,8 @@ export default class MediaStreamTrack extends EventTarget {
 	public [PropertySymbol.label]: string = '';
 	public [PropertySymbol.kind]: 'audio' | 'video' = 'video';
 	public [PropertySymbol.constraints]: IMediaTrackConstraints = {};
-	public [PropertySymbol.capabilities]: IMediaTrackCapabilities = JSON.parse(
-		JSON.stringify(CAPABILITIES)
-	);
-	public [PropertySymbol.settings]: IMediaTrackSettings = JSON.parse(JSON.stringify(SETTINGS));
+	public [PropertySymbol.capabilities]: IMediaTrackCapabilities = structuredClone(CAPABILITIES);
+	public [PropertySymbol.settings]: IMediaTrackSettings = structuredClone(SETTINGS);
 
 	// Events
 	public onended: ((event: Event) => void) | null = null;


### PR DESCRIPTION
Resolves #2045

This PR uses `structuredClone()` for deep cloning instead of `JSON.parse(JSON.stringify())`.

## Files changed
- Headers.ts: Clone entries when constructing from another Headers instance
- CSSStyleDeclarationPropertyManager.ts: Clone properties in clone() method
- MediaStreamTrack.ts: Clone CAPABILITIES and SETTINGS constants