### PR TITLE
fix: [#2152] Fix TreeWalker.previousNode() skipping nodes when sibling has FILTER_SKIP children

### DIFF
--- a/packages/happy-dom/src/tree-walker/TreeWalker.ts
+++ b/packages/happy-dom/src/tree-walker/TreeWalker.ts
@@ -133,7 +133,7 @@ export default class TreeWalker {
 			let sibling = node?.previousSibling || null;
 
 			while (sibling !== null) {
-				let node = sibling;
+				node = sibling;
 				let result = this[PropertySymbol.filterNode](node);
 
 				while (result !== NodeFilter.FILTER_REJECT && node[PropertySymbol.nodeArray].length) {

--- a/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
+++ b/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
@@ -284,6 +284,31 @@ describe('TreeWalker', () => {
 				expectedPreviousNode = currentNode;
 			}
 		});
+
+		it('Returns correct previous node when previous sibling has FILTER_SKIP children.', () => {
+			const root = document.createElement('div');
+			root.innerHTML = `
+				<button>Bold</button>
+				<button>Italic</button>
+			`;
+			document.body.appendChild(root);
+
+			const buttons = root.querySelectorAll('button');
+			const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
+				acceptNode: (node: Node) =>
+					(<Element>node).tagName === 'BUTTON'
+						? NodeFilter.FILTER_ACCEPT
+						: NodeFilter.FILTER_SKIP
+			});
+
+			walker.currentNode = <Node>buttons[1];
+
+			const previous = walker.previousNode();
+
+			expect(previous).toBe(buttons[0]);
+
+			document.body.removeChild(root);
+		});
 	});
 
 	describe('parentNode()', () => {

--- a/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
+++ b/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
@@ -296,9 +296,7 @@ describe('TreeWalker', () => {
 			const buttons = root.querySelectorAll('button');
 			const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
 				acceptNode: (node: Node) =>
-					(<Element>node).tagName === 'BUTTON'
-						? NodeFilter.FILTER_ACCEPT
-						: NodeFilter.FILTER_SKIP
+					(<Element>node).tagName === 'BUTTON' ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
 			});
 
 			walker.currentNode = <Node>buttons[1];


### PR DESCRIPTION
Fixes #2152

`previousNode()` used `let node = sibling` inside the inner while loop, shadowing the outer `node` variable. After the loop finished, the outer code called `.parentNode` on the stale outer `node` (still `currentNode`) instead of on the deepest node visited in the sibling subtree.

Per the WHATWG spec the algorithm uses a single `node` variable throughout — removing `let` fixes the shadowing and matches the spec behavior.

**Example** (from the issue):

```js
const root = document.createElement('div');
root.innerHTML = '<button>Bold</button><button>Italic</button>';
const buttons = root.querySelectorAll('button');

const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
  acceptNode: node => node.tagName === 'BUTTON' ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
});

walker.currentNode = buttons[1];
walker.previousNode(); // returned null — now correctly returns buttons[0]
```

All 20 existing TreeWalker tests pass. Added a regression test.