### PR TITLE
fix: [#2203] Allow replaceWith() on document element

### DIFF
--- a/packages/happy-dom/src/nodes/html-document/HTMLDocument.ts
+++ b/packages/happy-dom/src/nodes/html-document/HTMLDocument.ts
@@ -70,7 +70,8 @@ export default class HTMLDocument extends Document {
 
 		if (
 			newNode[PropertySymbol.nodeType] === NodeTypeEnum.elementNode &&
-			this[PropertySymbol.elementArray].length !== 0
+			this[PropertySymbol.elementArray].length !== 0 &&
+			referenceNode?.[PropertySymbol.nodeType] !== NodeTypeEnum.elementNode
 		) {
 			throw new this[PropertySymbol.window].Error(
 				`Failed to execute 'insertBefore' on 'Node': Only one element on document allowed.`

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1020,6 +1020,20 @@ describe('Document', () => {
 		});
 	});
 
+	describe('replaceWith()', () => {
+		it('Replaces documentElement with another element.', () => {
+			const newHtml = document.createElement('html');
+			const newBody = document.createElement('body');
+			newHtml.appendChild(newBody);
+
+			const oldHtml = document.documentElement;
+			oldHtml.replaceWith(newHtml);
+
+			expect(document.documentElement).toBe(newHtml);
+			expect(oldHtml.parentNode).toBeNull();
+		});
+	});
+
 	describe('write()', () => {
 		it('Replaces the content of documentElement with new content the first time it is called and writes the body part to the body the second time.', () => {
 			const html = `


### PR DESCRIPTION
Fixes #2203

`document.documentElement.replaceWith(newElement)` throws "Only one element on document allowed" because `ChildNodeUtility.replaceWith()` calls `insertBefore(newNode, oldNode)` before `removeChild(oldNode)`. The Document's `insertBefore` check rejects a second element child even though the old one is about to be removed.

Per the DOM spec, `replaceWith` uses the internal insert algorithm which doesn't enforce the one-element-per-document constraint. The fix adds a check: when the reference node in `insertBefore` is itself an element, skip the one-element guard since the reference node will be removed (as in the replaceWith/replaceChild flow).
