### PR TITLE
fix: [#2013] Stop ResponseCache evicting expired-but-revalidatable entries

### DIFF
--- a/packages/happy-dom/src/fetch/cache/response/ResponseCache.ts
+++ b/packages/happy-dom/src/fetch/cache/response/ResponseCache.ts
@@ -201,8 +201,16 @@ export default class ResponseCache implements IResponseCache {
 			}
 		}
 
-		// Cache is invalid if it has expired and doesn't have an ETag.
-		if (!cachedResponse.etag && (!cachedResponse.expires || cachedResponse.expires < Date.now())) {
+		// Don't cache a response that has no freshness lifetime, or that has already expired and
+		// cannot be revalidated. An expired response that has an ETag or a "Last-Modified" date is
+		// still kept, because get() serves it as stale and revalidates it (see the matching logic in
+		// get()). Without this, a response with a very short max-age could expire between being
+		// computed above and this check, evicting an entry that should have remained revalidatable.
+		if (
+			!cachedResponse.etag &&
+			(!cachedResponse.expires ||
+				(cachedResponse.expires < Date.now() && !cachedResponse.lastModified))
+		) {
 			const entries = this.#entries.get(url);
 			if (entries) {
 				const index = entries.indexOf(cachedResponse);

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -15,7 +15,7 @@ import Path from 'path';
 import { URLSearchParams } from 'url';
 import '../types.d.js';
 import { ReadableStream } from 'stream/web';
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import FetchHTTPSCertificate from '../../src/fetch/certificate/FetchHTTPSCertificate.js';
 import * as PropertySymbol from '../../src/PropertySymbol.js';
 import { fail } from 'assert';
@@ -43,6 +43,8 @@ interface IMockNetwork {
 }
 
 describe('Fetch', () => {
+	let dateNow: number;
+
 	function mockNetwork(
 		schema: 'http' | 'https',
 		specification?: {
@@ -93,6 +95,12 @@ describe('Fetch', () => {
 			}
 		};
 	}
+
+	beforeEach(() => {
+		// Mock the clock so cache-expiry tests are deterministic instead of racing real time.
+		dateNow = Date.now();
+		vi.spyOn(Date, 'now').mockImplementation(() => dateNow);
+	});
 
 	afterEach(() => {
 		resetMockedModules();
@@ -3774,7 +3782,8 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = await window.fetch(url);
 			const text2 = await response2.text();
@@ -3933,7 +3942,8 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = await window.fetch(url);
 			const text2 = await response2.text();
@@ -4104,7 +4114,8 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = await window.fetch(url, {
 				method: 'HEAD'
@@ -4273,7 +4284,8 @@ describe('Fetch', () => {
 			});
 			const text1 = await response1.text();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = await window.fetch(url);
 			const text2 = await response2.text();

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -28,6 +28,7 @@ const PLATFORM =
 describe('SyncFetch', () => {
 	let browserFrame: IBrowserFrame;
 	let window: BrowserWindow;
+	let dateNow: number;
 
 	beforeEach(() => {
 		const browser = new Browser();
@@ -35,6 +36,10 @@ describe('SyncFetch', () => {
 
 		browserFrame = page.mainFrame;
 		window = page.mainFrame.window;
+
+		// Mock the clock so cache-expiry tests are deterministic instead of racing real time.
+		dateNow = Date.now();
+		vi.spyOn(Date, 'now').mockImplementation(() => dateNow);
 	});
 
 	afterEach(() => {
@@ -2984,7 +2989,8 @@ describe('SyncFetch', () => {
 			}).send();
 			const text1 = response1.body!.toString();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = new SyncFetch({ browserFrame, window, url }).send();
 			const text2 = response2.body!.toString();
@@ -3121,7 +3127,8 @@ describe('SyncFetch', () => {
 			}).send();
 			const text1 = response1.body!.toString();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = new SyncFetch({ browserFrame, window, url }).send();
 			const text2 = response2.body!.toString();
@@ -3269,7 +3276,8 @@ describe('SyncFetch', () => {
 			}).send();
 			const text1 = response1.body!.toString();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = new SyncFetch({
 				browserFrame,
@@ -3421,7 +3429,8 @@ describe('SyncFetch', () => {
 			}).send();
 			const text1 = response1.body!.toString();
 
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			// Advance the mocked clock past the cached response's max-age so it becomes stale.
+			dateNow += 100;
 
 			const response2 = new SyncFetch({ browserFrame, window, url }).send();
 			const text2 = response2.body!.toString();

--- a/packages/happy-dom/test/fetch/cache/response/ResponseCache.test.ts
+++ b/packages/happy-dom/test/fetch/cache/response/ResponseCache.test.ts
@@ -101,6 +101,34 @@ describe('ResponseCache', () => {
 			dateNow += 100;
 			expect(responseCache.get(request)).toBeNull();
 		});
+
+		it('Keeps an already-expired response that has a "Last-Modified" header so it can be revalidated.', () => {
+			const request = {
+				url: 'http://localhost:8080',
+				method: 'GET',
+				headers: new Headers()
+			};
+			const response = {
+				status: 200,
+				statusText: 'OK',
+				url: 'http://localhost:8080',
+				headers: new Headers({
+					'Content-Type': 'text/html',
+					// "Age" exceeds "max-age", so the response is already expired when added — but with a
+					// "Last-Modified" date it must still be cached as stale (not evicted) so a later
+					// request can revalidate it with an "If-Modified-Since" header.
+					'Cache-Control': 'max-age=60',
+					Age: '120',
+					'Last-Modified': LAST_MODIFIED_DATE
+				}),
+				body: Buffer.from('test'),
+				waitingForBody: false
+			};
+			responseCache.add(request, response);
+			const cachedResponse = responseCache.get(request);
+			expect(cachedResponse?.state).toBe(CachedResponseStateEnum.stale);
+			expect(cachedResponse?.lastModified).toBe(LAST_MODIFIED_MILLISECONDS);
+		});
 	});
 
 	describe('add()', () => {


### PR DESCRIPTION
Fixes #2013.

This PR addresses a bug that was causing random CI failures for other PRs.

The cache-revalidation tests in `Fetch.test.ts` and `SyncFetch.test.ts` fail intermittently in CI (most recently observed failing on the Node 20 matrix job while passing on 22 and 24). This PR fixes the **root cause** in `ResponseCache`, not just the test values, and makes the affected tests deterministic.

This PR supersedes #2014 and #2104. Both of those are test-only mitigations (Date.now() mocking / bumping `max-age`) that reduce the odds of tripping the race but leave the underlying `ResponseCache` bug in place. This PR fixes the source bug and adds a regression test, then applies the same deterministic-clock treatment to the integration tests.

## Root cause

In `ResponseCache.add()`, a `max-age` response gets `expires = Date.now() + max-age * 1000` (line 157). Then, at the very end of the same `add()` call, the entry is re-checked and evicted if expired:

```js
// before
if (!cachedResponse.etag && (!cachedResponse.expires || cachedResponse.expires < Date.now())) {
    // ...splice the just-added entry and return null
}
```

With the tests' `max-age=0.0001` (a 0.1 ms lifetime), the entry "expires" almost immediately — so if more than 0.1 ms of wall-clock elapses between computing `expires` and this final check (easy on a loaded CI runner), the entry **self-evicts during `add()`**. The next request then finds nothing cached, issues a plain request instead of a conditional revalidation, and returns the original body — producing the observed `expected 'some new text', received 'some text'` failure.

Crucially, this eviction is **inconsistent with `get()`**, which keeps an expired entry that has a validator and serves it as stale for revalidation:

```js
// get(), lines 56-63
if (entry.expires && entry.expires < Date.now()) {
    if (entry.lastModified) {
        entry.state = CachedResponseStateEnum.stale;   // keep — revalidate later
    } else if (!entry.etag) {
        entries.splice(i, 1);                           // drop only if no validator
        return null;
    }
}
```

So `add()` was discarding a perfectly revalidatable response that `get()` would have kept.

## The fix

Make `add()`'s eviction guard match `get()`'s semantics — only drop an expired entry when it has *neither* an ETag *nor* a `Last-Modified` validator:

```js
if (
    !cachedResponse.etag &&
    (!cachedResponse.expires ||
        (cachedResponse.expires < Date.now() && !cachedResponse.lastModified))
) {
    // ...evict...
}
```

This is correct per HTTP caching semantics (RFC 7234): expiry and removal are distinct — a stale response carrying a validator should be retained so it can be conditionally revalidated (`If-Modified-Since` / `If-None-Match`) into a cheap 304. `SyncFetch`/`Fetch` rely on exactly this: a stale entry with a `lastModified` triggers an `If-Modified-Since` revalidation.

**Behavior change is limited to the intended case:** an expired, no-ETag, has-`Last-Modified` entry is now kept (revalidatable) instead of evicted. All other branches are unchanged — no-freshness-lifetime entries (`!expires`) are still dropped, ETag entries are still kept, fresh entries are still kept. No unbounded retention: kept entries are revalidated on next access (or dropped by `get()` if they somehow lack a validator), and `clear({ toTime })` still prunes by `cacheUpdateTime`.

## Tests

- **`ResponseCache.test.ts`** — adds a deterministic regression test, *"Keeps an already-expired response that has a 'Last-Modified' header so it can be revalidated."* It uses `Age: 120` with `max-age=60` to force `expires` into the past under a frozen clock (no timing race), and asserts the entry is kept with `state === stale`. **Verified it fails on master** (the entry is evicted, so `get()` returns null) **and passes with the fix.**
- **`Fetch.test.ts` / `SyncFetch.test.ts`** — the 8 cache-revalidation tests now mock `Date.now()` in `beforeEach` and advance it with `dateNow += 100` instead of `await setTimeout(100)`. This removes ~800 ms of real waiting and all timing fragility. (This is the same approach as #2014, folded in here so the fix and its tests land together.)

## Related

- #1985 / #1986 — prior report and its merged `parseInt`→`parseFloat` fix, which addressed `max-age` truncation but not this eviction race.
- #2014 (mine, open) / #2104 (open) / #2116 (closed) — test-only mitigations of the same flake; this PR supersedes them by fixing the source.