### PR TITLE
fix: [#2149] Remove non-standard Promise rejection handling from event listeners

### DIFF
--- a/packages/happy-dom/src/event/EventTarget.ts
+++ b/packages/happy-dom/src/event/EventTarget.ts
@@ -276,27 +276,19 @@ export default class EventTarget {
 					browserSettings?.errorCapture === BrowserErrorCaptureEnum.tryAndCatch
 				) {
 					if ((<TEventListenerObject>listener).handleEvent) {
-						let result: any;
 						try {
-							result = (<TEventListenerObject>listener).handleEvent.call(listener, event);
+							(<TEventListenerObject>listener).handleEvent.call(listener, event);
 						} catch (error) {
 							window[PropertySymbol.dispatchError](<Error>error);
 						}
 
-						if (result instanceof Promise) {
-							result.catch((error) => window[PropertySymbol.dispatchError](error));
-						}
 					} else {
-						let result: any;
 						try {
-							result = (<TEventListenerFunction>listener).call(this, event);
+							(<TEventListenerFunction>listener).call(this, event);
 						} catch (error) {
 							window[PropertySymbol.dispatchError](<Error>error);
 						}
 
-						if (result instanceof Promise) {
-							result.catch((error) => window[PropertySymbol.dispatchError](error));
-						}
 					}
 				} else {
 					if ((<TEventListenerObject>listener).handleEvent) {
@@ -354,16 +346,12 @@ export default class EventTarget {
 						!browserSettings?.disableErrorCapturing &&
 						browserSettings?.errorCapture === BrowserErrorCaptureEnum.tryAndCatch
 					) {
-						let result: any;
 						try {
-							result = eventListener(event);
+							eventListener(event);
 						} catch (error) {
 							window[PropertySymbol.dispatchError](<Error>error);
 						}
 
-						if (result instanceof Promise) {
-							result.catch((error) => window[PropertySymbol.dispatchError](error));
-						}
 					} else {
 						eventListener(event);
 					}

--- a/packages/happy-dom/test/event/EventTarget.test.ts
+++ b/packages/happy-dom/test/event/EventTarget.test.ts
@@ -366,4 +366,49 @@ describe('EventTarget', () => {
 			expect(called).toBe(true);
 		});
 	});
+
+	describe('Async event listeners', () => {
+		it('Does not cause RangeError when async listener rejects.', async () => {
+			// Per the DOM spec (§2.9), event listener return values should be ignored.
+			// Previously, happy-dom wrapped async listener return values with .catch()
+			// calling dispatchError, which caused infinite recursion when async
+			// listeners rejected and the error dispatch triggered more async listeners.
+			//
+			// Simulate the reka-ui DismissableLayer pattern: async handlers on
+			// pointerdown and focusin that reject, plus an error handler that also
+			// rejects (async). This previously caused RangeError: Maximum call stack
+			// size exceeded.
+			let handlerCalls = 0;
+
+			window.document.addEventListener('pointerdown', async () => {
+				handlerCalls++;
+				throw new Error('pointerdown failure');
+			});
+
+			window.document.addEventListener('focusin', async () => {
+				handlerCalls++;
+				throw new Error('focus failure');
+			});
+
+			window.addEventListener('error', async () => {
+				handlerCalls++;
+				throw new Error('error handler failure');
+			});
+
+			// Should not throw RangeError: Maximum call stack size exceeded
+			expect(() => {
+				window.document.dispatchEvent(new Event('pointerdown'));
+			}).not.toThrow();
+
+			expect(() => {
+				window.document.dispatchEvent(new Event('focusin'));
+			}).not.toThrow();
+
+			// Give any pending promises time to settle (for unhandled rejection detection)
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			// Handlers were called but without infinite recursion
+			expect(handlerCalls).toBe(2);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #2149

Per the DOM spec (§2.9), addEventListener callback return values are ignored. Browsers do not catch or handle promises returned from event listeners.

Previously, happy-dom wrapped the return value of every listener with `.catch()` calling `dispatchError`. When an async listener rejected, this dispatched an ErrorEvent on window. If that error event also had an async listener that rejected, the cycle repeated — causing `RangeError: Maximum call stack size exceeded`.

This broke libraries like reka-ui (DismissableLayer) that register async pointerdown/focusin handlers on the document.

Removed the three `result.catch(...)` blocks and the now-unused `result` variable declarations. The synchronous try/catch error handling remains (matching browser behavior).
