### PR TITLE
fix: [#1845] Replace ConsoleConstructor import with indexed access type

### DIFF
--- a/packages/happy-dom/src/console/VirtualConsole.ts
+++ b/packages/happy-dom/src/console/VirtualConsole.ts
@@ -2,7 +2,6 @@ import type IVirtualConsolePrinter from './IVirtualConsolePrinter.js';
 import VirtualConsoleLogLevelEnum from './enums/VirtualConsoleLogLevelEnum.js';
 import VirtualConsoleLogTypeEnum from './enums/VirtualConsoleLogTypeEnum.js';
 import type IVirtualConsoleLogGroup from './IVirtualConsoleLogGroup.js';
-import type { ConsoleConstructor } from 'console';
 
 /**
  * Virtual Console.
@@ -10,9 +9,11 @@ import type { ConsoleConstructor } from 'console';
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Console
  */
 export default class VirtualConsole implements Console {
-	// This is needed as the interface for the NodeJS Console also have a reference to the ConsoleConstructor class as a property for some reason.
-	// This is not part of the browser specs.
-	public declare Console: ConsoleConstructor;
+	// The NodeJS Console interface includes a reference to ConsoleConstructor as a property.
+	// This is not part of the browser specs, but we need to declare it for type compatibility.
+	// Using an indexed access type avoids importing from the 'console' module, which can fail
+	// in consumer projects that don't resolve Node.js built-in module types.
+	public declare Console: Console['Console'];
 
 	#printer: IVirtualConsolePrinter;
 	#count: { [label: string]: number } = {};


### PR DESCRIPTION
**Update:** This PR fixed the `ConsoleConstructor` import (TS2305) but did not fix the TS2420 reported in #1845 — I misattributed the issue. I should have filed a separate issue for the ConsoleConstructor problem rather than linking it to #1845. The actual fix for #1845 is in #2102.

---

## Problem

`VirtualConsole.ts` imports `ConsoleConstructor` from the Node.js `'console'` module:

```typescript
import type { ConsoleConstructor } from 'console';
```

This import is emitted into the published `lib/console/VirtualConsole.d.ts`, causing `TS2305: Module '"console"' has no exported member 'ConsoleConstructor'` for consumers whose TypeScript configuration doesn't resolve Node.js built-in module types — for example, projects with `skipLibCheck: false` and a `moduleResolution` that doesn't map the `'console'` specifier to `@types/node`'s console declarations.

### Reproduction

Any consumer project with `skipLibCheck: false` that imports something from happy-dom touching VirtualConsole's type will get:

```
node_modules/happy-dom/lib/console/VirtualConsole.d.ts(2,15): error TS2305: Module '"console"' has no exported member 'ConsoleConstructor'.
```

This is related to #1845, which reports a similar type compatibility issue with VirtualConsole.

## Fix

Replace the `ConsoleConstructor` import with an indexed access type `Console['Console']`. This resolves to the same type (the `Console` property on the global `Console` interface points to `ConsoleConstructor`) but avoids the `import from 'console'` module specifier entirely.

### Before

```typescript
import type { ConsoleConstructor } from 'console';
public declare Console: ConsoleConstructor;
```

### After

```typescript
// No import needed
public declare Console: Console['Console'];
```

## Verification

- `npm run compile`: passes
- `npm run lint` (root): passes (zero warnings)
- `npm test` (packages/happy-dom): all 48 console tests pass. 4 pre-existing failures in unrelated test files (SyncFetch, ModuleURLUtility, BrowserWindow, DetachedWindowAPI) — identical on clean `master`.
- Consumer project with `skipLibCheck: false`: zero ConsoleConstructor errors after fix (confirmed `TS2305` without fix)
