### PR TITLE
fix: [#2106] `Request.formData()` should honor `Content-Type` header

### DIFF
--- a/packages/happy-dom/src/fetch/Request.ts
+++ b/packages/happy-dom/src/fetch/Request.ts
@@ -432,7 +432,7 @@ export default class Request implements Request {
 		const window = this[PropertySymbol.window];
 		const asyncTaskManager = new WindowBrowserContext(window).getAsyncTaskManager()!;
 
-		const contentType = this[PropertySymbol.contentType];
+		const contentType = this.headers.get('Content-Type') ?? this[PropertySymbol.contentType];
 
 		if (this.body && contentType && /multipart/i.test(contentType)) {
 			if (this[PropertySymbol.bodyUsed]) {

--- a/packages/happy-dom/test/fetch/Request.test.ts
+++ b/packages/happy-dom/test/fetch/Request.test.ts
@@ -729,6 +729,19 @@ describe('Request', () => {
 			expect(formDataResponse.get('some')).toBe('test');
 		});
 
+		it('Returns FormData for string body with explicit Content-Type header.', async () => {
+			const request = new window.Request(TEST_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: 'key1=value1&key2=value2&key3=value3'
+			});
+			const formDataResponse = await request.formData();
+
+			expect(formDataResponse.get('key1')).toBe('value1');
+			expect(formDataResponse.get('key2')).toBe('value2');
+			expect(formDataResponse.get('key3')).toBe('value3');
+		});
+
 		it('Returns FormData for "application/x-www-form-urlencoded" content.', async () => {
 			const urlSearchParams = new URLSearchParams();
 


### PR DESCRIPTION
`Request.formData()` was checking the internal `PropertySymbol.contentType` (inferred from the body init) instead of the actual `Content-Type` header. This caused `formData()` to fail when a string body was paired with an explicit `Content-Type` header, since the body-inferred type was always `text/plain;charset=UTF-8`.

This aligns `Request.formData()` with `Response.formData()`, which already reads from headers.

Fixes #2106.