### PR TITLE
fix: [#2170] Restore Node.contains() for proxied form/select ancestors

### DIFF
--- a/packages/happy-dom/src/nodes/node/NodeUtility.ts
+++ b/packages/happy-dom/src/nodes/node/NodeUtility.ts
@@ -67,14 +67,27 @@ export default class NodeUtility {
 			return true;
 		}
 
+		// HTMLFormElement and HTMLSelectElement return a Proxy from their constructor, but the
+		// parent chain may hold either the proxy or the underlying node. Compare nodes by their
+		// canonical identity (the proxy when one exists) so a proxied ancestor still matches the
+		// raw node stored in the tree. Without this, contains() wrongly returns false for a
+		// proxied <form>/<select> ancestor when the subtree is assembled detached and then
+		// attached to the document (the React render order). See #2170.
+		const canonical = (node: Node | null): Node | null =>
+			node && node[PropertySymbol.proxy] ? node[PropertySymbol.proxy] : node;
+		const canonicalAncestor = canonical(ancestorNode);
+
 		let parent: Node | null = referenceNode[PropertySymbol.parentNode];
 
 		while (parent) {
-			if (ancestorNode === parent) {
+			if (canonicalAncestor === canonical(parent)) {
 				return true;
 			}
 
-			if (ancestorNode[PropertySymbol.parentNode] === parent[PropertySymbol.parentNode]) {
+			if (
+				canonical(ancestorNode[PropertySymbol.parentNode]) ===
+				canonical(parent[PropertySymbol.parentNode])
+			) {
 				return false;
 			}
 

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -388,6 +388,38 @@ describe('Node', () => {
 			expect(form.contains(div)).toBe(true);
 			expect(div.contains(input)).toBe(true);
 		});
+
+		it('Returns "true" for a descendant when a proxied <form> subtree is assembled detached and then attached to the document (issue #2170).', () => {
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+			const input = document.createElement('input');
+
+			// Assemble the subtree while detached, then attach it (React render order).
+			div.appendChild(input);
+			form.appendChild(div);
+			document.body.appendChild(form);
+
+			expect(form.contains(input)).toBe(true);
+			expect(form.contains(div)).toBe(true);
+			// A non-descendant sibling must still report false (no false positive).
+			const sibling = document.createElement('input');
+			document.body.appendChild(sibling);
+			expect(form.contains(sibling)).toBe(false);
+		});
+
+		it('Returns "true" for a descendant when a proxied <select> subtree is assembled detached and then attached to the document (issue #2170).', () => {
+			const select = document.createElement('select');
+			const optgroup = document.createElement('optgroup');
+			const option = document.createElement('option');
+
+			option.setAttribute('value', '1');
+			optgroup.appendChild(option);
+			select.appendChild(optgroup);
+			document.body.appendChild(select);
+
+			expect(select.contains(option)).toBe(true);
+			expect(select.contains(optgroup)).toBe(true);
+		});
 	});
 
 	describe('getRootNode()', () => {


### PR DESCRIPTION
Fixes #2170.

### Problem

Since **v20.3.3**, `Node.contains()` returns `false` for a genuine descendant when a `<form>` or `<select>` subtree is assembled **detached** and then attached to the document — the order React / React Testing Library uses, which breaks `toContainElement` and any `contains()`-based assertion for rendered DOM.

```js
const input = document.createElement('input');
const div = document.createElement('div');
const form = document.createElement('form');
div.appendChild(input);
form.appendChild(div);          // subtree assembled while DETACHED
document.body.appendChild(form);
form.contains(input); // v20.3.2: true (correct) — v20.3.3…v20.9.0: false (bug)
```

### Root cause

The regression was introduced in #1991 (the fix for #1876), which made `contains()` pass the form/select **proxy** as the ancestor into `NodeUtility.isInclusiveAncestor`:

```ts
const self = this[PropertySymbol.proxy] || this;
return NodeUtility.isInclusiveAncestor(self, otherNode);
```

`isInclusiveAncestor` walks up the `parentNode` chain testing raw identity (`ancestorNode === parent`). When the subtree is assembled detached and then attached, the parent chain holds the **underlying** node, so the proxied ancestor never matches and the walk returns `false`. It fixed the flat case in #1876 but regressed the nested-detached case. (Bisected at patch granularity: 20.3.2 ✓ → 20.3.3 ✗; the boundary is #1991, not the later 20.4.0 GC rework.)

### Fix

Normalize each node to its canonical identity — the proxy when one exists — on **both sides** of the two identity comparisons in the ancestor walk, so a proxied `<form>`/`<select>` ancestor matches the raw node held in the tree. This preserves #1876's behaviour without reintroducing the bug, and leaves non-proxied nodes unchanged.

### Tests

Adds regression tests in `Node.test.ts` for detached-then-attached `<form>` and `<select>` subtrees, including a **negative sibling case** so the normalization can't produce false positives.

- `npm run compile` — clean
- `npm test` (happy-dom package) — **7587 passed**, including the existing #1876 tests and the new #2170 cases
- `npm run lint` — clean
