### PR TITLE
feat: [#2123] Add missing 'translate' property to `HTMLElement`

### DIFF
--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -944,6 +944,45 @@ export default class HTMLElement extends Element {
 	}
 
 	/**
+	 * Returns translate.
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute
+	 * @returns Translate.
+	 */
+	public get translate(): boolean {
+		const translateAttr = this.getAttribute('translate');
+
+		if (translateAttr !== null) {
+			const translateAttrLower = translateAttr.toLowerCase();
+
+			if (translateAttrLower === '' || translateAttrLower === 'yes') {
+				return true;
+			}
+
+			if (translateAttrLower === 'no') {
+				return false;
+			}
+		}
+
+		// Inherit state: missing value default, invalid value default
+		if (this === this.ownerDocument.documentElement) {
+			return true;
+		}
+
+		return this.parentElement ? this.parentElement.translate : false;
+	}
+
+	/**
+	 * Sets translate.
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute
+	 * @param value Value.
+	 */
+	public set translate(value: boolean) {
+		this.setAttribute('translate', value ? 'yes' : 'no');
+	}
+
+	/**
 	 * Triggers a click event.
 	 */
 	public click(): void {

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -2,6 +2,7 @@ import EventTarget from '../../event/EventTarget.js';
 import * as PropertySymbol from '../../PropertySymbol.js';
 import type Document from '../document/Document.js';
 import type Element from '../element/Element.js';
+import type HTMLElement from '../html-element/HTMLElement.js';
 import NodeTypeEnum from './NodeTypeEnum.js';
 import NodeDocumentPositionEnum from './NodeDocumentPositionEnum.js';
 import NodeUtility from './NodeUtility.js';
@@ -292,16 +293,16 @@ export default class Node extends EventTarget {
 	}
 
 	/**
-	 * Returns parent element.
+	 * Returns parent HTMLElement.
 	 *
-	 * @returns Element.
+	 * @returns HTMLElement.
 	 */
-	public get parentElement(): Element | null {
+	public get parentElement(): HTMLElement | null {
 		let parent = this[PropertySymbol.parentNode];
 		while (parent && parent[PropertySymbol.nodeType] !== NodeTypeEnum.elementNode) {
 			parent = parent[PropertySymbol.parentNode];
 		}
-		return <Element>parent;
+		return <HTMLElement>parent;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -616,6 +616,153 @@ describe('HTMLElement', () => {
 		});
 	});
 
+	describe('get translate()', () => {
+		it('Returns true when the attribute "translate" is set to "yes".', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'yes');
+			expect(element.translate).toBe(true);
+		});
+
+		it('Returns true when the attribute "translate" is set to "YES" (case-insensitive).', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'YES');
+			expect(element.translate).toBe(true);
+		});
+
+		it('Returns true when the attribute "translate" is set to empty string.', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', '');
+			expect(element.translate).toBe(true);
+		});
+
+		it('Returns false when the attribute "translate" is set to "no".', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'no');
+			expect(element.translate).toBe(false);
+		});
+
+		it('Returns false when the attribute "translate" is set to "NO" (case-insensitive).', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'NO');
+			expect(element.translate).toBe(false);
+		});
+
+		it('Returns true for document element when the attribute "translate" is missing.', () => {
+			expect(document.documentElement.translate).toBe(true);
+		});
+
+		it('Returns false for document element when the attribute "translate" is set to "no".', () => {
+			document.documentElement.translate = false;
+			expect(document.documentElement.translate).toBe(false);
+			document.documentElement.removeAttribute('translate');
+		});
+
+		it('Returns true when the attribute "translate" is missing and parent translate is true.', () => {
+			const parent = document.createElement('div');
+			parent.setAttribute('translate', 'yes');
+			const child = document.createElement('div');
+			parent.appendChild(child);
+			document.body.appendChild(parent);
+			expect(child.translate).toBe(true);
+			parent.remove();
+		});
+
+		it('Returns false when the attribute "translate" is missing and parent translate is false.', () => {
+			const parent = document.createElement('div');
+			parent.setAttribute('translate', 'no');
+			const child = document.createElement('div');
+			parent.appendChild(child);
+			document.body.appendChild(parent);
+			expect(child.translate).toBe(false);
+			parent.remove();
+		});
+
+		it('Returns false when the attribute "translate" is missing and parent translate is inherited as false.', () => {
+			const grandparent = document.createElement('div');
+			grandparent.setAttribute('translate', 'no');
+			const parent = document.createElement('div');
+			const child = document.createElement('div');
+			grandparent.appendChild(parent);
+			parent.appendChild(child);
+			document.body.appendChild(grandparent);
+			expect(child.translate).toBe(false);
+			grandparent.remove();
+		});
+
+		it('Returns false when the attribute "translate" is missing and the element has no parent.', () => {
+			const element = document.createElement('div');
+			expect(element.translate).toBe(false);
+		});
+
+		it('Returns false when the attribute "translate" is set to an invalid value and the element has no parent.', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'invalid');
+			expect(element.translate).toBe(false);
+		});
+
+		it('Returns false when the attribute "translate" is set to "no" and overrides parent translate true.', () => {
+			const parent = document.createElement('div');
+			parent.setAttribute('translate', 'yes');
+			const child = document.createElement('div');
+			child.setAttribute('translate', 'no');
+			parent.appendChild(child);
+			document.body.appendChild(parent);
+			expect(child.translate).toBe(false);
+			parent.remove();
+		});
+
+		it('Returns true when the attribute "translate" is set to "yes" and overrides parent translate false.', () => {
+			const parent = document.createElement('div');
+			parent.setAttribute('translate', 'no');
+			const child = document.createElement('div');
+			child.setAttribute('translate', 'yes');
+			parent.appendChild(child);
+			document.body.appendChild(parent);
+			expect(child.translate).toBe(true);
+			parent.remove();
+		});
+	});
+
+	describe('set translate()', () => {
+		it('Sets the attribute "translate" to "yes" when set to true.', () => {
+			const element = document.createElement('div');
+			element.translate = true;
+			expect(element.getAttribute('translate')).toBe('yes');
+		});
+
+		it('Sets the attribute "translate" to "no" when set to false.', () => {
+			const element = document.createElement('div');
+			element.translate = false;
+			expect(element.getAttribute('translate')).toBe('no');
+		});
+
+		it('Sets the attribute "translate" to "yes" when the existing attribute is "no".', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'no');
+			element.translate = true;
+			expect(element.getAttribute('translate')).toBe('yes');
+		});
+
+		it('Sets the attribute "translate" to "no" when the existing attribute is "yes".', () => {
+			const element = document.createElement('div');
+			element.setAttribute('translate', 'yes');
+			element.translate = false;
+			expect(element.getAttribute('translate')).toBe('no');
+		});
+
+		it('Returns true from get translate() after setting to true.', () => {
+			const element = document.createElement('div');
+			element.translate = true;
+			expect(element.translate).toBe(true);
+		});
+
+		it('Returns false from get translate() after setting to false.', () => {
+			const element = document.createElement('div');
+			element.translate = false;
+			expect(element.translate).toBe(false);
+		});
+	});
+
 	for (const property of ['lang', 'title']) {
 		describe(`get ${property}`, () => {
 			it(`Returns the attribute "${property}".`, () => {


### PR DESCRIPTION
close: #2123

**Changes:**
* **HTMLElement**: Added `get translate()` and `set translate(value: boolean)`.
    * The getter correctly handles the "missing value default" and "invalid value default" by inheriting the state from the parent element.
    * If the element is the root (`documentElement`), it defaults to `true`.
    * The setter maps `true` to `"yes"` and `false` to `"no"`.
* **Node**: Updated the `parentElement` getter type hint to return `HTMLElement` instead of `Element`. 
    * **Note**: This change also improves compliance with the standard TypeScript `lib.dom.d.ts`, where `parentElement` is natively defined as `HTMLElement | null`.

**Related:**
- https://html.spec.whatwg.org/multipage/dom.html#the-translate-attribute
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/translate
