### PR TITLE
fix: [#1848] Implement PageTransitionEvent with persisted property

### DIFF
--- a/packages/happy-dom/src/event/events/IPageTransitionEventInit.ts
+++ b/packages/happy-dom/src/event/events/IPageTransitionEventInit.ts
@@ -1,0 +1,5 @@
+import type IEventInit from '../IEventInit.js';
+
+export default interface IPageTransitionEventInit extends IEventInit {
+	persisted?: boolean;
+}

--- a/packages/happy-dom/src/event/events/PageTransitionEvent.ts
+++ b/packages/happy-dom/src/event/events/PageTransitionEvent.ts
@@ -1,0 +1,23 @@
+import Event from '../Event.js';
+import type IPageTransitionEventInit from './IPageTransitionEventInit.js';
+
+/**
+ * Page transition event.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent
+ */
+export default class PageTransitionEvent extends Event {
+	public readonly persisted: boolean;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param type Event type.
+	 * @param [eventInit] Event init.
+	 */
+	constructor(type: string, eventInit: IPageTransitionEventInit | null = null) {
+		super(type, eventInit);
+
+		this.persisted = eventInit?.persisted ?? false;
+	}
+}

--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -57,6 +57,7 @@ import InputEvent from './event/events/InputEvent.js';
 import KeyboardEvent from './event/events/KeyboardEvent.js';
 import MediaQueryListEvent from './event/events/MediaQueryListEvent.js';
 import MouseEvent from './event/events/MouseEvent.js';
+import PageTransitionEvent from './event/events/PageTransitionEvent.js';
 import PointerEvent from './event/events/PointerEvent.js';
 import PopStateEvent from './event/events/PopStateEvent.js';
 import ProgressEvent from './event/events/ProgressEvent.js';
@@ -216,6 +217,7 @@ import type IInputEventInit from './event/events/IInputEventInit.js';
 import type IKeyboardEventInit from './event/events/IKeyboardEventInit.js';
 import type IMediaQueryListInit from './event/events/IMediaQueryListInit.js';
 import type IMouseEventInit from './event/events/IMouseEventInit.js';
+import type IPageTransitionEventInit from './event/events/IPageTransitionEventInit.js';
 import type IProgressEventInit from './event/events/IProgressEventInit.js';
 import type ISubmitEventInit from './event/events/ISubmitEventInit.js';
 import type ITouchEventInit from './event/events/ITouchEventInit.js';
@@ -243,6 +245,7 @@ export type {
 	IKeyboardEventInit,
 	IMediaQueryListInit,
 	IMouseEventInit,
+	IPageTransitionEventInit,
 	IOptionalBrowserSettings,
 	IOptionalCookie,
 	IProgressEventInit,
@@ -408,6 +411,7 @@ export {
 	NodeIterator,
 	Permissions,
 	PermissionStatus,
+	PageTransitionEvent,
 	PointerEvent,
 	PopStateEvent,
 	ProcessingInstruction,

--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -50,6 +50,7 @@ import StorageEvent from '../event/events/StorageEvent.js';
 import SubmitEvent from '../event/events/SubmitEvent.js';
 import TouchEvent from '../event/events/TouchEvent.js';
 import WheelEvent from '../event/events/WheelEvent.js';
+import PageTransitionEvent from '../event/events/PageTransitionEvent.js';
 import type DOMException from '../exception/DOMException.js';
 import DOMExceptionNameEnum from '../exception/DOMExceptionNameEnum.js';
 import type AbortController from '../fetch/AbortController.js';
@@ -590,7 +591,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	public readonly MutationEvent = Event;
 	public readonly OfflineAudioCompletionEvent = Event;
 	public readonly OverconstrainedError = Event;
-	public readonly PageTransitionEvent = Event;
+	public readonly PageTransitionEvent = PageTransitionEvent;
 	public readonly PaymentRequestUpdateEvent = Event;
 	public readonly RelatedEvent = Event;
 	public readonly RTCDataChannelEvent = Event;

--- a/packages/happy-dom/test/event/events/PageTransitionEvent.test.ts
+++ b/packages/happy-dom/test/event/events/PageTransitionEvent.test.ts
@@ -1,0 +1,40 @@
+import Event from '../../../src/event/Event.js';
+import PageTransitionEvent from '../../../src/event/events/PageTransitionEvent.js';
+import Window from '../../../src/window/Window.js';
+import { describe, it, expect } from 'vitest';
+
+describe('PageTransitionEvent', () => {
+	describe('constructor', () => {
+		it('Creates a page transition event with persisted set to true.', () => {
+			const event = new PageTransitionEvent('pageshow', { persisted: true });
+			expect(event).toBeInstanceOf(Event);
+			expect(event.type).toBe('pageshow');
+			expect(event.persisted).toBe(true);
+		});
+
+		it('Defaults persisted to false.', () => {
+			const event = new PageTransitionEvent('pagehide');
+			expect(event.persisted).toBe(false);
+		});
+
+		it('Defaults persisted to false when eventInit is null.', () => {
+			const event = new PageTransitionEvent('pageshow', null);
+			expect(event.persisted).toBe(false);
+		});
+	});
+
+	it('Preserves persisted property through dispatchEvent.', () => {
+		const window = new Window();
+
+		let receivedEvent: PageTransitionEvent | null = null;
+		window.addEventListener('pageshow', (e) => {
+			receivedEvent = <PageTransitionEvent>e;
+		});
+
+		window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+
+		expect(receivedEvent).not.toBeNull();
+		expect(receivedEvent!.type).toBe('pageshow');
+		expect(receivedEvent!.persisted).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #1848

### Problem

`PageTransitionEvent` was aliased to the base `Event` class, so the `persisted` property from the init object was silently dropped. Dispatching a `new PageTransitionEvent('pageshow', { persisted: true })` and reading `event.persisted` in the handler returned `undefined`.

### Changes

- Created `PageTransitionEvent` class extending `Event` with a readonly `persisted` property, defaulting to `false`.
- Created `IPageTransitionEventInit` interface.
- Updated `BrowserWindow` to use the new class instead of the `Event` alias.
- Exported both from the package index.
- Added tests covering constructor defaults, `persisted: true`, and round-tripping through `dispatchEvent`.
