### PR TITLE
fix: [#2194] Fix `~=` attribute selector matching hyphenated substrings

### DIFF
--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -474,7 +474,7 @@ export default class SelectorParser {
 		switch (attribute.operator) {
 			// [attribute~="value"] - Contains a specified word.
 			case '~':
-				return new RegExp(`[- ]${escapedValue}|${escapedValue}[- ]|^${escapedValue}$`, modifier);
+				return new RegExp(`(^|\\s)${escapedValue}(\\s|$)`, modifier);
 			// [attribute|="value"] - Starts with the specified word.
 			case '|':
 				return new RegExp(`^${escapedValue}[- ]|^${escapedValue}$`, modifier);

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -706,6 +706,22 @@ describe('QuerySelector', () => {
 			expect(elements[1] === container.children[0].children[1].children[1]).toBe(true);
 		});
 
+		it('Does not match hyphenated substrings with "~=" selector.', () => {
+			const container = document.createElement('div');
+			container.innerHTML =
+				'<div data-controller="modal"><div data-controller="modal-auto-close"></div></div>';
+			const parent = container.children[0];
+			const child = container.children[0].children[0];
+
+			expect(parent.matches('[data-controller~="modal"]')).toBe(true);
+			expect(child.matches('[data-controller~="modal"]')).toBe(false);
+			expect(child.matches('[data-controller~="modal-auto"]')).toBe(false);
+			expect(child.matches('[data-controller~="auto"]')).toBe(false);
+			expect(child.matches('[data-controller~="odal"]')).toBe(false);
+			expect(child.matches('[data-controller~="modal-auto-close"]')).toBe(true);
+			expect(container.querySelector('[data-controller~="modal"]')).toBe(parent);
+		});
+
 		it('Returns all elements with an attribute value starting with the specified word using "[class|="class1"]".', () => {
 			const container = document.createElement('div');
 			container.innerHTML = QuerySelectorHTML;


### PR DESCRIPTION
Fixes #2194

The `~=` attribute selector incorrectly treated hyphens as word separators and allowed unanchored substring matching. For example, `[data-controller~="modal"]` matched `data-controller="modal-auto-close"` and `[data-controller~="odal"]` matched it too.

Per [CSS Selectors Level 4 §6.2](https://www.w3.org/TR/selectors-4/#attribute-representation), `~=` should match only when the value is one of the **whitespace-separated** words.

Changed the regex from `[- ]v|v[- ]|^v$` to `(^|\s)v(\s|$)`. Added regression test covering the Stimulus controller `closest()` pattern that motivated this fix.