### PR TITLE
fix: [#2054] Events created with native Event constructor now bubble correctly

### DIFF
--- a/packages/happy-dom/test/event/EventBubbling.test.ts
+++ b/packages/happy-dom/test/event/EventBubbling.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import Window from '../../src/window/Window.js';
+
+describe('Event bubbling with native Event constructor', () => {
+	it('should bubble native Events to parent elements.', () => {
+		const window = new Window();
+		const document = window.document;
+
+		const parent = document.createElement('div');
+		const child = document.createElement('span');
+		parent.appendChild(child);
+		document.body.appendChild(parent);
+
+		let bubbled = false;
+		parent.addEventListener('click', () => {
+			bubbled = true;
+		});
+
+		const event = new Event('click', { bubbles: true });
+		child.dispatchEvent(event);
+		expect(bubbled).toBe(true);
+	});
+
+	it('should not bubble native Events when bubbles is false.', () => {
+		const window = new Window();
+		const document = window.document;
+
+		const parent = document.createElement('div');
+		const child = document.createElement('span');
+		parent.appendChild(child);
+		document.body.appendChild(parent);
+
+		const events: string[] = [];
+		parent.addEventListener('custom', () => {
+			events.push('parent');
+		});
+		child.addEventListener('custom', () => {
+			events.push('child');
+		});
+
+		const event = new Event('custom', { bubbles: false });
+		child.dispatchEvent(event);
+		// Should only fire on child, not bubble to parent
+		expect(events).toEqual(['child']);
+	});
+
+	it('should call listeners on the target element for native Events.', () => {
+		const window = new Window();
+		const document = window.document;
+
+		const child = document.createElement('span');
+		document.body.appendChild(child);
+
+		let called = false;
+		child.addEventListener('click', () => {
+			called = true;
+		});
+
+		const event = new Event('click', { bubbles: true });
+		child.dispatchEvent(event);
+		expect(called).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #2054

### Problem

Events created with the native `Event` constructor (e.g. `new Event('click', { bubbles: true })`) don't bubble to parent elements when dispatched via `dispatchEvent()`. Events created with `document.createEvent()`/`initEvent()` or `new window.Event()` work fine.

The root cause: happy-dom's dispatch logic reads event properties via internal Symbol keys (`event[PropertySymbol.bubbles]`, `event[PropertySymbol.eventPhase]`, etc.). Native `Event` objects don't have these Symbol properties, so `event[PropertySymbol.bubbles]` returns `undefined` (falsy) and the bubbling phase is skipped entirely. Additionally, `event[PropertySymbol.eventPhase]` being `undefined` caused the capturing phase to incorrectly invoke bubbling-phase listeners.

### Changes

**`packages/happy-dom/src/event/EventTarget.ts`**
- At the top of `dispatchEvent()`, detect non-happy-dom events (where `event[PropertySymbol.type]` is `undefined`) and copy standard properties (`type`, `bubbles`, `cancelable`, `composed`, etc.) to the internal Symbol properties. Also override `composedPath()` to traverse happy-dom's DOM tree.
- In `#callDispatchEventListeners()`, read `eventPhase` from the Symbol property instead of the native getter, so the capturing/bubbling phase distinction works correctly for native events.

**`packages/happy-dom/test/event/EventBubbling.test.ts`** (new)
- Tests that native `Event` objects bubble to parent elements.
- Tests that native `Event` objects with `bubbles: false` do not bubble.
- Tests that native `Event` objects fire on the target element.
