### PR TITLE
fix [#2152] previousNode() returns null when intervening FILTER_SKIP sibling has text children

### DIFF
--- a/packages/happy-dom/src/tree-walker/TreeWalker.ts
+++ b/packages/happy-dom/src/tree-walker/TreeWalker.ts
@@ -133,7 +133,7 @@ export default class TreeWalker {
 			let sibling = node?.previousSibling || null;
 
 			while (sibling !== null) {
-				let node = sibling;
+				node = sibling;
 				let result = this[PropertySymbol.filterNode](node);
 
 				while (result !== NodeFilter.FILTER_REJECT && node[PropertySymbol.nodeArray].length) {

--- a/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
+++ b/packages/happy-dom/test/tree-walker/TreeWalker.test.ts
@@ -284,6 +284,64 @@ describe('TreeWalker', () => {
 				expectedPreviousNode = currentNode;
 			}
 		});
+
+		it('Returns the previous accepted sibling when an intervening sibling is FILTER_SKIP and contains a text node.', () => {
+			// Regression: when a FILTER_SKIP sibling contains a text child and whatToShow=SHOW_ELEMENT,
+			// previousNode() was descending into the text node via nodeArray and then taking
+			// textNode.previousSibling (null) instead of span.previousSibling, causing it to lose
+			// its position and return null instead of the accepted element before the skipped one.
+			const div = document.createElement('div');
+			div.innerHTML =
+				'<span class="accept">A</span><span class="skip">:</span><span class="accept">B</span>';
+
+			const filter = {
+				acceptNode: (node: Element): number =>
+					node.classList.contains('accept') ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+			};
+
+			const walker = document.createTreeWalker(div, NodeFilter.SHOW_ELEMENT, filter);
+
+			// Forward: a → b
+			expect((<Element>walker.nextNode()).id).toBe('');
+			expect((<Element>walker.nextNode()).textContent).toBe('B');
+
+			// Backward from b: must find a, not null
+			const prev = walker.previousNode();
+			expect(prev).not.toBeNull();
+			expect((<Element>prev).textContent).toBe('A');
+		});
+
+		it('Returns the previous accepted sibling when currentNode is set directly and an intervening sibling is FILTER_SKIP with a text child.', () => {
+			const div = document.createElement('div');
+
+			const a = document.createElement('span');
+			a.className = 'accept';
+			a.textContent = 'A';
+
+			const skip = document.createElement('span');
+			skip.className = 'skip';
+			skip.textContent = ':';
+
+			const b = document.createElement('span');
+			b.className = 'accept';
+			b.textContent = 'B';
+
+			div.appendChild(a);
+			div.appendChild(skip);
+			div.appendChild(b);
+
+			const filter = {
+				acceptNode: (node: Element): number =>
+					node.classList.contains('accept') ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+			};
+
+			const walker = document.createTreeWalker(div, NodeFilter.SHOW_ELEMENT, filter);
+			walker.currentNode = <Node>(<unknown>b);
+
+			const prev = walker.previousNode();
+			expect(prev).not.toBeNull();
+			expect((<Element>prev).textContent).toBe('A');
+		});
 	});
 
 	describe('parentNode()', () => {


### PR DESCRIPTION
## What

`TreeWalker.previousNode()` incorrectly returns `null` when walking backward past a `FILTER_SKIP` sibling that contains a text child node and `whatToShow` is set to `SHOW_ELEMENT`.

## Minimal reproduction

```js
const div = document.createElement('div');
div.innerHTML = '<span class="a">A</span><span class="sep">:</span><span class="b">B</span>';

const walker = document.createTreeWalker(div, NodeFilter.SHOW_ELEMENT, {
  acceptNode: node =>
    node.classList.contains('a') || node.classList.contains('b')
      ? NodeFilter.FILTER_ACCEPT
      : NodeFilter.FILTER_SKIP
});

walker.nextNode(); // span.a
walker.nextNode(); // span.b

walker.previousNode(); // returns null, expected span.a
```

## Root cause

The inner `while (sibling !== null)` loop declared `let node = sibling`, shadowing the outer `node` variable. After descending into the children of the skip-filtered sibling via `nodeArray`, the algorithm lands on the text node `":"`. Because text nodes have no element siblings within their parent, `node.previousSibling` is `null` and the inner loop exits early.

When control returns to the outer `while`, the outer `node` still points to the original `currentNode` rather than the text node we descended into. So `node.parentNode` climbs to the wrong ancestor and the correct previous sibling is never visited.

The WHATWG spec (https://dom.spec.whatwg.org/#dom-treewalker-previousnode) uses a single `node` variable throughout the algorithm. After the inner loop exits, `node.parentNode` is expected to backtrack from the deepest descendant visited, not from the original `currentNode`.

## Fix

Remove the `let` from `let node = sibling` inside the inner loop so both loops share the same variable, matching the spec algorithm.

```diff
- let node = sibling;
+ node = sibling;
```

## Testing

Two regression tests added to `TreeWalker.test.ts`:
- `previousNode()` after `nextNode()` traversal through a FILTER_SKIP+text sibling
- `previousNode()` after setting `currentNode` directly

## Relevant issue

Fixes https://github.com/capricorn86/happy-dom/issues/2152