### PR TITLE
fix: [#2089] Make removeEventListener respect the capture parameter

### DIFF
--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -77,34 +77,32 @@ export default class EventTarget {
 
 		if (options.signal && !options.signal.aborted) {
 			options.signal.addEventListener('abort', () => {
-				this.removeEventListener(type, listener);
+				this.removeEventListener(type, listener, options);
 			});
 		}
 	}
 
 	/**
-	 * Adds an event listener.
+	 * Removes an event listener.
 	 *
 	 * @param type Event type.
 	 * @param listener Listener.
+	 * @param options An object that specifies characteristics about the event listener, or a boolean indicating capture.
 	 */
-	public removeEventListener(type: string, listener: TEventListener): void {
-		const bubblingListeners = this[PropertySymbol.listeners].bubbling.get(type);
-		if (bubblingListeners) {
-			const index = bubblingListeners.indexOf(listener);
-			if (index !== -1) {
-				bubblingListeners.splice(index, 1);
-				this[PropertySymbol.listenerOptions].bubbling.get(type)!.splice(index, 1);
-				return;
-			}
-		}
+	public removeEventListener(
+		type: string,
+		listener: TEventListener,
+		options?: boolean | IEventListenerOptions
+	): void {
+		options = typeof options === 'boolean' ? { capture: options } : options || {};
+		const eventPhase = options.capture ? 'capturing' : 'bubbling';
 
-		const capturingListeners = this[PropertySymbol.listeners].capturing.get(type);
-		if (capturingListeners) {
-			const index = capturingListeners.indexOf(listener);
+		const listeners = this[PropertySymbol.listeners][eventPhase].get(type);
+		if (listeners) {
+			const index = listeners.indexOf(listener);
 			if (index !== -1) {
-				capturingListeners.splice(index, 1);
-				this[PropertySymbol.listenerOptions].capturing.get(type)!.splice(index, 1);
+				listeners.splice(index, 1);
+				this[PropertySymbol.listenerOptions][eventPhase].get(type)!.splice(index, 1);
 			}
 		}
 	}
@@ -313,7 +311,7 @@ export default class EventTarget {
 					// The value corresponding to the cloned array is not deleted. So we need to delete the value in the cloned array.
 					listeners.splice(i, 1);
 					listenerOptions.splice(i, 1);
-					this.removeEventListener(event.type, listener);
+					this.removeEventListener(event.type, listener, options);
 					i--;
 					max--;
 				}

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1715,7 +1715,7 @@ export default class Document extends Node {
 			const listeners = this[PropertySymbol.listeners].capturing.get(eventType);
 			if (listeners) {
 				for (const listener of listeners) {
-					this.removeEventListener(eventType, listener);
+					this.removeEventListener(eventType, listener, { capture: true });
 				}
 			}
 		}

--- a/packages/happy-dom/test/event/EventTarget.test.ts
+++ b/packages/happy-dom/test/event/EventTarget.test.ts
@@ -47,6 +47,37 @@ describe('EventTarget', () => {
 			expect(count).toBe(1);
 		});
 
+		it('Once auto-removal does not remove a listener in the other phase.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			eventTarget.addEventListener(EVENT_TYPE, listener, {});
+			eventTarget.addEventListener(EVENT_TYPE, listener, { capture: true, once: true });
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(2);
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(3);
+		});
+
+		it('Signal abort removes listener from the correct phase only.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			const controller = new window.AbortController();
+			eventTarget.addEventListener(EVENT_TYPE, listener, {});
+			eventTarget.addEventListener(EVENT_TYPE, listener, {
+				capture: true,
+				signal: controller.signal
+			});
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(2);
+			controller.abort();
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(3);
+		});
+
 		it('Adds an event listener and set options once and bind the same event multiple times', () => {
 			let count = 0;
 			const listener = (): void => {
@@ -156,6 +187,88 @@ describe('EventTarget', () => {
 			eventTarget.removeEventListener(EVENT_TYPE, listener);
 			eventTarget.dispatchEvent(dispatchedEvent);
 			expect(receivedEvent).toBe(null);
+		});
+
+		it('Does not remove a capture listener when removeEventListener is called without capture.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			eventTarget.addEventListener(EVENT_TYPE, listener, true);
+			eventTarget.removeEventListener(EVENT_TYPE, listener, false);
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(1);
+		});
+
+		it('Does not remove a non-capture listener when removeEventListener is called with capture.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			eventTarget.addEventListener(EVENT_TYPE, listener, false);
+			eventTarget.removeEventListener(EVENT_TYPE, listener, true);
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(1);
+		});
+
+		it('Removes a capture listener when removeEventListener is called with capture.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			eventTarget.addEventListener(EVENT_TYPE, listener, true);
+			eventTarget.removeEventListener(EVENT_TYPE, listener, true);
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(0);
+		});
+
+		it('Accepts options object for the capture parameter.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			eventTarget.addEventListener(EVENT_TYPE, listener, { capture: true });
+			eventTarget.removeEventListener(EVENT_TYPE, listener, { capture: false });
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(1);
+		});
+
+		it('Defaults to non-capture removal when called without third argument.', () => {
+			let count = 0;
+			const listener = (): void => {
+				count++;
+			};
+			eventTarget.addEventListener(EVENT_TYPE, listener, true);
+			eventTarget.removeEventListener(EVENT_TYPE, listener);
+			eventTarget.dispatchEvent(new Event(EVENT_TYPE));
+			expect(count).toBe(1);
+		});
+
+		it('Removes capture listener on a DOM element without affecting the bubbling listener.', () => {
+			const parent = window.document.createElement('div');
+			const child = window.document.createElement('span');
+			parent.appendChild(child);
+			window.document.body.appendChild(parent);
+
+			const calls: string[] = [];
+			const captureListener = (): void => {
+				calls.push('capture');
+			};
+			const bubbleListener = (): void => {
+				calls.push('bubble');
+			};
+
+			parent.addEventListener(EVENT_TYPE, captureListener, true);
+			parent.addEventListener(EVENT_TYPE, bubbleListener, false);
+
+			child.dispatchEvent(new Event(EVENT_TYPE, { bubbles: true }));
+			expect(calls).toEqual(['capture', 'bubble']);
+
+			calls.length = 0;
+			parent.removeEventListener(EVENT_TYPE, captureListener, true);
+
+			child.dispatchEvent(new Event(EVENT_TYPE, { bubbles: true }));
+			expect(calls).toEqual(['bubble']);
 		});
 	});
 

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1125,6 +1125,26 @@ describe('Document', () => {
 				html.replace(/[\s]/gm, '')
 			);
 		});
