### PR TITLE
chore: avoid eager DOMException construction when parsing selectors

### DIFF
--- a/packages/happy-dom/src/query-selector/SelectorParser.ts
+++ b/packages/happy-dom/src/query-selector/SelectorParser.ts
@@ -4,6 +4,7 @@ import type ISelectorPseudo from './ISelectorPseudo.js';
 import type Element from '../nodes/element/Element.js';
 import type DocumentFragment from '../nodes/document-fragment/DocumentFragment.js';
 import type BrowserWindow from '../window/BrowserWindow.js';
+import type DOMException from '../exception/DOMException.js';
 import NodeTypeEnum from '../nodes/node/NodeTypeEnum.js';
 import * as PropertySymbol from '../PropertySymbol.js';
 
@@ -143,6 +144,22 @@ export default class SelectorParser {
 	}
 
 	/**
+	 * Returns an error for an invalid selector.
+	 *
+	 * Constructed lazily, as creating a DOMException captures the current stack trace, which is
+	 * expensive on hot paths such as Element.matches() and getComputedStyle() during rendering.
+	 *
+	 * @param selector Selector.
+	 * @returns Error.
+	 */
+	private getInvalidSelectorError(selector: string): DOMException {
+		const name = this.scope.nodeType === NodeTypeEnum.documentNode ? 'Document' : 'Element';
+		return new this.window.DOMException(
+			`Failed to execute 'querySelectorAll' on '${name}': '${selector}' is not a valid selector.`
+		);
+	}
+
+	/**
 	 * Parses a selector string and returns instances of SelectorItem without using cache.
 	 *
 	 * @param selector Selector.
@@ -158,10 +175,6 @@ export default class SelectorParser {
 			doubleApostrophe: 0,
 			singleApostrophe: 0
 		};
-		const name = this.scope.nodeType === NodeTypeEnum.documentNode ? 'Document' : 'Element';
-		const error = new this.window.DOMException(
-			`Failed to execute 'querySelectorAll' on '${name}': '${selector}' is not a valid selector.`
-		);
 		let match: null | RegExpExecArray = null;
 		let lastIndex = 0;
 		let selectorItem: SelectorItem | null = null;
@@ -187,7 +200,7 @@ export default class SelectorParser {
 								if (this.ignoreErrors) {
 									return [];
 								}
-								throw error;
+								throw this.getInvalidSelectorError(selector);
 							}
 							currentGroup.push(selectorItem);
 							currentGroup = [];
@@ -200,7 +213,7 @@ export default class SelectorParser {
 								if (this.ignoreErrors) {
 									return [];
 								}
-								throw error;
+								throw this.getInvalidSelectorError(selector);
 							}
 							currentGroup.push(selectorItem);
 							combinator = SelectorCombinatorEnum.child;
@@ -211,7 +224,7 @@ export default class SelectorParser {
 								if (this.ignoreErrors) {
 									return [];
 								}
-								throw error;
+								throw this.getInvalidSelectorError(selector);
 							}
 							currentGroup.push(selectorItem);
 							combinator = SelectorCombinatorEnum.adjacentSibling;
@@ -222,7 +235,7 @@ export default class SelectorParser {
 								if (this.ignoreErrors) {
 									return [];
 								}
-								throw error;
+								throw this.getInvalidSelectorError(selector);
 							}
 							currentGroup.push(selectorItem);
 							combinator = SelectorCombinatorEnum.subsequentSibling;
@@ -233,7 +246,7 @@ export default class SelectorParser {
 								if (this.ignoreErrors) {
 									return [];
 								}
-								throw error;
+								throw this.getInvalidSelectorError(selector);
 							}
 							currentGroup.push(selectorItem);
 							combinator = SelectorCombinatorEnum.descendant;
@@ -291,7 +304,7 @@ export default class SelectorParser {
 			if (this.ignoreErrors) {
 				return [];
 			}
-			throw error;
+			throw this.getInvalidSelectorError(selector);
 		}
 
 		if (combinator === SelectorCombinatorEnum.none && currentGroup.length > 0) {


### PR DESCRIPTION
### Description

`SelectorParser.getSelectorGroupsUncached()` constructs the invalid-selector `DOMException` **eagerly on every parse**, even when the selector is perfectly valid and the error is never thrown. Constructing the exception captures the current stack trace, which is expensive when the call stack is deep — exactly the situation on hot paths such as `Element.matches()` (used by every `@testing-library` text query) and `getComputedStyle()` → CSS-rule selector matching (hit by Radix UI's `Presence` and `react-remove-scroll` during React rendering).

This PR makes the construction lazy: the `DOMException` is only created at the point where the selector actually fails to parse. No behavior change — invalid selectors still throw the exact same exception; the `ignoreErrors` paths are untouched.

**Measured impact** (CPU profile of a downstream React 19 + happy-dom + Vitest suite, one 25-test file): `DOMException` construction under `getSelectorGroups` accounted for **216 ms of 1 520 ms** total test self-time (~14%). After applying this change (as a patch to the published build), the file's wall time dropped from 1 657 ms → 1 480 ms without coverage and 2 312 ms → 1 988 ms with V8 coverage, with interaction-heavy tests improving the most. The full downstream suite (2 974 tests, heavily happy-dom based) stays green with the patch applied.

Note: the `querySelectorCache` on master already avoids re-parsing repeated selectors, but the eager construction still costs on every first parse per selector per `Window` — test runners typically create many windows, and CSS rule matching + RTL queries produce many distinct selectors.

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. *(No pre-existing issue — happy to open one if preferred.)*
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests

- [x] Behavior is unchanged and already covered by the existing invalid-selector tests (`QuerySelector.test.ts` asserts the thrown `DOMException` for malformed selectors). I did not add a new test because the only observable difference is *when* the exception object is allocated; if you'd like a regression test that counts `DOMException` constructions for valid selectors, I'm happy to add one.
- [ ] `npm test` was **not** run locally (restricted sandbox on my side) — relying on PR CI here; the change was validated downstream by applying the equivalent patch to the published `20.10.2` build under a 2 974-test suite. Apologies, and happy to follow up on any CI findings.

### AI disclosure

Prepared with assistance from Claude Code (Anthropic); reviewed, measured, and submitted by me.
