### PR TITLE
fix: treat '<' followed by non-letter as text in HTML parser

### DIFF
--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -32,7 +32,7 @@ import type Text from '../nodes/text/Text.js';
  * Group 7: End of self closing start tag (e.g. "/>" in "<img/>").
  * Group 8: End of start tag or comment tag (e.g. ">" in "<div>").
  */
-const MARKUP_REGEXP = /<([^\s/!>?]+)|<\/([^\s/!>?]+)\s*>|(<!--)|(-->|--!>)|(<!)|(<\?)|(\/>)|(>)/gm;
+const MARKUP_REGEXP = /<([a-zA-Z][^\s/!>?]*)|<\/([a-zA-Z][^\s/!>?]*)\s*>|(<!--)|(-->|--!>)|(<!)|(<\?)|(\/>)|(>)/gm;
 
 /**
  * Attribute RegExp.

--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -32,7 +32,8 @@ import type Text from '../nodes/text/Text.js';
  * Group 7: End of self closing start tag (e.g. "/>" in "<img/>").
  * Group 8: End of start tag or comment tag (e.g. ">" in "<div>").
  */
-const MARKUP_REGEXP = /<([a-zA-Z][^\s/!>?]*)|<\/([a-zA-Z][^\s/!>?]*)\s*>|(<!--)|(-->|--!>)|(<!)|(<\?)|(\/>)|(>)/gm;
+const MARKUP_REGEXP =
+	/<([a-zA-Z][^\s/!>?]*)|<\/([a-zA-Z][^\s/!>?]*)\s*>|(<!--)|(-->|--!>)|(<!)|(<\?)|(\/>)|(>)/gm;
 
 /**
  * Attribute RegExp.

--- a/packages/happy-dom/test/html-parser/HTMLParser.malformedHTML.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.malformedHTML.test.ts
@@ -266,16 +266,16 @@ describe('HTMLParser - Malformed HTML handling (Issue #1949)', () => {
 		it('Should treat "<" followed by a digit as text, not a tag', () => {
 			const container = window.document.createElement('div');
 			container.innerHTML = '<p>text <3 more</p>';
-			const p = container.childNodes[0] as HTMLElement;
+			const p = <HTMLElement>container.childNodes[0];
 			expect(p.childNodes.length).toBe(1);
 			expect(p.childNodes[0].nodeType).toBe(3);
-			expect((p.childNodes[0] as Text).data).toBe('text <3 more');
+			expect((<Text>p.childNodes[0]).data).toBe('text <3 more');
 		});
 
 		it('Should not create element for "<" followed by a digit', () => {
 			const container = window.document.createElement('div');
 			container.innerHTML = '<p>I love you <3</p>';
-			const p = container.childNodes[0] as HTMLElement;
+			const p = <HTMLElement>container.childNodes[0];
 			expect(p.children.length).toBe(0);
 			expect(p.childNodes.length).toBe(1);
 			expect(p.childNodes[0].nodeType).toBe(3);

--- a/packages/happy-dom/test/html-parser/HTMLParser.malformedHTML.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.malformedHTML.test.ts
@@ -261,4 +261,24 @@ describe('HTMLParser - Malformed HTML handling (Issue #1949)', () => {
 			expect(doc.body.innerHTML).toContain('<caption>Correct parent</caption>');
 		});
 	});
+
+	describe('Less-than sign followed by non-letter (issue #2156)', () => {
+		it('Should treat "<" followed by a digit as text, not a tag', () => {
+			const container = window.document.createElement('div');
+			container.innerHTML = '<p>text <3 more</p>';
+			const p = container.childNodes[0] as HTMLElement;
+			expect(p.childNodes.length).toBe(1);
+			expect(p.childNodes[0].nodeType).toBe(3);
+			expect((p.childNodes[0] as Text).data).toBe('text <3 more');
+		});
+
+		it('Should not create element for "<" followed by a digit', () => {
+			const container = window.document.createElement('div');
+			container.innerHTML = '<p>I love you <3</p>';
+			const p = container.childNodes[0] as HTMLElement;
+			expect(p.children.length).toBe(0);
+			expect(p.childNodes.length).toBe(1);
+			expect(p.childNodes[0].nodeType).toBe(3);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #2156

Per the WHATWG HTML5 tokenization spec, when the parser encounters `<` followed by a character that is not an ASCII alpha, `!`, `/`, or `?`, it should emit `<` as a character token and reconsume the character in the data state. Previously, the `MARKUP_REGEXP` pattern `<([^\s/!>?]+)` would match `<` followed by any non-whitespace character (including digits), incorrectly treating `<3` as an opening tag with name `"3"`.

This fix restricts tag name matching to start with an ASCII letter (`[a-zA-Z]`), which aligns with the HTML5 spec and matches browser behavior.

**Before:**
```js
container.innerHTML = '<p>text <3 more</p>';
// Creates a "<3>" element inside <p>, swallowing subsequent content
```

**After:**
```js
container.innerHTML = '<p>text <3 more</p>';
// Correctly produces a single text node: "text <3 more"
```