### PR TITLE
fix: [#2088] Handle CSS hex escape sequences in querySelector

### DIFF
--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -9,10 +9,12 @@ import NodeTypeEnum from '../nodes/node/NodeTypeEnum.js';
 /**
  * Selector group RegExp.
  *
+ * Non-capturing match: CSS escape sequences (hex or character), consumed to avoid
+ * misinterpreting the optional trailing space in hex escapes as a descendant combinator.
  * Group 1: Combinator (" ", ",", "+", ">", "̣~")
  * Group 2: Parentheses or brackets.
  */
-const SELECTOR_GROUP_REGEXP = /(\s*[\s,+>~]\s*)|([\[\]\(\)"'])/gm;
+const SELECTOR_GROUP_REGEXP = /(?:\\[0-9a-fA-F]{1,6}\s?|\\[^\n])|(\s*[\s,+>~]\s*)|([\[\]\(\)"'])/gm;
 
 /**
  * Selector RegExp.
@@ -42,7 +44,7 @@ const SELECTOR_GROUP_REGEXP = /(\s*[\s,+>~]\s*)|([\[\]\(\)"'])/gm;
  * Group 23: Pseudo element (e.g. "::after", "::-webkit-inner-spin-button").
  */
 const SELECTOR_REGEXP =
-	/(\*)|([a-zA-Z0-9\u00A0-\uFFFF-]+)|#(([a-zA-Z0-9\u00A0-\uFFFF_-]|\\.)+)|\.(([a-zA-Z0-9\u00A0-\uFFFF_-]|\\.)+)|\[(([a-zA-Z0-9-_]|\\.)+)\]|\[(([a-zA-Z0-9-_]|\\.)+)\s*([~|^$*]{0,1})\s*=\s*("([^"]*)"|'([^']*)')\s*(s|i){0,1}\]|\[(([a-zA-Z0-9-_]|\\.)+)\s*([~|^$*]{0,1})\s*=\s*(([a-zA-Z0-9\u00A0-\uFFFF_¤£-]|\\.)+)\]|:([a-zA-Z-]+)\s*\(.+\)|:([a-zA-Z-]+)|::([a-zA-Z-]+)/gm;
+	/(\*)|([a-zA-Z0-9\u00A0-\uFFFF-]+)|#(([a-zA-Z0-9\u00A0-\uFFFF_-]|\\[0-9a-fA-F]{1,6}\s?|\\.)+)|\.(([a-zA-Z0-9\u00A0-\uFFFF_-]|\\[0-9a-fA-F]{1,6}\s?|\\.)+)|\[(([a-zA-Z0-9-_]|\\[0-9a-fA-F]{1,6}\s?|\\.)+)\]|\[(([a-zA-Z0-9-_]|\\[0-9a-fA-F]{1,6}\s?|\\.)+)\s*([~|^$*]{0,1})\s*=\s*("([^"]*)"|'([^']*)')\s*(s|i){0,1}\]|\[(([a-zA-Z0-9-_]|\\[0-9a-fA-F]{1,6}\s?|\\.)+)\s*([~|^$*]{0,1})\s*=\s*(([a-zA-Z0-9\u00A0-\uFFFF_¤£-]|\\[0-9a-fA-F]{1,6}\s?|\\.)+)\]|:([a-zA-Z-]+)\s*\(.+\)|:([a-zA-Z-]+)|::([a-zA-Z-]+)/gm;
 
 /**
  * Selector pseudo RegExp.
@@ -51,11 +53,6 @@ const SELECTOR_REGEXP =
  * Group 2: Parentheses or brackets.
  */
 const SELECTOR_PSEUDO_REGEXP = /:([a-zA-Z-]+)|([()])/gm;
-
-/**
- * Escaped Character RegExp.
- */
-const ESCAPED_CHARACTER_REGEXP = /\\/g;
 
 /**
  * CSS Escape RegExp.
@@ -336,18 +333,18 @@ export default class SelectorParser {
 			} else if (match[3]) {
 				// Matches ID, e.g. "#id"
 
-				selectorItem.id = match[3].replace(ESCAPED_CHARACTER_REGEXP, '');
+				selectorItem.id = SelectorParser.cssUnescape(match[3]);
 			} else if (match[5]) {
 				// Matches class names, e.g. ".class1"
 
 				selectorItem.classNames = selectorItem.classNames || [];
-				selectorItem.classNames.push(match[5].replace(ESCAPED_CHARACTER_REGEXP, ''));
+				selectorItem.classNames.push(SelectorParser.cssUnescape(match[5]));
 			} else if (match[7]) {
 				// Matches attributes without value, e.g. [attr]
 
 				selectorItem.attributes = selectorItem.attributes || [];
 				selectorItem.attributes.push({
-					name: match[7].replace(ESCAPED_CHARACTER_REGEXP, ''),
+					name: SelectorParser.cssUnescape(match[7]),
 					operator: null,
 					value: null,
 					modifier: null,
@@ -360,7 +357,7 @@ export default class SelectorParser {
 				const unescapedValue = SelectorParser.cssUnescape(value);
 				selectorItem.attributes = selectorItem.attributes || [];
 				selectorItem.attributes.push({
-					name: match[9].replace(ESCAPED_CHARACTER_REGEXP, ''),
+					name: SelectorParser.cssUnescape(match[9]),
 					operator: match[11] || null,
 					value: unescapedValue,
 					modifier: <'s'>match[15] || null,
@@ -376,7 +373,7 @@ export default class SelectorParser {
 				const unescapedValue = SelectorParser.cssUnescape(match[19]);
 				selectorItem.attributes = selectorItem.attributes || [];
 				selectorItem.attributes.push({
-					name: match[16].replace(ESCAPED_CHARACTER_REGEXP, ''),
+					name: SelectorParser.cssUnescape(match[16]),
 					operator: match[18] || null,
 					value: unescapedValue,
 					modifier: null,

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -1777,6 +1777,38 @@ describe('QuerySelector', () => {
 			expect(div.querySelector('#\\:id\\:') === div2).toBe(true);
 		});
 
+		it('Returns an element by ID when using CSS.escape() on an ID starting with a digit.', () => {
+			const container = document.createElement('div');
+			const child = document.createElement('span');
+			const id = '97e356d3-601d-42ca-9c13-3446228274ac';
+			child.id = id;
+			container.appendChild(child);
+
+			const result = container.querySelector(`#${window.CSS.escape(id)}`);
+			expect(result === child).toBe(true);
+		});
+
+		it('Returns an element by ID with a hex escape sequence in the selector.', () => {
+			const container = document.createElement('div');
+			const child = document.createElement('span');
+			child.id = '0abc';
+			container.appendChild(child);
+
+			// CSS.escape('0abc') produces '\\30 abc'
+			const result = container.querySelector('#\\30 abc');
+			expect(result === child).toBe(true);
+		});
+
+		it('Returns an element by class name with a hex escape sequence in the selector.', () => {
+			const container = document.createElement('div');
+			const child = document.createElement('span');
+			child.className = '0abc';
+			container.appendChild(child);
+
+			const result = container.querySelector('.\\30 abc');
+			expect(result === child).toBe(true);
+		});
+
 		it('Does not find input with selector of input:not([list])[type="search"]', () => {
 			const div = document.createElement('div');
 			const input = document.createElement('input');


### PR DESCRIPTION
querySelector and querySelectorAll throw a SyntaxError (or silently return null) when the selector contains CSS hex escape sequences like `#\39 7e356d3-...`, which is what `CSS.escape()` produces for IDs starting with a digit.

The root cause was in SelectorParser:

1. `SELECTOR_GROUP_REGEXP` wasn't escape-aware — it saw the trailing space in `\39 ` as a descendant combinator and split the selector in half.
2. `SELECTOR_REGEXP`'s ID/class/attribute patterns only handled single-character escapes (`\.`), not hex escapes (`\39 `), so they couldn't consume the full escaped identifier.
3. IDs, classes, and attribute names were "unescaped" by just stripping backslashes (`/\\/g`), which turned `\39 7e...` into `397e...` instead of decoding `\39` as the character `9`. The `cssUnescape()` method that handles this correctly already existed — it just wasn't being used for these cases.

### Changes

- Added a non-capturing escape sequence alternative to `SELECTOR_GROUP_REGEXP` so hex/character escapes are consumed before their trailing space can be misread as a combinator
- Updated `SELECTOR_REGEXP` to match hex escapes (`\\[0-9a-fA-F]{1,6}\s?`) in ID, class, attribute name, and unquoted attribute value patterns
- Switched ID/class/attribute name handling from the naive backslash strip to `cssUnescape()`
- Removed the now-unused `ESCAPED_CHARACTER_REGEXP`

### Testing

- Added tests for `CSS.escape()` with a UUID ID, hex escapes in ID selectors, and hex escapes in class selectors
- All existing querySelector tests still pass

Fixes #2088