### PR TITLE
feat: [#2157] Add defaultSelected property to HTMLOptionElement

### DIFF
--- a/packages/happy-dom/src/nodes/html-option-element/HTMLOptionElement.ts
+++ b/packages/happy-dom/src/nodes/html-option-element/HTMLOptionElement.ts
@@ -59,6 +59,28 @@ export default class HTMLOptionElement extends HTMLElement {
 	}
 
 	/**
+	 * Returns default selected.
+	 *
+	 * @returns Default selected.
+	 */
+	public get defaultSelected(): boolean {
+		return this.getAttribute('selected') !== null;
+	}
+
+	/**
+	 * Sets default selected.
+	 *
+	 * @param defaultSelected Default selected.
+	 */
+	public set defaultSelected(defaultSelected: boolean) {
+		if (!defaultSelected) {
+			this.removeAttribute('selected');
+		} else {
+			this.setAttribute('selected', '');
+		}
+	}
+
+	/**
 	 * Returns selected.
 	 *
 	 * @returns Selected.

--- a/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-option-element/HTMLOptionElement.test.ts
@@ -61,6 +61,46 @@ describe('HTMLOptionElement', () => {
 		});
 	});
 
+	describe('get defaultSelected()', () => {
+		it('Returns false when "selected" attribute is absent.', () => {
+			expect(element.defaultSelected).toBe(false);
+		});
+
+		it('Returns true when "selected" attribute is set.', () => {
+			element.setAttribute('selected', '');
+			expect(element.defaultSelected).toBe(true);
+		});
+	});
+
+	describe('set defaultSelected()', () => {
+		it('Sets the "selected" attribute when set to true.', () => {
+			element.defaultSelected = true;
+			expect(element.getAttribute('selected')).toBe('');
+		});
+
+		it('Removes the "selected" attribute when set to false.', () => {
+			element.setAttribute('selected', '');
+			element.defaultSelected = false;
+			expect(element.getAttribute('selected')).toBe(null);
+		});
+
+		it('Reflects default selection but does not affect dirty selected state.', () => {
+			const select = <HTMLSelectElement>document.createElement('select');
+			const option1 = <HTMLOptionElement>document.createElement('option');
+			const option2 = <HTMLOptionElement>document.createElement('option');
+
+			select.appendChild(option1);
+			select.appendChild(option2);
+
+			option2.selected = true;
+			expect(option2.selected).toBe(true);
+
+			option2.defaultSelected = false;
+			expect(option2.defaultSelected).toBe(false);
+			expect(option2.selected).toBe(true);
+		});
+	});
+
 	describe('get selected()', () => {
 		it('Returns the selected state of the option.', () => {
 			const select = <HTMLSelectElement>document.createElement('select');


### PR DESCRIPTION
Fixes #2157.

Adds the `defaultSelected` getter/setter to `HTMLOptionElement`, reflecting the `selected` HTML attribute per the [WHATWG spec](https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-defaultselected).

- Getter returns `true` when the `selected` attribute is present
- Setter sets/removes the `selected` attribute (triggering existing selectedness update logic via `onSetAttribute`/`onRemoveAttribute`)
- Does not affect the dirty `selected` state (by design — the existing attribute handlers already handle this correctly)