### PR TITLE
fix: [#2206] Coerce null qualifiedName to empty string in createDocument

### DIFF
--- a/packages/happy-dom/src/dom-implementation/DOMImplementation.ts
+++ b/packages/happy-dom/src/dom-implementation/DOMImplementation.ts
@@ -27,12 +27,21 @@ export default class DOMImplementation {
 	 * @param qualifiedName Qualified name.
 	 * @param [_docType] Document type.
 	 */
-	public createDocument(_namespaceURI: string, qualifiedName: string, _docType?: string): Document {
+	public createDocument(
+		_namespaceURI: string | null,
+		qualifiedName: string | null,
+		_docType?: string | null
+	): Document {
 		if (arguments.length < 2) {
 			throw new this.#document[PropertySymbol.window].TypeError(
 				`Failed to execute 'createDocument' on 'DOMImplementation': 2 arguments required, but only ${arguments.length} present.`
 			);
 		}
+
+		// The spec declares "qualifiedName" as "[LegacyNullToEmptyString] DOMString",
+		// so "null" is coerced to an empty string instead of being rejected.
+		qualifiedName = qualifiedName === null ? '' : String(qualifiedName);
+
 		switch (qualifiedName.split(':').pop()) {
 			case 'svg':
 			case 'xml':

--- a/packages/happy-dom/test/dom-implementation/DOMImplementation.test.ts
+++ b/packages/happy-dom/test/dom-implementation/DOMImplementation.test.ts
@@ -31,9 +31,15 @@ describe('DOMImplementation', () => {
 		it('Returns a new XMLDocument for "xml".', () => {
 			const document = window.document.implementation.createDocument(
 				'http://www.w3.org/2000/svg',
-				'svg'
+				'xml'
 			);
 			expect(document instanceof window.XMLDocument).toBe(true);
+			expect(document.defaultView).toBe(null);
+		});
+
+		it('Returns a new HTMLDocument when "qualifiedName" is null.', () => {
+			const document = window.document.implementation.createDocument(null, null, null);
+			expect(document instanceof window.HTMLDocument).toBe(true);
 			expect(document.defaultView).toBe(null);
 		});
 


### PR DESCRIPTION
Fixes #2206.

`document.implementation.createDocument(null, null, null)` started throwing `TypeError: Cannot read properties of null (reading 'split')` in 20.10.2. It worked in 20.10.1 and works in Chrome, Firefox and Safari.

The `createDocument` rewrite in #2188 added a `qualifiedName.split(':')` switch but dereferences `qualifiedName` directly. Per the DOM spec the parameter is declared [`[LegacyNullToEmptyString] DOMString`](https://webidl.spec.whatwg.org/#LegacyNullToEmptyString), so `null` should be coerced to `""` rather than rejected (see the [createDocument steps](https://dom.spec.whatwg.org/#dom-domimplementation-createdocument)).

This coerces `null` to an empty string before the switch — matching the existing pattern in `MediaList.ts` — and widens the parameter types to accept `null`. An empty/`null` qualified name falls through to the default branch and returns an `HTMLDocument`, restoring the 20.10.1 behaviour.

One note on scope: the spec has `createDocument` always return an `XMLDocument`, but the current implementation is an intentional stub (`TODO: Not fully implemented`) that keys off the qualified name and returns `HTMLDocument` by default. I kept that behaviour so this stays a focused regression fix rather than a rework of document-type selection — happy to follow up separately if you'd like it to track the spec more closely.

While I was in the file I also fixed the neighbouring `"xml"` test, which passed `"svg"` and so never actually exercised the `xml` branch.

### Testing

Added a regression test for `createDocument(null, null, null)`. It fails on `master` with the reported `TypeError` and passes with this change. Lint and the `DOMImplementation` suite are green.
