### PR TITLE
fix: [#2215] Add isTrusted property to Event

### DIFF
--- a/packages/happy-dom/src/event/Event.ts
+++ b/packages/happy-dom/src/event/Event.ts
@@ -22,6 +22,7 @@ export default class Event {
 	public AT_TARGET = Event.AT_TARGET;
 	public BUBBLING_PHASE = Event.BUBBLING_PHASE;
 
+	public readonly isTrusted: boolean;
 	public [PropertySymbol.composed] = false;
 	public [PropertySymbol.bubbles] = false;
 	public [PropertySymbol.cancelable] = false;
@@ -48,6 +49,13 @@ export default class Event {
 		this[PropertySymbol.bubbles] = eventInit?.bubbles ?? false;
 		this[PropertySymbol.cancelable] = eventInit?.cancelable ?? false;
 		this[PropertySymbol.composed] = eventInit?.composed ?? false;
+
+		Object.defineProperty(this, 'isTrusted', {
+			value: false,
+			writable: false,
+			configurable: false,
+			enumerable: true
+		});
 	}
 
 	/**

--- a/packages/happy-dom/test/event/Event.test.ts
+++ b/packages/happy-dom/test/event/Event.test.ts
@@ -354,4 +354,61 @@ describe('Event', () => {
 			expect((<EventTarget[]>(<unknown>composedPath))[4] === window).toBe(true);
 		});
 	});
+
+	describe('get isTrusted()', () => {
+		it('Returns false for programmatically created events.', () => {
+			const event = new Event('click');
+			expect(event.isTrusted).toBe(false);
+		});
+
+		it('Returns false for events dispatched via dispatchEvent.', () => {
+			const div = document.createElement('div');
+			let trusted: boolean | undefined;
+			div.addEventListener('click', (e: Event) => {
+				trusted = e.isTrusted;
+			});
+			div.dispatchEvent(new Event('click'));
+			expect(trusted).toBe(false);
+		});
+
+		it('Cannot be overwritten by assignment.', () => {
+			const event = new Event('click');
+			expect(() => {
+				(<any>event).isTrusted = true;
+			}).toThrow();
+			expect(event.isTrusted).toBe(false);
+		});
+
+		it('Cannot be redefined via Object.defineProperty.', () => {
+			const event = new Event('click');
+			expect(() => {
+				Object.defineProperty(event, 'isTrusted', {
+					value: true,
+					configurable: true
+				});
+			}).toThrow();
+			expect(event.isTrusted).toBe(false);
+		});
+
+		it('Has correct property descriptor.', () => {
+			const event = new Event('click');
+			const descriptor = Object.getOwnPropertyDescriptor(event, 'isTrusted');
+			expect(descriptor).toBeDefined();
+			expect(descriptor!.value).toBe(false);
+			expect(descriptor!.writable).toBe(false);
+			expect(descriptor!.configurable).toBe(false);
+			expect(descriptor!.enumerable).toBe(true);
+		});
+
+		it('Subclass getter is shadowed by instance property.', () => {
+			class SubclassedEvent extends Event {
+				public override get isTrusted(): boolean {
+					return true;
+				}
+			}
+			const event = new SubclassedEvent('click');
+			// The instance property defined in Event constructor shadows the subclass getter
+			expect(event.isTrusted).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
Fixes #2215

`Event.isTrusted` was missing entirely — it returned `undefined` instead of `false`. The property was also writable and configurable, violating the spec.

Fixed by defining `isTrusted` as a non-writable, non-configurable property with value `false` in the Event constructor via `Object.defineProperty`. This matches browser behavior:
- Returns `false` for programmatically created events
- Cannot be overwritten by assignment
- Cannot be redefined via `Object.defineProperty`
- Subclass getters are shadowed by the own instance property
