### PR TITLE
fix: [#2112] Add missing destination property to Request

### DIFF
--- a/packages/happy-dom/src/fetch/Request.ts
+++ b/packages/happy-dom/src/fetch/Request.ts
@@ -191,6 +191,16 @@ export default class Request implements Request {
 	}
 
 	/**
+	 * Returns destination.
+	 *
+	 * @see https://fetch.spec.whatwg.org/#concept-request-destination
+	 * @returns Destination.
+	 */
+	public get destination(): '' {
+		return '';
+	}
+
+	/**
 	 * Returns mode.
 	 *
 	 * @returns Mode.

--- a/packages/happy-dom/test/fetch/Request.test.ts
+++ b/packages/happy-dom/test/fetch/Request.test.ts
@@ -54,6 +54,7 @@ describe('Request', () => {
 			expect(request.credentials).toBe('same-origin');
 			expect(request.referrer).toBe('about:client');
 			expect(request.mode).toBe('cors');
+			expect(request.destination).toBe('');
 		});
 
 		it('Supports URL as string from Request object.', () => {


### PR DESCRIPTION
`request.destination` was returning `undefined` because the property wasn't implemented. Per the [fetch spec](https://fetch.spec.whatwg.org/#concept-request-destination), the destination is always `""` for requests created via the `Request` constructor or `fetch()` — the browser only sets it to something meaningful internally for resource loads (scripts, images, stylesheets, etc.).

Added a read-only getter that returns `""`.

Fixes #2112

### Testing

Added a check for `destination` in the existing default properties test. All existing Request tests still pass.