### PR TITLE
fix: [#2053] Normalize invalid input type attribute to "text" per HTML spec

### DIFF
--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
@@ -21,6 +21,33 @@ import MouseEvent from '../../event/events/MouseEvent.js';
 import type NodeList from '../node/NodeList.js';
 import ElementEventAttributeUtility from '../element/ElementEventAttributeUtility.js';
 
+// Valid input type states per HTML spec:
+// https://html.spec.whatwg.org/multipage/input.html#attr-input-type
+const INPUT_TYPE_STATES = new Set([
+	'hidden',
+	'text',
+	'search',
+	'tel',
+	'url',
+	'email',
+	'password',
+	'date',
+	'month',
+	'week',
+	'time',
+	'datetime-local',
+	'number',
+	'range',
+	'color',
+	'checkbox',
+	'radio',
+	'file',
+	'submit',
+	'image',
+	'reset',
+	'button'
+]);
+
 /**
  * HTML Input Element.
  *
@@ -370,7 +397,8 @@ export default class HTMLInputElement extends HTMLElement {
 	 * @returns Type. Defaults to "text".
 	 */
 	public get type(): string {
-		return this.getAttribute('type') || 'text';
+		const value = (this.getAttribute('type') ?? '').toLowerCase();
+		return INPUT_TYPE_STATES.has(value) ? value : 'text';
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
@@ -925,6 +925,20 @@ describe('HTMLInputElement', () => {
 			element.setAttribute('type', 'date');
 			expect(element.type).toBe('date');
 		});
+
+		it('Returns "text" for invalid type attribute.', () => {
+			element.setAttribute('type', '123');
+			expect(element.type).toBe('text');
+
+			element.setAttribute('type', 'invalid');
+			expect(element.type).toBe('text');
+		});
+
+		it('Preserves the raw invalid value in the attribute itself.', () => {
+			element.setAttribute('type', '123');
+			expect(element.getAttribute('type')).toBe('123');
+			expect(element.type).toBe('text');
+		});
 	});
 
 	describe('set type()', () => {


### PR DESCRIPTION
## Summary

- When an invalid value was set on the `type` attribute of an `<input>` element, `element.type` returned the invalid value instead of "text"
- This fix makes `element.type` return `"text"` for any invalid type value, matching browser behavior and the HTML spec
- `getAttribute('type')` still returns the raw value (this is correct per spec)

Fixes #2053

## Changes

- HTMLInputElement.ts: HTMLInputElement.ts: Define the 22 valid input type states from the [HTML spec](https://html.spec.whatwg.org/multipage/input.html#attr-input-type)
- HTMLInputElement.test.ts: Add tests for invalid type normalization