### PR TITLE
feat(file): add webkitRelativePath property to File class

### DIFF
--- a/packages/happy-dom/src/file/File.ts
+++ b/packages/happy-dom/src/file/File.ts
@@ -11,6 +11,7 @@ import type { Buffer } from 'buffer';
 export default class File extends Blob {
 	public readonly lastModified: number;
 	public readonly name: string;
+	public readonly webkitRelativePath: string = '';
 
 	/**
 	 * Constructor.

--- a/packages/happy-dom/test/file/File.test.ts
+++ b/packages/happy-dom/test/file/File.test.ts
@@ -27,4 +27,11 @@ describe('File', () => {
 			expect(file.lastModified).toBe(NOW);
 		});
 	});
+
+	describe('get webkitRelativePath()', () => {
+		it('Returns an empty string by default.', () => {
+			const file = new File(['TEST'], 'filename.jpg');
+			expect(file.webkitRelativePath).toBe('');
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Adds the missing `webkitRelativePath` property to the `File` class as required by the W3C File API specification.

## Problem
The `File` class in Happy-DOM was missing the `webkitRelativePath` property, which should be present and default to an empty string according to the [W3C File API specification](https://w3c.github.io/FileAPI/#dfn-webkitrelativepath).

This property is commonly used when working with file uploads, particularly when handling directory uploads where browsers need to preserve relative paths within the directory structure.

## Solution
- Added `readonly webkitRelativePath: string = ''` property to the `File` class
- Added a test case to verify the property returns an empty string by default
- Follows the W3C specification requirement that this property should default to an empty string

## Changes
- **File.ts**: Added the `webkitRelativePath` property with empty string default
- **File.test.ts**: Added test case to verify correct default behavior

## Testing
- Added unit test that verifies `webkitRelativePath` returns an empty string by default
- The fix is minimal and follows the exact specification requirements

## W3C Specification Reference
According to the [W3C File API specification](https://w3c.github.io/FileAPI/#dfn-webkitrelativepath):
> The webkitRelativePath attribute must return the value it was initialized to. Initially, this is the empty string.

Fixes #2093