### PR TITLE
fix: [#2231] Fixes SVG style/script raw text elements dropping remaining document content in HTMLParser

### DIFF
--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -779,7 +779,14 @@ export default class HTMLParser {
 	private parseRawTextElementContent(tagName: string, text: string): void {
 		const upperTagName = StringUtility.asciiUpperCase(tagName);
 
-		if (upperTagName !== (<Element>this.currentNode)[PropertySymbol.tagName]) {
+		// SVG (and other foreign-content) elements preserve their original tag name case (e.g.
+		// "style"), unlike HTML elements whose tagName is always upper-cased. Comparing both sides
+		// upper-cased keeps foreign raw text elements matching their own closing tag, instead of
+		// never matching and silently absorbing the rest of the document.
+		if (
+			upperTagName !==
+			StringUtility.asciiUpperCase((<Element>this.currentNode)[PropertySymbol.tagName] ?? '')
+		) {
 			return;
 		}
 

--- a/packages/happy-dom/test/html-parser/HTMLParser.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.test.ts
@@ -436,6 +436,23 @@ describe('HTMLParser', () => {
 			);
 		});
 
+		it('Does not lose a <style> or <script> element (or its following siblings) inside an SVG.', () => {
+			const result = new HTMLParser(window).parse(
+				`<div>
+					<svg xmlns="${NamespaceURI.svg}">
+						<style>.a{fill:red}</style>
+						<g><rect x="1" y="2" width="3" height="4"></rect></g>
+					</svg>
+				</div>`
+			);
+			const svg = result.children[0].children[0];
+
+			expect(svg.children.length).toBe(2);
+			expect(svg.children[0].tagName).toBe('style');
+			expect(svg.children[0].textContent).toBe('.a{fill:red}');
+			expect(svg.children[1].tagName).toBe('g');
+		});
+
 		it('Handles unclosed regular elements.', () => {
 			const result = new HTMLParser(window).parse(`<div>test`);
 


### PR DESCRIPTION
### Description

Resolves #2231 for non-self-closed tags using the suggested fix in that issue: upper-casing both sides of the tag name comparison in `HTMLParser.parseRawTextElementContent`.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.
