### PR TITLE
fix: [#2186] Batch requestAnimationFrame callbacks per frame with shared timestamp

### DIFF
--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -875,6 +875,9 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	#zeroDelayTimeout: { timeouts: Array<Timeout> | null } = { timeouts: null };
 	#timerLoopStacks: string[] = [];
 	#timerLoopLimits: ITimerLoopsLimit[] = [];
+	#animationFrameCallbacks: Map<number, (timestamp: number) => void> = new Map();
+	#animationFrameId = 0;
+	#animationFrameImmediate: NodeJS.Immediate | null = null;
 
 	/**
 	 * Constructor.
@@ -2602,9 +2605,9 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	 * @param callback Callback.
 	 * @returns ID.
 	 */
-	public requestAnimationFrame(callback: (timestamp: number) => void): NodeJS.Immediate {
+	public requestAnimationFrame(callback: (timestamp: number) => void): number {
 		if (this.closed) {
-			return <NodeJS.Immediate>{};
+			return 0;
 		}
 		const settings = this.#browserFrame.page.context.browser.settings;
 
@@ -2621,7 +2624,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 						? 1
 						: (settings.timer.preventTimerLoops.requestAnimationFrame ?? 1))
 				) {
-					return <NodeJS.Immediate>{};
+					return 0;
 				}
 			} else {
 				timerLoopStacks.push(stack);
@@ -2632,29 +2635,46 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 			}
 		}
 
-		const useTryCatch =
-			!settings ||
-			(!settings.disableErrorCapturing &&
-				settings.errorCapture === BrowserErrorCaptureEnum.tryAndCatch);
-		const id = TIMER.setImmediate(() => {
-			// We need to call endImmediate() before the callback as the callback might throw an error.
-			this.#browserFrame[PropertySymbol.asyncTaskManager].endImmediate(id);
-			if (useTryCatch) {
-				let result: any;
-				try {
-					result = callback(this.performance.now());
-				} catch (error) {
-					this[PropertySymbol.dispatchError](<Error>error);
+		const handle = ++this.#animationFrameId;
+		this.#animationFrameCallbacks.set(handle, callback);
+
+		if (this.#animationFrameImmediate === null) {
+			const useTryCatch =
+				!settings ||
+				(!settings.disableErrorCapturing &&
+					settings.errorCapture === BrowserErrorCaptureEnum.tryAndCatch);
+
+			const id = TIMER.setImmediate(() => {
+				this.#browserFrame[PropertySymbol.asyncTaskManager].endImmediate(id);
+				this.#animationFrameImmediate = null;
+
+				const timestamp = this.performance.now();
+				for (const currentHandle of [...this.#animationFrameCallbacks.keys()]) {
+					const frameCallback = this.#animationFrameCallbacks.get(currentHandle);
+					if (!frameCallback) {
+						continue;
+					}
+					this.#animationFrameCallbacks.delete(currentHandle);
+					if (useTryCatch) {
+						let result: any;
+						try {
+							result = frameCallback(timestamp);
+						} catch (error) {
+							this[PropertySymbol.dispatchError](<Error>error);
+						}
+						if (result instanceof Promise) {
+							result.catch((error: Error) => this[PropertySymbol.dispatchError](error));
+						}
+					} else {
+						frameCallback(timestamp);
+					}
 				}
-				if (result instanceof Promise) {
-					result.catch((error: Error) => this[PropertySymbol.dispatchError](error));
-				}
-			} else {
-				callback(this.performance.now());
-			}
-		});
-		this.#browserFrame[PropertySymbol.asyncTaskManager].startImmediate(id);
-		return id;
+			});
+			this.#animationFrameImmediate = id;
+			this.#browserFrame[PropertySymbol.asyncTaskManager].startImmediate(id);
+		}
+
+		return handle;
 	}
 
 	/**
@@ -2662,14 +2682,8 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	 *
 	 * @param id ID.
 	 */
-	public cancelAnimationFrame(id: NodeJS.Immediate): void {
-		// We need to make sure that the ID is an Immediate object, otherwise Node.js might throw an error.
-		// This is only necessary if we are in a Node.js environment.
-		if (IS_NODE_JS_TIMEOUT_ENVIRONMENT && (!id || id.constructor.name !== 'Immediate')) {
-			return;
-		}
-		TIMER.clearImmediate(id);
-		this.#browserFrame[PropertySymbol.asyncTaskManager].endImmediate(id);
+	public cancelAnimationFrame(handle: number): void {
+		this.#animationFrameCallbacks.delete(handle);
 	}
 
 	/**

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -1833,7 +1833,8 @@ describe('BrowserWindow', () => {
 		it('Requests an animation frame.', async () => {
 			await new Promise((resolve) => {
 				const timeoutId = window.requestAnimationFrame(resolve);
-				expect(timeoutId.constructor.name).toBe('Immediate');
+				expect(typeof timeoutId).toBe('number');
+				expect(timeoutId).toBeGreaterThan(0);
 			});
 		});
 
@@ -1937,6 +1938,34 @@ describe('BrowserWindow', () => {
 
 			expect(loopCount).toBe(5);
 		});
+
+		it('Runs all callbacks registered for the same frame with a single shared timestamp.', async () => {
+			const timestamps: number[] = [];
+			await new Promise((resolve) => {
+				window.requestAnimationFrame((t) => timestamps.push(t));
+				window.requestAnimationFrame((t) => {
+					timestamps.push(t);
+					resolve(null);
+				});
+			});
+			expect(timestamps).toHaveLength(2);
+			expect(timestamps[0]).toBe(timestamps[1]);
+		});
+
+		it('Defers a callback registered during the frame to the next frame.', async () => {
+			const order: string[] = [];
+			await new Promise((resolve) => {
+				window.requestAnimationFrame(() => {
+					order.push('a');
+					window.requestAnimationFrame(() => {
+						order.push('c');
+						resolve(null);
+					});
+				});
+				window.requestAnimationFrame(() => order.push('b'));
+			});
+			expect(order).toEqual(['a', 'b', 'c']);
+		});
 	});
 
 	describe('cancelAnimationFrame()', () => {
@@ -1948,7 +1977,7 @@ describe('BrowserWindow', () => {
 		});
 
 		it('Supports number values.', () => {
-			window.cancelAnimationFrame(<NodeJS.Immediate>(<unknown>-1));
+			window.cancelAnimationFrame(-1);
 		});
 	});
 


### PR DESCRIPTION
Resolves #2186

### Description

requestAnimationFrame was scheduling a separate setImmediate per call, so callbacks registered for the same frame received different timestamps and ran in separate tasks instead of one atomic pass.

This batches callbacks into a per-frame map, flushed in a single setImmediate with one shared timestamp. Callbacks registered during a frame are deferred to the next frame (snapshot before iterating).

The return type changes from NodeJS.Immediate to number, matching the spec (unsigned long integer) and browser/jsdom behavior.

### Changes
- BrowserWindow.ts: Added animationFrameCallbacks map and animationFrameImmediate for batching. requestAnimationFrame returns number. cancelAnimationFrame removes from map.
- BrowserWindow.test.ts: Updated return type assertion. Added tests for shared timestamp and deferred-callback behavior.
