### PR TITLE
fix: [#2184] Exclude disabled select and textarea elements from FormData

### DIFF
--- a/packages/happy-dom/src/form-data/FormData.ts
+++ b/packages/happy-dom/src/form-data/FormData.ts
@@ -100,6 +100,9 @@ export default class FormData implements Iterable<[string, string | File]> {
 						break;
 					case 'TEXTAREA':
 					case 'SELECT':
+						if ((<HTMLInputElement>item).disabled) {
+							break;
+						}
 						this.append(name, (<HTMLInputElement>item).value);
 						break;
 				}

--- a/packages/happy-dom/test/form-data/FormData.test.ts
+++ b/packages/happy-dom/test/form-data/FormData.test.ts
@@ -307,6 +307,37 @@ describe('FormData', () => {
 			expect(formData.getAll('radioInput')).toEqual([]);
 			expect(formData.getAll('checkboxInput')).toEqual([]);
 		});
+
+		it('Excludes disabled select and textarea elements.', () => {
+			const form = document.createElement('form');
+
+			const select = document.createElement('select');
+			select.name = 'sel';
+			select.disabled = true;
+			const option = document.createElement('option');
+			option.value = 'x';
+			option.selected = true;
+			select.appendChild(option);
+
+			const textarea = document.createElement('textarea');
+			textarea.name = 'ta';
+			textarea.disabled = true;
+			textarea.value = 'hello';
+
+			const input = document.createElement('input');
+			input.type = 'text';
+			input.name = 'in';
+			input.value = 'i';
+			input.disabled = true;
+
+			form.appendChild(select);
+			form.appendChild(textarea);
+			form.appendChild(input);
+
+			const formData = new window.FormData(form);
+
+			expect([...formData.keys()]).toEqual([]);
+		});
 	});
 
 	describe('forEach()', () => {


### PR DESCRIPTION
Fixes #2184

The FormData constructor already excluded disabled `<input>` elements but skipped the disabled check for `<select>` and `<textarea>` controls. Added the same guard.

Per the spec, all disabled submittable elements should be excluded from the entry list regardless of element type.