### PR TITLE
fix: Fix flaky cache revalidation tests caused by sub-millisecond max-age

### DIFF
--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -3734,7 +3734,7 @@ describe('Fetch', () => {
 										'content-length',
 										String(responseText.length),
 										'cache-control',
-										'max-age=0.0001',
+										'max-age=0.1',
 										'last-modified',
 										'Mon, 11 Dec 2023 01:00:00 GMT'
 									];
@@ -3755,7 +3755,7 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			await new Promise((resolve) => setTimeout(resolve, 300));
 
 			const response2 = await window.fetch(url);
 			const text2 = await response2.text();
@@ -3779,7 +3779,7 @@ describe('Fetch', () => {
 			expect(headers1).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
-				'cache-control': `max-age=0.0001`,
+				'cache-control': `max-age=0.1`,
 				'last-modified': 'Mon, 11 Dec 2023 01:00:00 GMT'
 			});
 
@@ -3893,7 +3893,7 @@ describe('Fetch', () => {
 										'content-length',
 										String(responseText1.length),
 										'cache-control',
-										'max-age=0.0001',
+										'max-age=0.1',
 										'last-modified',
 										'Mon, 11 Dec 2023 01:00:00 GMT'
 									];
@@ -3914,7 +3914,7 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			await new Promise((resolve) => setTimeout(resolve, 300));
 
 			const response2 = await window.fetch(url);
 			const text2 = await response2.text();
@@ -3946,7 +3946,7 @@ describe('Fetch', () => {
 			expect(headers1).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText1.length),
-				'cache-control': `max-age=0.0001`,
+				'cache-control': `max-age=0.1`,
 				'last-modified': 'Mon, 11 Dec 2023 01:00:00 GMT'
 			});
 
@@ -4061,7 +4061,7 @@ describe('Fetch', () => {
 										'content-length',
 										String(responseText.length),
 										'cache-control',
-										'max-age=0.0001',
+										'max-age=0.1',
 										'last-modified',
 										'Mon, 11 Dec 2023 01:00:00 GMT',
 										'etag',
@@ -4085,7 +4085,7 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			await new Promise((resolve) => setTimeout(resolve, 300));
 
 			const response2 = await window.fetch(url, {
 				method: 'HEAD'
@@ -4111,7 +4111,7 @@ describe('Fetch', () => {
 			expect(headers1).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
-				'cache-control': `max-age=0.0001`,
+				'cache-control': `max-age=0.1`,
 				'last-modified': 'Mon, 11 Dec 2023 01:00:00 GMT',
 				etag: etag1
 			});
@@ -4125,7 +4125,7 @@ describe('Fetch', () => {
 			expect(headers2).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
-				'cache-control': `max-age=0.0001`,
+				'cache-control': `max-age=0.1`,
 				'Last-Modified': 'Mon, 11 Dec 2023 02:00:00 GMT',
 				ETag: etag2
 			});
@@ -4231,7 +4231,7 @@ describe('Fetch', () => {
 										'content-length',
 										String(responseText1.length),
 										'cache-control',
-										'max-age=0.0001',
+										'max-age=0.1',
 										'last-modified',
 										'Mon, 11 Dec 2023 01:00:00 GMT',
 										'etag',
@@ -4254,7 +4254,7 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			await new Promise((resolve) => setTimeout(resolve, 300));
 
 			const response2 = await window.fetch(url);
 			const text2 = await response2.text();
@@ -4278,7 +4278,7 @@ describe('Fetch', () => {
 			expect(headers1).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText1.length),
-				'cache-control': `max-age=0.0001`,
+				'cache-control': `max-age=0.1`,
 				'last-modified': 'Mon, 11 Dec 2023 01:00:00 GMT',
 				etag: etag1
 			});


### PR DESCRIPTION
## Problem

The cache revalidation tests in `Fetch.test.ts` intermittently fail on CI because they use `max-age=0.0001` (0.1 milliseconds) for cache expiry.

In `ResponseCache.ts`, the cache entry's expiry is calculated as:

```ts
cachedResponse.expires = Date.now() + parseFloat(value) * 1000;
// With max-age=0.0001: expires = Date.now() + 0.1
```

Later in the same `add()` method, the entry is validated:

```ts
if (!cachedResponse.etag && (!cachedResponse.expires || cachedResponse.expires < Date.now())) {
    entries.splice(index, 1);  // Entry removed immediately!
    return null;
}
```

Since `Date.now()` has millisecond precision, if even 1ms passes between the expiry calculation and this validation check, the entry is considered expired and **removed during insertion**. The second fetch then makes a fresh request instead of a cache revalidation, returning the original response headers instead of the 304 revalidation headers.

## Solution

- Change `max-age=0.0001` (0.1ms) to `max-age=0.1` (100ms) — large enough to survive the cache insertion, small enough to expire within the test's wait period
- Increase the wait from 100ms to 300ms — ensures the cache has reliably expired before the second fetch (200ms margin over the 100ms max-age)

Affected tests (4 test cases, 9 value sites + 4 wait sites):

- `Revalidates cache with a "If-Modified-Since" request for a GET response with "Cache-Control" set to a "max-age".`
- `Updates cache after a failed revalidation with a "If-Modified-Since" request for a GET response with "Cache-Control" set to a "max-age".`
- `Revalidates cache with a "If-None-Match" request for a HEAD response with an "Etag" header.`
- `Updates cache after a failed revalidation with a "If-None-Match" request for a GET response with an "Etag" header.`

## Verification

All 103 Fetch tests pass. The same test that was failing on CI in #1910 and #2114 now has sufficient timing margin to pass reliably.
