### PR TITLE
fix: [#2202] Stop the virtual console buffer from leaking logged errors

### DIFF
--- a/packages/happy-dom/src/console/VirtualConsolePrinter.ts
+++ b/packages/happy-dom/src/console/VirtualConsolePrinter.ts
@@ -14,6 +14,9 @@ export default class VirtualConsolePrinter implements IVirtualConsolePrinter {
 		clear: Array<(event: Event) => void>;
 	} = { print: [], clear: [] };
 	#closed = false;
+	// Maximum number of buffered log entries kept when nothing reads the buffer. Prevents an
+	// unbounded buffer (and the objects its entries retain) from leaking on a long-lived Window.
+	#maxLogEntries = 1000;
 
 	/**
 	 * Returns closed state.
@@ -33,6 +36,26 @@ export default class VirtualConsolePrinter implements IVirtualConsolePrinter {
 		if (this.#closed) {
 			return;
 		}
+
+		// On V8, an Error keeps its structured stack trace (an array of call sites) alive until
+		// ".stack" is first read, and each call site retains its frame's receiver. When an exception
+		// thrown from an event listener is caught and logged here, that receiver is the listening
+		// element, so the buffered Error pins the element - and through it the document. The buffer
+		// is rarely read, so the trace would otherwise never be released. Materialize ".stack" now to
+		// drop the structured trace (and the receivers it holds) while keeping the formatted string.
+		for (const message of logEntry.message) {
+			if (message instanceof Error) {
+				void message.stack;
+			}
+		}
+
+		// Log entries are buffered until read(). When nothing reads them (the default when a Window
+		// is used without inspecting its console) the buffer grows without bound, so cap it and drop
+		// the oldest entries, matching how a real console keeps only a limited scrollback.
+		if (this.#logEntries.length >= this.#maxLogEntries) {
+			this.#logEntries.splice(0, this.#logEntries.length - this.#maxLogEntries + 1);
+		}
+
 		this.#logEntries.push(logEntry);
 		this.dispatchEvent(new Event('print'));
 	}

--- a/packages/happy-dom/test/console/VirtualConsolePrinter.test.ts
+++ b/packages/happy-dom/test/console/VirtualConsolePrinter.test.ts
@@ -61,6 +61,45 @@ describe('VirtualConsolePrinter', () => {
 
 			expect(virtualConsolePrinter.read()).toEqual([]);
 		});
+
+		it('Caps the number of buffered log entries so an unread buffer does not grow without bound.', () => {
+			for (let i = 0; i < 1500; i++) {
+				virtualConsolePrinter.print({
+					type: VirtualConsoleLogTypeEnum.log,
+					level: VirtualConsoleLogLevelEnum.log,
+					message: [`Test ${i}`],
+					group: null
+				});
+			}
+
+			const entries = virtualConsolePrinter.read();
+
+			// Buffer is capped and keeps the most recent entries.
+			expect(entries.length).toBe(1000);
+			expect(entries[0].message[0]).toBe('Test 500');
+			expect(entries[entries.length - 1].message[0]).toBe('Test 1499');
+		});
+
+		it('Materializes the stack of logged errors so they do not retain their structured stack trace.', () => {
+			let stackReads = 0;
+			const error = new Error('test');
+			Object.defineProperty(error, 'stack', {
+				configurable: true,
+				get() {
+					stackReads++;
+					return 'stack';
+				}
+			});
+
+			virtualConsolePrinter.print({
+				type: VirtualConsoleLogTypeEnum.error,
+				level: VirtualConsoleLogLevelEnum.error,
+				message: [error],
+				group: null
+			});
+
+			expect(stackReads).toBe(1);
+		});
 	});
 
 	describe('clear()', () => {


### PR DESCRIPTION
Fixes #2202.

## Problem

By default, a `Window`'s `console` is a `VirtualConsole` backed by a per-page `VirtualConsolePrinter`. Every `console.*` call buffers a log entry in the printer's private `#logEntries` array, and **nothing in the `Window`/frame/page lifecycle ever drains it** — the only things that empty the buffer are an explicit `read()` / `readAsString()`, `console.clear()`, or page `close()`. So on a long-lived `Window` whose console is never read, the buffer grows for the lifetime of the `Window`.

This leaks memory two ways:

1. **Retained stack-frame receivers (V8/Node).** On V8, an `Error` keeps its structured stack trace (an array of call sites) alive until `.stack` is first read, and each call site retains its frame's receiver (`this`). When an exception thrown from an **event listener** is caught (default `errorCapture: 'tryAndCatch'`) and logged via `console.error(error)`, that receiver is the listening element — so the buffered `Error` pins the element and, through it, the document. Because the buffer is rarely read, the trace is never materialized and the retention is permanent.

2. **Unbounded buffer.** Independently of (1), `#logEntries` had no size limit, so it grows without bound on any engine.

### Repro — unbounded buffer

```js
import { Window } from 'happy-dom';

const window = new Window();
for (let i = 0; i < 5000; i++) {
  window.console.error(new Error(`boom ${i}`));
}
// Nothing ever read the console:
window.happyDOM.virtualConsolePrinter.read().length; // master: 5000 (grows with the loop)
```

### Repro — buffered listener error pins a detached element

```js
// node --expose-gc
import { Window } from 'happy-dom';

const window = new Window();
const document = window.document;
const registry = new FinalizationRegistry((tag) => console.log('collected:', tag));

(() => {
  const div = document.createElement('div');
  div.addEventListener('click', () => { throw new Error('listener boom'); });
  document.body.appendChild(div);
  div.dispatchEvent(new window.Event('click')); // caught → console.error(error), buffered
  registry.register(div, 'div');
  document.body.removeChild(div); // detach
})();

global.gc();
setTimeout(() => global.gc(), 50);
// On master, "collected: div" never prints — the buffered Error pins the div (and the document).
```

## Fix

In `VirtualConsolePrinter.print()`:

1. **Materialize `.stack` of any logged `Error`** (`void message.stack`) so V8 drops the structured trace — and the receivers it holds — while keeping the formatted string for later `readAsString()`.
2. **Cap `#logEntries` at 1000**, dropping the oldest, so an unread buffer can't grow without bound (matching a real console's bounded scrollback).

## Scope / caveats for the `.stack` mechanism

The receiver-retention is a V8/Node implementation detail, not specified by ECMAScript:

- It is **bounded by `Error.stackTraceLimit`** (default `10`) — only the receivers of the captured top frames are pinned.
- It **does not apply on non-V8 engines** (JavaScriptCore, SpiderMonkey, Hermes).
- It **does not occur** when `Error.stackTraceLimit === 0`, and a custom `Error.prepareStackTrace` that retains the `CallSite` array can keep receivers alive even after `.stack` is read.

The materialization is therefore a no-op-to-cheap on engines/configs where the retention doesn't happen, and the targeted release where it does.

## Behavior change

The 1000-entry cap is observable: a consumer that logs **more than the cap** and *then* reads the console (with no intervening read) gets only the newest 1000 entries — the **oldest are silently dropped**. Since errors often occur early in a run, the first failure-explaining line could be pushed out. The limit here is a hardcoded private field with no public configuration. 

## Tests

`test/console/VirtualConsolePrinter.test.ts` adds two tests:

- **"Caps the number of buffered log entries…"** — logs 1500 entries, asserts the buffer keeps exactly the most recent 1000 (`Test 500` … `Test 1499`).
- **"Materializes the stack of logged errors…"** — installs a counting getter on an `Error`'s `.stack` and asserts `print()` reads it exactly once.

## Related

- #2120 — "Window leaks memory" (broad symptom this contributes to)
- #2195 / #2196 — sibling "detached document pinned to a `Window`-lifetime structure" leak (different path: `CustomElementRegistry` upgrade callback)
