### PR TITLE
fix: [#2151] Make Attr.nodeValue return the attribute value

### DIFF
--- a/packages/happy-dom/src/nodes/attr/Attr.ts
+++ b/packages/happy-dom/src/nodes/attr/Attr.ts
@@ -93,6 +93,20 @@ export default class Attr extends Node implements Attr {
 	}
 
 	/**
+	 * @override
+	 */
+	public override get nodeValue(): string | null {
+		return this[PropertySymbol.value];
+	}
+
+	/**
+	 * @override
+	 */
+	public override set nodeValue(value: string | null) {
+		this[PropertySymbol.value] = value === null ? '' : String(value);
+	}
+
+	/**
 	 * Returns namespace URI.
 	 *
 	 * @returns Namespace URI.

--- a/packages/happy-dom/test/nodes/attr/Attr.test.ts
+++ b/packages/happy-dom/test/nodes/attr/Attr.test.ts
@@ -60,6 +60,36 @@ describe('Attr', () => {
 		});
 	});
 
+	describe('get nodeValue()', () => {
+		it('Returns the attribute value.', () => {
+			const attr = document.createAttribute('test');
+			attr[PropertySymbol.value] = 'value';
+			expect(attr.nodeValue).toBe('value');
+		});
+
+		it('Returns an empty string when set to an empty string.', () => {
+			const attr = document.createAttribute('test');
+			attr[PropertySymbol.value] = '';
+			expect(attr.nodeValue).toBe('');
+		});
+	});
+
+	describe('set nodeValue()', () => {
+		it('Sets the attribute value.', () => {
+			const attr = document.createAttribute('test');
+			attr.nodeValue = 'value';
+			expect(attr.value).toBe('value');
+			expect(attr[PropertySymbol.value]).toBe('value');
+		});
+
+		it('Treats null as an empty string.', () => {
+			const attr = document.createAttribute('test');
+			attr[PropertySymbol.value] = 'value';
+			(<{ nodeValue: string | null }>(<unknown>attr)).nodeValue = null;
+			expect(attr.value).toBe('');
+		});
+	});
+
 	describe('get specified()', () => {
 		it('Returns specified.', () => {
 			const attr = document.createAttribute('test');


### PR DESCRIPTION
Fixes #2151

## Summary

- `Attr.nodeValue` was inheriting `Node`'s default getter and always returned `null`, contradicting the [DOM spec](https://dom.spec.whatwg.org/#dom-node-nodevalue) which defines it as the attribute's value.
- This also broke interop with libraries that rely on `nodeValue` for attribute nodes (e.g. [wgxpath](https://github.com/google/wgxpath)).
- Override `nodeValue` on `Attr` to return `[PropertySymbol.value]`, and have the setter coerce `null` to an empty string per spec.

## Test plan

- [x] `vitest run test/nodes/attr/Attr.test.ts` — added cases for `get nodeValue()`, `set nodeValue()`, and `null` handling.
- [x] `vitest run test/nodes/` — all 4024 existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)