### PR TITLE
fix: [#1733] Add setPointerCapture, hasPointerCapture, and releasePointerCapture to Element

### DIFF
--- a/packages/happy-dom/src/PropertySymbol.ts
+++ b/packages/happy-dom/src/PropertySymbol.ts
@@ -71,6 +71,7 @@ export const windowResizeListener = Symbol('windowResizeListener');
 export const mutationObservers = Symbol('mutationObservers');
 export const openerFrame = Symbol('openerFrame');
 export const openerWindow = Symbol('openerWindow');
+export const pointerCaptures = Symbol('pointerCaptures');
 export const popup = Symbol('popup');
 export const isConnected = Symbol('isConnected');
 export const parentNode = Symbol('parentNode');

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -61,6 +61,7 @@ export default class Element
 	public [PropertySymbol.attributesProxy]: NamedNodeMap | null = null;
 	public [PropertySymbol.children]: HTMLCollection<Element> | null = null;
 	public [PropertySymbol.computedStyle]: CSSStyleDeclaration | null = null;
+	public [PropertySymbol.pointerCaptures]: Set<number> = new Set();
 	public [PropertySymbol.propertyEventListeners]: Map<string, ((event: Event) => void) | null> =
 		new Map();
 	public declare [PropertySymbol.tagName]: string | null;
@@ -976,6 +977,37 @@ export default class Element
 		const domRectList = new DOMRectList(PropertySymbol.illegalConstructor);
 		domRectList.push(this.getBoundingClientRect());
 		return domRectList;
+	}
+
+	/**
+	 * Designates a specific element as the capture target of future pointer events.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
+	 * @param pointerId Pointer ID.
+	 */
+	public setPointerCapture(pointerId: number): void {
+		this[PropertySymbol.pointerCaptures].add(pointerId);
+	}
+
+	/**
+	 * Returns whether the element on which it is invoked has pointer capture for the pointer identified by the given pointer ID.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/hasPointerCapture
+	 * @param pointerId Pointer ID.
+	 * @returns Whether the element has pointer capture.
+	 */
+	public hasPointerCapture(pointerId: number): boolean {
+		return this[PropertySymbol.pointerCaptures].has(pointerId);
+	}
+
+	/**
+	 * Releases pointer capture that was previously set for a specific pointer.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/releasePointerCapture
+	 * @param pointerId Pointer ID.
+	 */
+	public releasePointerCapture(pointerId: number): void {
+		this[PropertySymbol.pointerCaptures].delete(pointerId);
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -2039,6 +2039,45 @@ describe('Element', () => {
 		});
 	});
 
+	describe('setPointerCapture()', () => {
+		it('Sets pointer capture for the given pointer ID.', () => {
+			element.setPointerCapture(1);
+			expect(element.hasPointerCapture(1)).toBe(true);
+		});
+
+		it('Can capture multiple pointer IDs.', () => {
+			element.setPointerCapture(1);
+			element.setPointerCapture(2);
+			expect(element.hasPointerCapture(1)).toBe(true);
+			expect(element.hasPointerCapture(2)).toBe(true);
+		});
+	});
+
+	describe('hasPointerCapture()', () => {
+		it('Returns false when no pointer capture is set.', () => {
+			expect(element.hasPointerCapture(1)).toBe(false);
+		});
+
+		it('Returns true after setPointerCapture() is called with the same pointer ID.', () => {
+			element.setPointerCapture(5);
+			expect(element.hasPointerCapture(5)).toBe(true);
+			expect(element.hasPointerCapture(6)).toBe(false);
+		});
+	});
+
+	describe('releasePointerCapture()', () => {
+		it('Releases pointer capture for the given pointer ID.', () => {
+			element.setPointerCapture(1);
+			expect(element.hasPointerCapture(1)).toBe(true);
+			element.releasePointerCapture(1);
+			expect(element.hasPointerCapture(1)).toBe(false);
+		});
+
+		it('Does not throw when releasing a pointer ID that was not captured.', () => {
+			expect(() => element.releasePointerCapture(999)).not.toThrow();
+		});
+	});
+
 	describe('cloneNode()', () => {
 		it('Clones the properties of the element when cloned.', () => {
 			const child = document.createElement('div');


### PR DESCRIPTION
## Summary
- Adds `setPointerCapture()`, `hasPointerCapture()`, and `releasePointerCapture()` to `Element`
- These methods are part of the [Pointer Events API](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) and are expected to exist on all elements
- Tracks captured pointer IDs using an internal `Set` so that `hasPointerCapture()` correctly returns `true` after `setPointerCapture()` is called and `false` after `releasePointerCapture()`
- Without these methods, code that uses pointer capture (e.g. drag-and-drop libraries, React components) throws `TypeError: element.setPointerCapture is not a function`

## Test plan
- Added unit tests verifying `setPointerCapture()` adds pointer IDs
- Added unit tests verifying `hasPointerCapture()` returns correct state
- Added unit tests verifying `releasePointerCapture()` removes pointer IDs
- Added test for capturing multiple pointer IDs simultaneously
- Added test for releasing a pointer ID that was never captured (no throw)
- Verified all 7246 existing tests still pass

Closes #1733