### PR TITLE
fix: [#2231] Fixes SVG style/script self-closed elements being dropped in HTMLParser

### DIFF
--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -589,6 +589,12 @@ export default class HTMLParser {
 			}
 		}
 
+		// Elements in the SVG namespace can be self-closed (e.g. "/>"), which immediately closes
+		// them below without ever reaching `parseRawTextElementContent`. "/>" is ignored in the
+		// HTML namespace, so only foreign (SVG) elements are affected.
+		const isSelfClosedForeignElement =
+			isSelfClosed && this.nextElement![PropertySymbol.namespaceURI] === NamespaceURI.svg;
+
 		// Appends the new element to its parent
 		if (this.documentStructure) {
 			const { documentElement, head, body } = this.documentStructure.nodes;
@@ -597,15 +603,15 @@ export default class HTMLParser {
 
 			// Raw text elements (e.g. <script>) should be appended after the raw text has been added as content to the element.
 			// <html>, <head> and <body> are special elements with context constraints. They are already available in the document.
-			// Self-closed foreign (SVG) raw text elements (e.g. "<style/>") never reach
-			// `parseRawTextElementContent` - they are closed immediately below via the
-			// `isSelfClosed && namespaceURI === svg` branch - so deferring their append to that
-			// function, as is correct for ordinary non-self-closed raw text elements, would mean
-			// they are silently never appended at all. Append them here instead.
+			// Self-closed foreign raw text elements (e.g. "<style/>") never reach
+			// `parseRawTextElementContent` - they are closed immediately below via
+			// `isSelfClosedForeignElement` - so deferring their append to that function, as is
+			// correct for ordinary non-self-closed raw text elements, would mean they are silently
+			// never appended at all. Append them here instead.
 			if (
 				(!config ||
 					config.contentModel !== HTMLElementConfigContentModelEnum.rawText ||
-					(isSelfClosed && this.nextElement![PropertySymbol.namespaceURI] === NamespaceURI.svg)) &&
+					isSelfClosedForeignElement) &&
 				this.nextElement !== documentElement &&
 				this.nextElement !== head &&
 				this.nextElement !== body
@@ -645,12 +651,9 @@ export default class HTMLParser {
 			}
 
 			// Check if the tag is a void element and should be closed immediately.
-			// Elements in the SVG namespace can be self-closed (e.g. "/>").
-			// "/>" will be ignored in the HTML namespace.
 			if (
 				config?.contentModel === HTMLElementConfigContentModelEnum.noDescendants ||
-				(isSelfClosed &&
-					(<Element>this.currentNode)[PropertySymbol.namespaceURI] === NamespaceURI.svg)
+				isSelfClosedForeignElement
 			) {
 				this.nodeStack.pop();
 				this.tagNameStack.pop();

--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -597,8 +597,15 @@ export default class HTMLParser {
 
 			// Raw text elements (e.g. <script>) should be appended after the raw text has been added as content to the element.
 			// <html>, <head> and <body> are special elements with context constraints. They are already available in the document.
+			// Self-closed foreign (SVG) raw text elements (e.g. "<style/>") never reach
+			// `parseRawTextElementContent` - they are closed immediately below via the
+			// `isSelfClosed && namespaceURI === svg` branch - so deferring their append to that
+			// function, as is correct for ordinary non-self-closed raw text elements, would mean
+			// they are silently never appended at all. Append them here instead.
 			if (
-				(!config || config.contentModel !== HTMLElementConfigContentModelEnum.rawText) &&
+				(!config ||
+					config.contentModel !== HTMLElementConfigContentModelEnum.rawText ||
+					(isSelfClosed && this.nextElement![PropertySymbol.namespaceURI] === NamespaceURI.svg)) &&
 				this.nextElement !== documentElement &&
 				this.nextElement !== head &&
 				this.nextElement !== body

--- a/packages/happy-dom/test/html-parser/HTMLParser.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.test.ts
@@ -436,6 +436,22 @@ describe('HTMLParser', () => {
 			);
 		});
 
+		it('Does not lose a self-closed <style> or <script> element inside an SVG.', () => {
+			const result = new HTMLParser(window).parse(
+				`<div>
+					<svg xmlns="${NamespaceURI.svg}">
+						<style/>
+						<g><rect x="1" y="2" width="3" height="4"></rect></g>
+					</svg>
+				</div>`
+			);
+			const svg = result.children[0].children[0];
+
+			expect(svg.children.length).toBe(2);
+			expect(svg.children[0].tagName).toBe('style');
+			expect(svg.children[1].tagName).toBe('g');
+		});
+
 		it('Handles unclosed regular elements.', () => {
 			const result = new HTMLParser(window).parse(`<div>test`);
 


### PR DESCRIPTION
### Description

Resolves an issue where self-closed script/style elements in the SVG namespace would be dropped.

Resolves the more minor part of #2231.

I elected to split this change into a different PR (from #2234) as the bug doesn't personally impact me and such elements are admittedly relatively weird.

It does seem plausible that someone might care about these elements if they dynamically inject content into the DOM node based on an id. But it's pretty niche.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.
