### PR TITLE
fix: [#2182] Node.prototype.nodeName getter returns correct value for subclass instances

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -26,6 +26,8 @@ import type HTMLTextAreaElement from '../html-text-area-element/HTMLTextAreaElem
 import type HTMLSlotElement from '../html-slot-element/HTMLSlotElement.js';
 import NodeFactory from '../NodeFactory.js';
 import type SVGStyleElement from '../svg-style-element/SVGStyleElement.js';
+import type ProcessingInstruction from '../processing-instruction/ProcessingInstruction.js';
+import type DocumentType from '../document-type/DocumentType.js';
 
 /**
  * Node.
@@ -230,7 +232,26 @@ export default class Node extends EventTarget {
 	 * @returns Node name.
 	 */
 	public get nodeName(): string {
-		return '';
+		switch (this[PropertySymbol.nodeType]) {
+			case NodeTypeEnum.elementNode:
+				return (<Element>(<unknown>this))[PropertySymbol.tagName] ?? '';
+			case NodeTypeEnum.textNode:
+				return '#text';
+			case NodeTypeEnum.cdataSectionNode:
+				return '#cdata-section';
+			case NodeTypeEnum.processingInstructionNode:
+				return (<ProcessingInstruction>(<unknown>this))[PropertySymbol.target];
+			case NodeTypeEnum.commentNode:
+				return '#comment';
+			case NodeTypeEnum.documentNode:
+				return '#document';
+			case NodeTypeEnum.documentTypeNode:
+				return (<DocumentType>(<unknown>this)).name;
+			case NodeTypeEnum.documentFragmentNode:
+				return '#document-fragment';
+			default:
+				return '';
+		}
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -154,6 +154,25 @@ describe('Node', () => {
 		it('Returns emptry string.', () => {
 			expect(NodeFactory.createNode(document, Node).nodeName).toBe('');
 		});
+
+		it('Returns correct value when getter is extracted from Node.prototype and called on subclasses.', () => {
+			const nodeProtoGetter = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeName')!.get!;
+
+			const div = document.createElement('div');
+			expect(nodeProtoGetter.call(div)).toBe('DIV');
+
+			const text = document.createTextNode('hello');
+			expect(nodeProtoGetter.call(text)).toBe('#text');
+
+			const comment = document.createComment('test');
+			expect(nodeProtoGetter.call(comment)).toBe('#comment');
+
+			expect(nodeProtoGetter.call(document)).toBe('#document');
+
+			if (document.doctype) {
+				expect(nodeProtoGetter.call(document.doctype)).toBe('html');
+			}
+		});
 	});
 
 	describe('get previousSibling()', () => {


### PR DESCRIPTION
Fixes #2182

The `Node.prototype.nodeName` getter returned an empty string for all node types. When libraries like DOMPurify extract the getter from `Node.prototype` directly (via `Object.getOwnPropertyDescriptor`) and call it on an element, the result was always `''` instead of the tag name.

This happened because the base `Node` getter was hardcoded to `return ''`, and while subclasses override it, those overrides don't apply when the getter is called from `Node.prototype` directly.

Fixed by making `Node.prototype.nodeName` dispatch based on `nodeType`:
- Element: returns `tagName`
- Text: `#text`
- CDATASection: `#cdata-section`
- ProcessingInstruction: returns `target`
- Comment: `#comment`
- Document: `#document`
- DocumentType: returns `name`
- DocumentFragment: `#document-fragment`

All existing tests pass (4007 passed, 14 pre-existing failures unrelated to this change). Added regression test verifying the getter returns correct values when extracted from `Node.prototype` and called on subclass instances.