### PR TITLE
fix: [#2096] Add instance-level readyState enums to XMLHttpRequest

### DIFF
--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
@@ -34,12 +34,19 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	// Injected by WindowContextClassExtender
 	protected declare [PropertySymbol.window]: BrowserWindow;
 
-	// Constants
+	// Static constants
 	public static UNSENT = XMLHttpRequestReadyStateEnum.unsent;
 	public static OPENED = XMLHttpRequestReadyStateEnum.opened;
 	public static HEADERS_RECEIVED = XMLHttpRequestReadyStateEnum.headersReceived;
 	public static LOADING = XMLHttpRequestReadyStateEnum.loading;
 	public static DONE = XMLHttpRequestReadyStateEnum.done;
+
+	// Instance-level constants (mirrors of the static ones, per the XMLHttpRequest spec)
+	public readonly UNSENT = XMLHttpRequestReadyStateEnum.unsent;
+	public readonly OPENED = XMLHttpRequestReadyStateEnum.opened;
+	public readonly HEADERS_RECEIVED = XMLHttpRequestReadyStateEnum.headersReceived;
+	public readonly LOADING = XMLHttpRequestReadyStateEnum.loading;
+	public readonly DONE = XMLHttpRequestReadyStateEnum.done;
 
 	// Public properties
 	public upload: XMLHttpRequestUpload = new this[PropertySymbol.window].XMLHttpRequestUpload();

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -63,6 +63,25 @@ describe('XMLHttpRequest', () => {
 		vi.restoreAllMocks();
 	});
 
+	describe('readyState constants', () => {
+		it('Exposes readyState enums as instance properties.', () => {
+			expect(request.UNSENT).toBe(0);
+			expect(request.OPENED).toBe(1);
+			expect(request.HEADERS_RECEIVED).toBe(2);
+			expect(request.LOADING).toBe(3);
+			expect(request.DONE).toBe(4);
+		});
+
+		it('Instance constants match the static constants.', () => {
+			const XMLHttpRequest = window.XMLHttpRequest;
+			expect(request.UNSENT).toBe(XMLHttpRequest.UNSENT);
+			expect(request.OPENED).toBe(XMLHttpRequest.OPENED);
+			expect(request.HEADERS_RECEIVED).toBe(XMLHttpRequest.HEADERS_RECEIVED);
+			expect(request.LOADING).toBe(XMLHttpRequest.LOADING);
+			expect(request.DONE).toBe(XMLHttpRequest.DONE);
+		});
+	});
+
 	describe('get status()', () => {
 		it('Returns status for synchronous requests.', () => {
 			vi.spyOn(SyncFetch.prototype, 'send').mockImplementation(


### PR DESCRIPTION
XMLHttpRequest only defined `UNSENT`, `OPENED`, `HEADERS_RECEIVED`, `LOADING`, and `DONE` as static properties. In browsers these are also available on instances (they sit on the prototype), so `xhr.DONE === 4` works. In happy-dom it returned `undefined`, which silently breaks the common pattern `xhr.readyState === xhr.DONE`.

Added readonly instance properties that mirror the static ones.

Fixes #2096

### Testing

Added tests verifying the instance properties return the correct values and match their static counterparts. All existing XMLHttpRequest tests still pass.