+
+		it('Removes both capturing and bubbling event listeners.', () => {
+			let captureCount = 0;
+			let bubbleCount = 0;
+			const captureListener = (): void => {
+				captureCount++;
+			};
+			const bubbleListener = (): void => {
+				bubbleCount++;
+			};
+
+			document.addEventListener('click', captureListener, true);
+			document.addEventListener('click', bubbleListener, false);
+
+			document.open();
+
+			document.dispatchEvent(new Event('click'));
+			expect(captureCount).toBe(0);
+			expect(bubbleCount).toBe(0);
+		});
 	});
 
 	describe('close()', () => {


### PR DESCRIPTION
`removeEventListener` was ignoring its third argument, so it couldn't distinguish between capture and non-capture listeners. Calling `removeEventListener('click', cb, false)` would happily remove a listener that was added with `addEventListener('click', cb, true)`, which isn't how the [DOM spec](https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener) works.

The `once` auto-removal and `signal` abort cleanup had the same problem — neither forwarded the capture flag, so they could end up removing the wrong listener if the same callback was registered in both phases.

While fixing this I also noticed `Document.open()` was iterating capturing listeners but calling `removeEventListener` without `{ capture: true }`, so those listeners were silently surviving the clear.

Fixes #2089

### Testing

Added tests for capture-aware removal (boolean and options object), default-to-bubbling behavior, `once`/`signal` phase isolation, DOM element parent-child propagation, and `Document.open()` clearing both phases. All existing tests still pass.