### PR TITLE
fix: [#1847] Navigation with location.href now adds to history

### DIFF
--- a/packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts
+++ b/packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts
@@ -128,6 +128,20 @@ export default class BrowserFrameNavigator {
 
 		if (!BrowserFrameValidator.validateFrameNavigation(frame)) {
 			if (!frame.page.context.browser.settings.navigation.disableFallbackToSetURL) {
+				if (!disableHistory) {
+					const history = frame[PropertySymbol.history];
+
+					history.push({
+						title: '',
+						href: targetURL.href,
+						state: null,
+						popState: false,
+						scrollRestoration: HistoryScrollRestorationEnum.auto,
+						method: method || (formData ? 'POST' : 'GET'),
+						formData: formData || null
+					});
+				}
+
 				frame.window.location[PropertySymbol.setURL](frame, targetURL.href);
 			}
 

--- a/packages/happy-dom/test/history/History.test.ts
+++ b/packages/happy-dom/test/history/History.test.ts
@@ -1,5 +1,6 @@
 import type IBrowserFrame from '../../src/browser/types/IBrowserFrame.js';
 import Browser from '../../src/browser/Browser.js';
+import Window from '../../src/window/Window.js';
 import HistoryScrollRestorationEnum from '../../src/history/HistoryScrollRestorationEnum.js';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import * as PropertySymbol from '../../src/PropertySymbol.js';
@@ -39,6 +40,19 @@ describe('History', () => {
 
 			// 3 as the first item is added as "about:blank" in the constructor.
 			expect(browserFrame.window.history.length).toBe(3);
+		});
+
+		it('Increases when navigating with location.href.', async () => {
+			const window = new Window({ url: 'https://www.example.com/' });
+
+			expect(window.history.length).toBe(1);
+
+			window.location.href = 'https://www.example.com/page2';
+
+			// location.href setter calls goto() which is async
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(window.history.length).toBe(2);
 		});
 	});
 


### PR DESCRIPTION
Closes #1847

### Problem

Setting `location.href` doesn't increment `history.length`. The `href` setter calls `browserFrame.goto()` → `BrowserFrameNavigator.navigate()`, which pushes to history for full navigations. However, when using a detached window (e.g. `new Window()`, the common test scenario), `validateFrameNavigation()` returns `false` and the code falls through to a path that only updates the URL via `setURL()` without pushing a history entry.

### Changes

**`packages/happy-dom/src/browser/utilities/BrowserFrameNavigator.ts`**
- In the `validateFrameNavigation` fallback path (used by detached windows), push a history entry before calling `setURL()`, matching the behavior of the normal navigation path.

**`packages/happy-dom/test/history/History.test.ts`**
- Added test verifying `history.length` increases after setting `location.href` on a detached window.
