### PR TITLE
fix: [#2063] Response constructor throws RangeError for invalid status codes

### DIFF
--- a/packages/happy-dom/src/fetch/Response.ts
+++ b/packages/happy-dom/src/fetch/Response.ts
@@ -60,7 +60,15 @@ export default class Response implements Response {
 			);
 		}
 
-		this.status = init?.status !== undefined ? init.status : 200;
+		const status = init?.status !== undefined ? init.status : 200;
+
+		if (status < 200 || status > 599) {
+			throw new RangeError(
+				`Failed to construct 'Response': The status provided (${status}) is outside the range [200, 599].`
+			);
+		}
+
+		this.status = status;
 		this.statusText = init?.statusText || '';
 		this.ok = this.status >= 200 && this.status < 300;
 		this.headers = new this[PropertySymbol.window].Headers(init?.headers);
@@ -393,7 +401,9 @@ export default class Response implements Response {
 	 * @returns Response.
 	 */
 	public static error(): Response {
-		const response = new this[PropertySymbol.window].Response(null, { status: 0, statusText: '' });
+		const response = new this[PropertySymbol.window].Response(null);
+		(<number>response.status) = 0;
+		(<boolean>response.ok) = false;
 		(<string>response.type) = 'error';
 		return response;
 	}

--- a/packages/happy-dom/test/fetch/Response.test.ts
+++ b/packages/happy-dom/test/fetch/Response.test.ts
@@ -52,17 +52,44 @@ describe('Response', () => {
 			expect(response.status).toBe(404);
 		});
 
+		it('Throws RangeError for status below 200.', () => {
+			expect(() => new window.Response(null, { status: 0 })).toThrow(
+				new RangeError(
+					"Failed to construct 'Response': The status provided (0) is outside the range [200, 599]."
+				)
+			);
+			expect(() => new window.Response(null, { status: 199 })).toThrow(
+				new RangeError(
+					"Failed to construct 'Response': The status provided (199) is outside the range [200, 599]."
+				)
+			);
+		});
+
+		it('Throws RangeError for status above 599.', () => {
+			expect(() => new window.Response(null, { status: 600 })).toThrow(
+				new RangeError(
+					"Failed to construct 'Response': The status provided (600) is outside the range [200, 599]."
+				)
+			);
+		});
+
+		it('Accepts status codes at the boundaries of the valid range.', () => {
+			const response200 = new window.Response(null, { status: 200 });
+			expect(response200.status).toBe(200);
+
+			const response599 = new window.Response(null, { status: 599 });
+			expect(response599.status).toBe(599);
+		});
+
 		it('Sets status text from init object.', () => {
 			const response = new window.Response(null, { statusText: 'test' });
 			expect(response.statusText).toBe('test');
 		});
 
 		it('Sets ok state correctly based on status code.', () => {
-			const response199 = new window.Response(null, { status: 199 });
 			const response200 = new window.Response(null, { status: 200 });
 			const response299 = new window.Response(null, { status: 299 });
 			const response300 = new window.Response(null, { status: 300 });
-			expect(response199.ok).toBe(false);
 			expect(response200.ok).toBe(true);
 			expect(response299.ok).toBe(true);
 			expect(response300.ok).toBe(false);


### PR DESCRIPTION
Closes #2063

### Problem

The `Response` constructor accepts any numeric status code without validation. Per the [fetch spec](https://fetch.spec.whatwg.org/#dom-response), `init["status"]` must be in the range [200, 599] — otherwise a `RangeError` should be thrown.

```js
new Response({}, { status: 0 })
// happy-dom: succeeds (incorrect)
// Chrome:   RangeError: Failed to construct 'Response': The status provided (0) is outside the range [200, 599].
// Firefox:  RangeError: Response constructor: Invalid response status code.
```

### Changes

**`packages/happy-dom/src/fetch/Response.ts`**
- Added a range check in the constructor that throws `RangeError` when the provided status is outside [200, 599], matching Chrome's error message format.
- Updated `Response.error()` to set `status: 0` directly on the response object after construction rather than passing it through the constructor, since error responses are spec-defined to have status 0.

**`packages/happy-dom/test/fetch/Response.test.ts`**
- Added tests for status codes below 200 (0, 199) and above 599 (600).
- Added boundary test confirming 200 and 599 are accepted.
- Updated existing "ok state" test to remove the now-invalid status 199 case.
