### PR TITLE
fix: CSSStyleDeclaration.setProperty null handling per MDN spec

### DIFF
--- a/packages/happy-dom/src/css/declaration/CSSStyleDeclaration.ts
+++ b/packages/happy-dom/src/css/declaration/CSSStyleDeclaration.ts
@@ -4862,7 +4862,7 @@ export default class CSSStyleDeclaration {
 	 * @param value Value. Must not contain "!important" as that should be set using the priority parameter.
 	 * @param [priority] Can be "important", or an empty string.
 	 */
-	public setProperty(name: string, value: string, priority?: 'important' | '' | undefined): void {
+	public setProperty(name: string, value: string | null, priority?: 'important' | '' | null | undefined): void {
 		if (this.#computed) {
 			throw new this[PropertySymbol.window].DOMException(
 				`Failed to execute 'setProperty' on 'CSSStyleDeclaration': These styles are computed, and therefore the '${name}' property is read-only.`,
@@ -4870,11 +4870,12 @@ export default class CSSStyleDeclaration {
 			);
 		}
 
-		if (priority !== '' && priority !== undefined && priority !== 'important') {
+		if (priority !== '' && priority !== undefined && priority !== null && priority !== 'important') {
 			return;
 		}
 
-		const stringValue = String(value).trim();
+		// Per MDN spec: null value is treated the same as empty string
+		const stringValue = String(value ?? '').trim();
 		const propertyManager = this.#getPropertyManager();
 
 		if (stringValue) {


### PR DESCRIPTION
Fixes #2100

## Problem

`setProperty('--someProp', null)` produced `style="--someProp: null;"` instead of removing the property.

Similarly, passing `null` as priority was not recognized as equivalent to empty string.

## Root Cause

1. `String(null)` produces `"null"` (truthy string), so `propertyManager.set()` was called instead of `propertyManager.remove()`
2. The priority check didn't include `null`

## Fix

Per [MDN spec](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty):
- A `null` value is treated the same as the empty string (`""`)
- `null` priority removes the `!important` flag if present

Changes:
1. Use `String(value ?? '')` so `null` becomes empty string, triggering property removal
2. Add `null` to the priority check
3. Update type signature to accept `null` for both value and priority