### PR TITLE
fix: [#2213] Expose waitForNavigation() on window.happyDOM

### DIFF
--- a/packages/happy-dom/src/window/DetachedWindowAPI.ts
+++ b/packages/happy-dom/src/window/DetachedWindowAPI.ts
@@ -46,6 +46,15 @@ export default class DetachedWindowAPI {
 	}
 
 	/**
+	 * Returns a promise that is resolved when the frame has navigated and the response HTML has been written to the document.
+	 *
+	 * @returns Promise.
+	 */
+	public waitForNavigation(): Promise<void> {
+		return this.#browserFrame.waitForNavigation();
+	}
+
+	/**
 	 * Waits for all async tasks to complete.
 	 *
 	 * @deprecated Use waitUntilComplete() instead.


### PR DESCRIPTION
Fixes #2213

`waitForNavigation()` exists on `DetachedBrowserFrame` and `DetachedBrowserPage` but was not exposed through `DetachedWindowAPI` (`window.happyDOM`). This made it inaccessible from Vitest's `happy-dom` environment where the only entry point to the browser API is `window.happyDOM`.

Added `waitForNavigation()` to `DetachedWindowAPI`, delegating to `this.#browserFrame.waitForNavigation()` — the same delegation pattern already used by `waitUntilComplete()`, `abort()`, and `close()`.
