### PR TITLE
fix: [#2195] Hold undefined custom element upgrade callback weakly to fix memory leak

### DIFF
--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -994,7 +994,18 @@ export default class HTMLElement extends Element {
 		// Therefore we need to register a callback for when it is defined in CustomElementRegistry and replace it with the registered element (see #404)
 		if (this.constructor === window.HTMLElement && localName.includes('-') && allCallbacks) {
 			if (!this.#customElementDefineCallback) {
-				const callback = this.#onCustomElementConnected.bind(this);
+				// The callback is stored in the window-lifetime CustomElementRegistry until the
+				// element is either disconnected or its custom element is defined. We hold the
+				// element through a WeakRef so that a detached document (e.g. created via DOMParser
+				// or document.write() and then dropped) can be garbage collected instead of being
+				// retained for the lifetime of the window (see #404 and the leak it introduced).
+				const reference = new WeakRef(this);
+				const callback = (): void => {
+					const element = reference.deref();
+					if (element) {
+						element.#onCustomElementConnected();
+					}
+				};
 				const callbacks = allCallbacks.get(localName);
 				if (callbacks) {
 					callbacks.unshift(callback);

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -10,6 +10,27 @@ import type CustomElementRegistry from '../../../src/custom-element/CustomElemen
 import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import type EventTarget from '../../../src/event/EventTarget.js';
 import Event from '../../../src/event/Event.js';
+import V8 from 'vm';
+import { setFlagsFromString } from 'v8';
+
+/**
+ * Returns a function that forces a garbage collection, or null if it can not be exposed.
+ *
+ * Vitest does not run workers with "--expose-gc", so we expose it at runtime for the
+ * memory regression test below. Returns null if exposing it is not possible.
+ */
+function getGarbageCollector(): (() => void) | null {
+	if (typeof globalThis.gc === 'function') {
+		return globalThis.gc;
+	}
+	try {
+		setFlagsFromString('--expose-gc');
+		const gc = V8.runInNewContext('gc');
+		return typeof gc === 'function' ? gc : null;
+	} catch {
+		return null;
+	}
+}
 
 describe('HTMLElement', () => {
 	let window: Window;
@@ -791,6 +812,34 @@ describe('HTMLElement', () => {
 
 			expect(parent.children[0] instanceof CustomElement).toBe(true);
 			expect(parent.children[0].shadowRoot?.children.length).toBe(2);
+		});
+
+		it('Does not retain detached documents that contain undefined custom elements (#404 regression).', async () => {
+			// An undefined custom element registers an upgrade callback in the window-lifetime
+			// CustomElementRegistry. The callback must hold the element weakly, otherwise every
+			// document parsed on a long-lived window (e.g. via DOMParser) is retained forever.
+			const gc = getGarbageCollector();
+			if (!gc) {
+				return;
+			}
+
+			const html = '<html><body><undefined-element></undefined-element></body></html>';
+			const collected: number[] = [];
+			const registry = new FinalizationRegistry((id: number) => collected.push(id));
+
+			for (let i = 0; i < 25; i++) {
+				let parsed: Document | null = new window.DOMParser().parseFromString(html, 'text/html');
+				registry.register(parsed, i);
+				expect(parsed.body.children.length).toBe(1);
+				parsed = null;
+			}
+
+			for (let i = 0; i < 20 && collected.length < 25; i++) {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				gc();
+			}
+
+			expect(collected.length).toBe(25);
 		});
 
 		it('Copies all properties from the unknown element to the new instance.', () => {


### PR DESCRIPTION
## Summary

Fixes #2195.

An undefined custom element (a hyphenated tag like `<my-widget>` whose class is never registered via `customElements.define`) registers an "upgrade" callback in the `Window`-lifetime `CustomElementRegistry` when it's connected to a document. That callback was created with `.bind(this)`, so it strongly captured the element — and through it, the element's owner document and entire node tree.

For a detached document that is parsed and then dropped without ever being disconnected (e.g. `new DOMParser().parseFromString(...)` or `document.write()` on a long-lived, reused window), this pinned the whole document for the lifetime of the `Window`.

This PR captures the element via `WeakRef` so the registry no longer keeps it alive.

## Root cause

This bug was introduced by #404, which added the `connectedToDocument` callback-registration mechanism.

In `HTMLElement[PropertySymbol.connectedToDocument]()`, for an element whose constructor is still the base `window.HTMLElement` and whose `localName` contains `'-'`, happy-dom registers an upgrade callback in `window.customElements[PropertySymbol.callbacks]` (a `Map<string, Array<() => void>>` that lives for the lifetime of the window):

```js
const callback = this.#onCustomElementConnected.bind(this);
```

The bound function permanently closes over `this`, giving the registry a strong reference to the element → its `ownerDocument` → the whole node tree. The registry is only drained on `disconnectedFromDocument` or by a later `define()`, so a detached document that is never disconnected can never be collected while the window lives.

Retention chain:

```
BrowserWindow (GC root)
  -> customElements -> CustomElementRegistry
    -> [PropertySymbol.callbacks] Map
      -> callback array keyed by localName
        -> bound .bind(this) callback
          -> BoundThis -> the HTMLElement
            -> ownerDocument -> Document tree
```

For a tiny page the retained-heap delta is small, but the leak is per-document and unbounded — each parse of a real ~193KB page (e.g. a GitHub page using `<include-fragment>`) retains roughly ~18MB.

## The fix

```diff
-				const callback = this.#onCustomElementConnected.bind(this);
+				const reference = new WeakRef(this);
+				const callback = (): void => {
+					const element = reference.deref();
+					if (element) {
+						element.#onCustomElementConnected();
+					}
+				};
```

**Why behavior is unchanged:** The callback is only ever invoked when the matching custom element is later defined via `CustomElementRegistry.define()`. In every case where the upgrade should happen, the element is still strongly reachable from a live document tree (that is exactly why it still needs upgrading), so `reference.deref()` returns the element and `#onCustomElementConnected()` runs identically. The only newly-reachable branch is the `if (element)` false case, which occurs precisely in the previously-leaking scenario where the element has already been collected.

## Tests

Adds a regression test to `HTMLElement.test.ts`: *"Does not retain detached documents that contain undefined custom elements (#404 regression)."* It parses 25 detached documents containing an `<undefined-element>`, registers each with a `FinalizationRegistry`, drops the references, then forces GC and asserts all 25 are collected.

Because Vitest does not run workers with `--expose-gc`, the test uses a `getGarbageCollector()` helper that exposes GC at runtime (`setFlagsFromString('--expose-gc')` + `vm.runInNewContext('gc')`) and no-ops gracefully if GC cannot be exposed. On `master` the strong bound callback keeps the documents alive, so they are never finalized and the assertion fails; with this fix all 25 are reclaimable.

## Checklist

- [x] `npm run compile` passes
- [x] `npm test` passes (added regression test fails on `master`, passes here)
- [x] `npx eslint --max-warnings 0` clean on changed files
- [x] Conventional Commit message with issue reference
