### PR TITLE
fix: [#2099] Lazily create ReadableStream for Request and Response body

### DIFF
--- a/packages/happy-dom/src/fetch/Request.ts
+++ b/packages/happy-dom/src/fetch/Request.ts
@@ -116,7 +116,11 @@ export default class Request implements Request {
 
 		if (contentLength) {
 			this[PropertySymbol.contentLength] = contentLength;
-		} else if (!this.body && (this.method === 'POST' || this.method === 'PUT')) {
+		} else if (
+			!this[PropertySymbol.body] &&
+			!this[PropertySymbol.bodyBuffer] &&
+			(this.method === 'POST' || this.method === 'PUT')
+		) {
 			this[PropertySymbol.contentLength] = 0;
 		}
 
@@ -187,6 +191,11 @@ export default class Request implements Request {
 	 * @returns Body.
 	 */
 	public get body(): ReadableStream | null {
+		if (!this[PropertySymbol.body] && this[PropertySymbol.bodyBuffer]) {
+			this[PropertySymbol.body] = FetchBodyUtility.toReadableStream(
+				this[PropertySymbol.bodyBuffer]
+			);
+		}
 		return this[PropertySymbol.body];
 	}
 

--- a/packages/happy-dom/src/fetch/Response.ts
+++ b/packages/happy-dom/src/fetch/Response.ts
@@ -31,7 +31,6 @@ export default class Response implements Response {
 	protected declare [PropertySymbol.window]: BrowserWindow;
 
 	// Public properties
-	public readonly body: ReadableStream | null = null;
 	public readonly bodyUsed = false;
 	public readonly redirected = false;
 	public readonly type: 'basic' | 'cors' | 'default' | 'error' | 'opaque' | 'opaqueredirect' =
@@ -43,6 +42,7 @@ export default class Response implements Response {
 	public readonly headers: Headers;
 	public [PropertySymbol.cachedResponse]: ICachedResponse | null = null;
 	public [PropertySymbol.buffer]: Buffer | null = null;
+	public [PropertySymbol.body]: ReadableStream | null = null;
 	public [PropertySymbol.virtualServerFile]: string | null = null;
 	public [PropertySymbol.aborted]: boolean = false;
 	public [PropertySymbol.error]: Error | null = null;
@@ -71,7 +71,7 @@ export default class Response implements Response {
 
 		if (body) {
 			const { stream, buffer, contentType } = FetchBodyUtility.getBodyStream(body);
-			this.body = stream;
+			this[PropertySymbol.body] = stream;
 
 			if (buffer) {
 				this[PropertySymbol.buffer] = buffer;
@@ -81,6 +81,18 @@ export default class Response implements Response {
 				this.headers.set('Content-Type', contentType);
 			}
 		}
+	}
+
+	/**
+	 * Returns body.
+	 *
+	 * @returns Body.
+	 */
+	public get body(): ReadableStream | null {
+		if (!this[PropertySymbol.body] && this[PropertySymbol.buffer]) {
+			this[PropertySymbol.body] = FetchBodyUtility.toReadableStream(this[PropertySymbol.buffer]);
+		}
+		return this[PropertySymbol.body];
 	}
 
 	/**

--- a/packages/happy-dom/src/fetch/utilities/FetchBodyUtility.ts
+++ b/packages/happy-dom/src/fetch/utilities/FetchBodyUtility.ts
@@ -37,7 +37,7 @@ export default class FetchBodyUtility {
 			const buffer = Buffer.from(body.toString());
 			return {
 				buffer,
-				stream: this.toReadableStream(buffer),
+				stream: null,
 				contentType: 'application/x-www-form-urlencoded;charset=UTF-8',
 				contentLength: buffer.length
 			};
@@ -45,14 +45,14 @@ export default class FetchBodyUtility {
 			const buffer = (<Blob>body)[PropertySymbol.buffer];
 			return {
 				buffer,
-				stream: this.toReadableStream(buffer),
+				stream: null,
 				contentType: body.type,
 				contentLength: body.size
 			};
 		} else if (Buffer.isBuffer(body)) {
 			return {
 				buffer: body,
-				stream: this.toReadableStream(body),
+				stream: null,
 				contentType: null,
 				contentLength: body.length
 			};
@@ -60,7 +60,7 @@ export default class FetchBodyUtility {
 			const buffer = Buffer.from(body);
 			return {
 				buffer,
-				stream: this.toReadableStream(buffer),
+				stream: null,
 				contentType: null,
 				contentLength: body.byteLength
 			};
@@ -68,7 +68,7 @@ export default class FetchBodyUtility {
 			const buffer = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
 			return {
 				buffer,
-				stream: this.toReadableStream(buffer),
+				stream: null,
 				contentType: null,
 				contentLength: body.byteLength
 			};
@@ -86,7 +86,7 @@ export default class FetchBodyUtility {
 		const buffer = Buffer.from(String(body));
 		return {
 			buffer,
-			stream: this.toReadableStream(buffer),
+			stream: null,
 			contentType: 'text/plain;charset=UTF-8',
 			contentLength: buffer.length
 		};
@@ -119,13 +119,13 @@ export default class FetchBodyUtility {
 			);
 		}
 
-		if (requestOrResponse.body === null || requestOrResponse.body === undefined) {
-			return null;
-		}
-
-		// If a buffer is set, use it to create a new stream.
+		// If a buffer is set, create a new stream from the buffer without triggering the lazy body getter.
 		if (requestOrResponse[PropertySymbol.buffer]) {
 			return this.toReadableStream(requestOrResponse[PropertySymbol.buffer]);
+		}
+
+		if (requestOrResponse.body === null || requestOrResponse.body === undefined) {
+			return null;
 		}
 
 		// Pipe underlying node stream if it exists.
@@ -135,15 +135,8 @@ export default class FetchBodyUtility {
 			(<any>requestOrResponse.body)[PropertySymbol.nodeStream].pipe(stream1);
 			(<any>requestOrResponse.body)[PropertySymbol.nodeStream].pipe(stream2);
 			// Sets the body of the cloned request/response to the first pass through stream.
-			// Request uses [PropertySymbol.body] with a getter, Response uses public readonly body.
 			const newStream = this.nodeToWebStream(stream1);
-			if (PropertySymbol.body in requestOrResponse) {
-				// Request object - set the symbol property (getter will return it)
-				(<any>requestOrResponse)[PropertySymbol.body] = newStream;
-			} else {
-				// Response object - set the public property directly
-				(<ReadableStream | null>(<any>requestOrResponse).body) = newStream;
-			}
+			(<any>requestOrResponse)[PropertySymbol.body] = newStream;
 			// Returns the clone.
 			return this.nodeToWebStream(stream2);
 		}
@@ -152,15 +145,8 @@ export default class FetchBodyUtility {
 		// This requires the stream to be consumed in parallel which is not the case for the fetch API
 		const [stream1, stream2] = requestOrResponse.body.tee();
 
-		// Sets the body of the cloned request to the first pass through stream.
-		// Request uses [PropertySymbol.body] with a getter, Response uses public readonly body.
-		if (PropertySymbol.body in requestOrResponse) {
-			// Request object - set the symbol property (getter will return it)
-			(<any>requestOrResponse)[PropertySymbol.body] = stream1;
-		} else {
-			// Response object - set the public property directly
-			(<ReadableStream | null>(<any>requestOrResponse).body) = stream1;
-		}
+		// Sets the body of the cloned request/response to the first pass through stream.
+		(<any>requestOrResponse)[PropertySymbol.body] = stream1;
 
 		// Returns the other stream as the clone
 		return stream2;

--- a/packages/happy-dom/src/fetch/utilities/FetchRequestValidationUtility.ts
+++ b/packages/happy-dom/src/fetch/utilities/FetchRequestValidationUtility.ts
@@ -58,7 +58,10 @@ export default class FetchRequestValidationUtility {
 	 * @param request Request.
 	 */
 	public static validateBody(request: Request): void {
-		if (request.body && (request.method === 'GET' || request.method === 'HEAD')) {
+		if (
+			(request[PropertySymbol.body] || request[PropertySymbol.bodyBuffer]) &&
+			(request.method === 'GET' || request.method === 'HEAD')
+		) {
 			throw new DOMException(
 				`Request with GET/HEAD method cannot have body.`,
 				DOMExceptionNameEnum.invalidStateError

--- a/packages/happy-dom/test/fetch/Request.test.ts
+++ b/packages/happy-dom/test/fetch/Request.test.ts
@@ -854,6 +854,28 @@ describe('Request', () => {
 		});
 	});
 
+	describe('body', () => {
+		it('Does not create a ReadableStream eagerly when constructed with a string body.', () => {
+			const request = new window.Request(TEST_URL, { method: 'POST', body: 'Hello World' });
+			expect(request[PropertySymbol.body]).toBe(null);
+		});
+
+		it('Creates a ReadableStream lazily when the body getter is accessed.', () => {
+			const request = new window.Request(TEST_URL, { method: 'POST', body: 'Hello World' });
+			expect(request[PropertySymbol.body]).toBe(null);
+
+			const body = request.body;
+			expect(body).toBeInstanceOf(ReadableStream);
+			expect(request[PropertySymbol.body]).toBe(body);
+		});
+
+		it('Returns null for body when request has no body.', () => {
+			const request = new window.Request(TEST_URL);
+			expect(request.body).toBe(null);
+			expect(request[PropertySymbol.body]).toBe(null);
+		});
+	});
+
 	describe('clone()', () => {
 		it('Clones request body stream without throwing when body has no buffer.', async () => {
 			// This test reproduces issue #1963: cloneBodyStream throws

--- a/packages/happy-dom/test/fetch/Response.test.ts
+++ b/packages/happy-dom/test/fetch/Response.test.ts
@@ -489,6 +489,47 @@ describe('Response', () => {
 		});
 	});
 
+	describe('body', () => {
+		it('Does not create a ReadableStream eagerly when constructed with a string body.', () => {
+			const response = new window.Response('Hello World');
+			// The internal body stream should not be created until the getter is accessed.
+			expect(response[PropertySymbol.body]).toBe(null);
+		});
+
+		it('Creates a ReadableStream lazily when the body getter is accessed.', async () => {
+			const response = new window.Response('Hello World');
+			expect(response[PropertySymbol.body]).toBe(null);
+
+			const body = response.body;
+			expect(body).toBeInstanceOf(ReadableStream);
+			expect(response[PropertySymbol.body]).toBe(body);
+		});
+
+		it('Does not create a ReadableStream when consuming body via text() without accessing body getter.', async () => {
+			const response = new window.Response('Hello World');
+			const text = await response.text();
+			expect(text).toBe('Hello World');
+			// body stream should not have been created since text() reads from buffer directly.
+			expect(response[PropertySymbol.body]).toBe(null);
+		});
+
+		it('Does not create a ReadableStream when consuming body via json() without accessing body getter.', async () => {
+			const response = new window.Response(JSON.stringify({ key: 'value' }), {
+				headers: { 'Content-Type': 'application/json' }
+			});
+			const json = await response.json();
+			expect(json).toEqual({ key: 'value' });
+			expect(response[PropertySymbol.body]).toBe(null);
+		});
+
+		it('Does not create a ReadableStream when consuming body via arrayBuffer() without accessing body getter.', async () => {
+			const response = new window.Response('Hello World');
+			const buffer = await response.arrayBuffer();
+			expect(Buffer.from(buffer).toString()).toBe('Hello World');
+			expect(response[PropertySymbol.body]).toBe(null);
+		});
+	});
+
 	describe('clone()', () => {
 		it('Returns a clone.', async () => {
 			const response = new window.Response('Hello World', {
@@ -522,6 +563,18 @@ describe('Response', () => {
 			expect(clone.status).toBe(404);
 			expect(clone.statusText).toBe('Not Found');
 			expect(clone.headers.get('Content-Type')).toBe('text/plain');
+		});
+
+		it('Can consume body from both original and clone without accessing body getter beforehand.', async () => {
+			const response = new window.Response('Hello World');
+
+			// Clone without accessing the body getter - should not create a ReadableStream.
+			const clone = response.clone();
+			expect(response[PropertySymbol.body]).toBe(null);
+
+			// Both original and clone should be independently consumable.
+			expect(await response.text()).toBe('Hello World');
+			expect(await clone.text()).toBe('Hello World');
 		});
 
 		it('Can clone Response with empty string as body.', async () => {


### PR DESCRIPTION
## Problem

When constructing a `Request` or `Response` with a body that can be synchronously buffered (e.g. `string`, `Buffer`, `Blob`, `ArrayBuffer`, `URLSearchParams`), `getBodyStream()` eagerly creates a `ReadableStream` via `toReadableStream()` even though the buffer is already available.

Methods like `text()`, `json()`, `arrayBuffer()`, and `blob()` check for the internal buffer first and skip stream consumption entirely when a buffer exists. This means the eagerly created `ReadableStream` is never read — it is constructed and then abandoned.

Node.js `ReadableStream` internally uses microtask-based state transitions, so abandoned streams leave unresolved promises. Vitest 4.1's `--detect-async-leaks` flag detects these as `PROMISE leaking`.

## Solution

- **`FetchBodyUtility.getBodyStream()`**: Return `stream: null` when a `buffer` is already available (6 call sites).
- **`Response`**: Change `body` from a `public readonly` field to a getter backed by `[PropertySymbol.body]`. The getter lazily creates a `ReadableStream` from the buffer on first access, matching the pattern already used by `Request`.
- **`Request`**: Add the same lazy creation logic to the existing `body` getter.
- **`Request` constructor**: Replace `this.body` getter access with direct internal field checks (`[PropertySymbol.body]` / `[PropertySymbol.bodyBuffer]`) for `contentLength` determination, avoiding unnecessary stream creation.
- **`FetchRequestValidationUtility.validateBody()`**: Use internal fields instead of the `body` getter to validate GET/HEAD requests, preventing lazy getter side effects.
- **`FetchBodyUtility.cloneBodyStream()`**: Move the buffer check before the `body === null` check so that cloning a buffered body does not trigger the lazy getter. Also simplify the Request/Response branching — both now use `[PropertySymbol.body]`, so the conditional is no longer needed.

## Verification

Reproduction project using Vitest 4.1 with `--detect-async-leaks`:

```ts
// Before: PROMISE leaking
const response = new Response(JSON.stringify({ hello: 'world' }), {
  headers: { 'Content-Type': 'application/json' },
});
const data = await response.json();
```

| | Before | After |
|---|---|---|
| PROMISE leaks | 1 | **0** |
| Timeout leaks | 2 | 2 (unrelated, see below) |

All existing tests pass (341 tests in `test/fetch/`), plus 9 new tests verifying lazy body stream behavior:

- Stream is not created eagerly on construction
- Stream is created lazily on first `body` getter access
- `text()` / `json()` / `arrayBuffer()` consume the buffer without creating a stream
- `clone()` works correctly without triggering the lazy getter
- `body` returns `null` when no body is set

## Out of scope

The `Timeout leaking` reports in #2099 are caused by a different mechanism (environment teardown ordering with `asyncTaskManager`) and will need a separate fix.

Related: #2099
