### PR TITLE
fix: [#2239] Return opaque-redirect response for manual redirect mode

### DIFF
--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -555,6 +555,7 @@ export default class Fetch {
 				if (
 					!this.disableCache &&
 					response instanceof Response &&
+					response.type !== 'opaqueredirect' &&
 					this.#browserFrame.page &&
 					this.#browserFrame.page.context
 				) {
@@ -579,7 +580,11 @@ export default class Fetch {
 					interceptedResponse instanceof Response ? interceptedResponse : response;
 
 				// The browser outputs errors to the console when the response is not ok.
-				if (returnResponse instanceof Response && !returnResponse.ok) {
+				if (
+					returnResponse instanceof Response &&
+					!returnResponse.ok &&
+					returnResponse.type !== 'opaqueredirect'
+				) {
 					this.#browserFrame.page.console.error(
 						`${this.request.method} ${this.request.url} ${returnResponse.status} (${returnResponse.statusText})`
 					);

--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -918,9 +918,18 @@ export default class Fetch {
 					)
 				);
 				return true;
-			case 'manual':
-				// Nothing to do
-				return false;
+			case 'manual': {
+				// A "manual" redirect produces an opaque-redirect filtered response:
+				// status 0, empty status text, empty headers and a null body. Only the
+				// URL list is preserved, so "url" still reflects the requested URL.
+				// @see https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect
+				this.finalizeRequest();
+				this.response = new this.#window.Response(null, { status: 0 });
+				(<string>this.response.type) = 'opaqueredirect';
+				(<string>this.response.url) = this.request.url;
+				this.resolve!(this.response);
+				return true;
+			}
 			case 'follow':
 				const locationHeader = responseHeaders.get('Location');
 				const shouldBecomeGetRequest =

--- a/packages/happy-dom/src/fetch/SyncFetch.ts
+++ b/packages/happy-dom/src/fetch/SyncFetch.ts
@@ -561,7 +561,7 @@ export default class SyncFetch {
 			: undefined;
 		const returnResponse =
 			typeof interceptedResponse === 'object' ? interceptedResponse : redirectedResponse;
-		if (!returnResponse.ok) {
+		if (!returnResponse.ok && returnResponse.type !== 'opaqueredirect') {
 			this.#browserFrame.page.console.error(
 				`${this.request.method} ${this.request.url} ${returnResponse.status} (${returnResponse.statusText})`
 			);

--- a/packages/happy-dom/src/fetch/SyncFetch.ts
+++ b/packages/happy-dom/src/fetch/SyncFetch.ts
@@ -537,7 +537,11 @@ export default class SyncFetch {
 
 		const redirectedResponse = this.handleRedirectResponse(response) || response;
 
-		if (!this.disableCache && !redirectedResponse.redirected) {
+		if (
+			!this.disableCache &&
+			!redirectedResponse.redirected &&
+			redirectedResponse.type !== 'opaqueredirect'
+		) {
 			this.#browserFrame.page.context.responseCache.add(this.request, {
 				status: <number>redirectedResponse.status,
 				statusText: <string>redirectedResponse.statusText,
@@ -635,7 +639,20 @@ export default class SyncFetch {
 					DOMExceptionNameEnum.abortError
 				);
 			case 'manual':
-				return null;
+				// A "manual" redirect produces an opaque-redirect filtered response:
+				// status 0, empty status text, empty headers and a null body. Only the
+				// URL list is preserved, so "url" still reflects the requested URL.
+				// @see https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect
+				return {
+					status: 0,
+					statusText: '',
+					ok: false,
+					url: this.request.url,
+					redirected: false,
+					type: 'opaqueredirect',
+					headers: new this.#window.Headers(),
+					body: null
+				};
 			case 'follow':
 				const locationHeader = response.headers.get('Location');
 				const shouldBecomeGetRequest =

--- a/packages/happy-dom/src/fetch/types/ISyncResponse.ts
+++ b/packages/happy-dom/src/fetch/types/ISyncResponse.ts
@@ -12,6 +12,7 @@ export default interface ISyncResponse {
 	ok: boolean;
 	url: string;
 	redirected: boolean;
+	type?: 'basic' | 'cors' | 'default' | 'error' | 'opaque' | 'opaqueredirect';
 	headers: Headers;
 	body: Buffer | null;
 	[PropertySymbol.virtualServerFile]?: string | null;

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -815,7 +815,7 @@ describe('Fetch', () => {
 			expect(tryCount).toBe(20 + 1);
 		});
 
-		it('Should support "manual" redirect mode.', async () => {
+		it('Should return an opaque-redirect response for "manual" redirect mode.', async () => {
 			const window = new Window({ url: 'https://localhost:8080/' });
 			const url = 'https://localhost:8080/test/';
 			const redirectURL = 'https://localhost:8080/redirect/';
@@ -830,11 +830,18 @@ describe('Fetch', () => {
 
 			const response = await window.fetch(url, { method: 'GET', redirect: 'manual' });
 
-			expect(response.status).toBe(301);
-			expect(response.headers.get('location')).toBe(redirectURL);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
+			expect(response.statusText).toBe('');
+			expect(response.ok).toBe(false);
+			expect(response.redirected).toBe(false);
+			expect(response.url).toBe(url);
+			expect(response.headers.get('location')).toBe(null);
+			expect([...response.headers]).toEqual([]);
+			expect(response.body).toBe(null);
 		});
 
-		it('Should support "manual" redirect mode with broken location header.', async () => {
+		it('Should mask a broken location header in "manual" redirect mode.', async () => {
 			const window = new Window({ url: 'https://localhost:8080/' });
 			const url = 'https://localhost:8080/test/';
 			const redirectURL = '<>';
@@ -848,11 +855,12 @@ describe('Fetch', () => {
 
 			const response = await window.fetch(url, { method: 'GET', redirect: 'manual' });
 
-			expect(response.status).toBe(301);
-			expect(response.headers.get('location')).toBe(redirectURL);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
+			expect(response.headers.get('location')).toBe(null);
 		});
 
-		it('Should support "manual" redirect mode to other host.', async () => {
+		it('Should return an opaque-redirect response for cross-host "manual" redirect mode.', async () => {
 			const window = new Window({ url: 'https://localhost:8080/' });
 			const url = 'https://localhost:8080/test/';
 			const redirectURL = 'https://example.com/redirect/';
@@ -866,11 +874,13 @@ describe('Fetch', () => {
 
 			const response = await window.fetch(url, { method: 'GET', redirect: 'manual' });
 
-			expect(response.status).toBe(301);
-			expect(response.headers.get('location')).toBe(redirectURL);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
+			expect(response.url).toBe(url);
+			expect(response.headers.get('location')).toBe(null);
 		});
 
-		it('Should treat missing location header as a normal response (manual).', async () => {
+		it('Should return an opaque-redirect response for "manual" redirect mode even without a location header.', async () => {
 			const window = new Window({ url: 'https://localhost:8080/' });
 			const url = 'https://localhost:8080/test/';
 
@@ -882,7 +892,8 @@ describe('Fetch', () => {
 
 			const response = await window.fetch(url, { method: 'GET', redirect: 'manual' });
 
-			expect(response.status).toBe(301);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
 		});
 
 		it('Should support "error" redirect.', async () => {

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -896,6 +896,30 @@ describe('Fetch', () => {
 			expect(response.status).toBe(0);
 		});
 
+		it('Should not cache an opaque-redirect response even when the redirect has cache headers (manual).', async () => {
+			const window = new Window({ url: 'https://localhost:8080/' });
+			const url = 'https://localhost:8080/test/';
+			const redirectURL = 'https://localhost:8080/redirect/';
+
+			const network = mockNetwork('https', {
+				responseProperties: {
+					statusCode: 301,
+					statusMessage: 'Moved Permanently',
+					rawHeaders: ['Location', redirectURL, 'Cache-Control', 'max-age=60']
+				}
+			});
+
+			const first = await window.fetch(url, { method: 'GET', redirect: 'manual' });
+			const second = await window.fetch(url, { method: 'GET', redirect: 'manual' });
+
+			expect(first.type).toBe('opaqueredirect');
+			expect(second.type).toBe('opaqueredirect');
+			expect(second.status).toBe(0);
+			// Both requests must reach the network; a cached opaque-redirect would
+			// have served the second request without a second network call.
+			expect(network.requestHistory.length).toBe(2);
+		});
+
 		it('Should support "error" redirect.', async () => {
 			const window = new Window({ url: 'https://localhost:8080/' });
 			const url = 'https://localhost:8080/test/';

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -1377,6 +1377,50 @@ describe('SyncFetch', () => {
 			expect(response.status).toBe(0);
 		});
 
+		it('Should not cache an opaque-redirect response even when the redirect has cache headers (manual).', () => {
+			browserFrame.url = 'https://localhost:8080/';
+
+			const url = 'https://localhost:8080/test/';
+			const redirectURL = 'https://localhost:8080/redirect/';
+			let callCount = 0;
+
+			mockModule('child_process', {
+				execFileSync: () => {
+					callCount++;
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: 301,
+							statusMessage: 'Moved Permanently',
+							rawHeaders: ['Location', redirectURL, 'Cache-Control', 'max-age=60'],
+							data: ''
+						}
+					});
+				}
+			});
+
+			const first = new SyncFetch({
+				browserFrame,
+				window,
+				url,
+				init: { redirect: 'manual' }
+			}).send();
+
+			const second = new SyncFetch({
+				browserFrame,
+				window,
+				url,
+				init: { redirect: 'manual' }
+			}).send();
+
+			expect(first.type).toBe('opaqueredirect');
+			expect(second.type).toBe('opaqueredirect');
+			expect(second.status).toBe(0);
+			// Both requests must reach the network; a cached opaque-redirect would
+			// have served the second request without a second execFileSync call.
+			expect(callCount).toBe(2);
+		});
+
 		it('Should support "error" redirect.', () => {
 			browserFrame.url = 'https://localhost:8080/';
 

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -1240,7 +1240,7 @@ describe('SyncFetch', () => {
 			expect(tryCount).toBe(20 + 1);
 		});
 
-		it('Should support "manual" redirect mode.', () => {
+		it('Should return an opaque-redirect response for "manual" redirect mode.', () => {
 			browserFrame.url = 'https://localhost:8080/';
 
 			const url = 'https://localhost:8080/test/';
@@ -1268,11 +1268,18 @@ describe('SyncFetch', () => {
 				}
 			}).send();
 
-			expect(response.status).toBe(301);
-			expect(response.headers.get('location')).toBe(redirectURL);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
+			expect(response.statusText).toBe('');
+			expect(response.ok).toBe(false);
+			expect(response.redirected).toBe(false);
+			expect(response.url).toBe(url);
+			expect(response.headers.get('location')).toBe(null);
+			expect([...response.headers]).toEqual([]);
+			expect(response.body).toBe(null);
 		});
 
-		it('Should support "manual" redirect mode with broken location header.', () => {
+		it('Should mask a broken location header in "manual" redirect mode.', () => {
 			browserFrame.url = 'https://localhost:8080/';
 
 			const url = 'https://localhost:8080/test/';
@@ -1300,11 +1307,12 @@ describe('SyncFetch', () => {
 				}
 			}).send();
 
-			expect(response.status).toBe(301);
-			expect(response.headers.get('location')).toBe(redirectURL);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
+			expect(response.headers.get('location')).toBe(null);
 		});
 
-		it('Should support "manual" redirect mode to other host.', () => {
+		it('Should return an opaque-redirect response for cross-host "manual" redirect mode.', () => {
 			browserFrame.url = 'https://localhost:8080/';
 
 			const url = 'https://localhost:8080/test/';
@@ -1332,11 +1340,13 @@ describe('SyncFetch', () => {
 				}
 			}).send();
 
-			expect(response.status).toBe(301);
-			expect(response.headers.get('location')).toBe(redirectURL);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
+			expect(response.url).toBe(url);
+			expect(response.headers.get('location')).toBe(null);
 		});
 
-		it('Should treat missing location header as a normal response (manual).', () => {
+		it('Should return an opaque-redirect response for "manual" redirect mode even without a location header.', () => {
 			browserFrame.url = 'https://localhost:8080/';
 
 			const url = 'https://localhost:8080/test/';
@@ -1363,7 +1373,8 @@ describe('SyncFetch', () => {
 				}
 			}).send();
 
-			expect(response.status).toBe(301);
+			expect(response.type).toBe('opaqueredirect');
+			expect(response.status).toBe(0);
 		});
 
 		it('Should support "error" redirect.', () => {


### PR DESCRIPTION
### Description

`fetch(..., { redirect: 'manual' })` now returns an opaque-redirect response when it hits a redirect, instead of leaking the raw 3xx (status, status text, and headers including `Location`). The response is masked to match browsers and the Fetch spec: `type: 'opaqueredirect'`, `status: 0`, empty status text, empty headers, `null` body, `redirected: false`, and `url` set to the requested URL. Both the async (`Fetch`) and sync (`SyncFetch`, used by `XMLHttpRequest`) paths are covered.

Upon review, I also caught a related caching bug: when a redirect carried caching headers (`Cache-Control`/`ETag`/`Expires`), the async path stored the masked `status: 0` response together with the original 3xx headers, so a later request could be served a corrupted response. Opaque-redirect responses are no longer cached, and the misleading "not ok" console error is skipped for them.

This handles redirects only. `mode: 'no-cors'` opaque responses (`type: 'opaque'`) are out of scope.

Note: debated whether this should have a BREAKING CHANGE header/prefix etc - it _will_ be breaking for people, but it does follow the _spec_ now - so I guess it depends on how you see it.

Resolves #2239

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

_AI disclosure: implemented with Claude Code, reviewed and tested by me._
