### PR TITLE
fix: [#2229] Fix Element.setAttribute() to accept names containing a colon (e.g. hx-on:click)

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -2050,12 +2050,13 @@ export default class Document extends Node {
 		// We should use the NodeFactory and not the class constructor, so that owner document will be this document
 		const attribute = NodeFactory.createNode(this, this[PropertySymbol.window].Attr);
 
+		// Per spec, createAttribute() (unlike createAttributeNS()) never derives a namespace
+		// prefix from the qualified name — the name is kept whole even if it contains a colon.
 		const name = StringUtility.asciiLowerCase(qualifiedName);
-		const parts = name.split(':');
 
 		attribute[PropertySymbol.name] = name;
-		attribute[PropertySymbol.localName] = parts[1] ?? name;
-		attribute[PropertySymbol.prefix] = parts[1] ? parts[0] : null;
+		attribute[PropertySymbol.localName] = name;
+		attribute[PropertySymbol.prefix] = null;
 
 		return attribute;
 	}

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -1284,6 +1284,17 @@ describe('Document', () => {
 			expect(attribute.ownerElement === null).toBe(true);
 			expect(attribute.ownerDocument === document).toBe(true);
 		});
+
+		it('Does not derive a namespace prefix from a colon in the qualified name.', () => {
+			// Unlike createAttributeNS(), createAttribute() must keep the qualified name whole,
+			// even if it contains a colon (e.g. custom attributes like "hx-on:click").
+			const attribute = document.createAttribute('foo:bar');
+
+			expect(attribute.name).toBe('foo:bar');
+			expect(attribute.localName).toBe('foo:bar');
+			expect(attribute.prefix).toBe(null);
+			expect(attribute.namespaceURI).toBe(null);
+		});
 	});
 
 	describe('createAttributeNS()', () => {

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -1867,9 +1867,9 @@ describe('Element', () => {
 			expect(element.getAttributeNames()).toEqual(['global:local1', 'key1', 'key2']);
 		});
 
-		it('Returns attribute names using the same local name with different prefix.', () => {
-			element.setAttribute('ns1:key', 'value1');
-			element.setAttribute('ns2:key', 'value1');
+		it('Returns attribute names using the same local name with different prefix and namespace.', () => {
+			element.setAttributeNS(NAMESPACE_URI, 'ns1:key', 'value1');
+			element.setAttributeNS(NAMESPACE_URI + '2', 'ns2:key', 'value1');
 			element.setAttribute('key1', 'value1');
 			element.setAttribute('key2', '');
 			expect(element.getAttributeNames()).toEqual(['ns1:key', 'ns2:key', 'key1', 'key2']);

--- a/packages/happy-dom/test/nodes/element/NamedNodeMap.test.ts
+++ b/packages/happy-dom/test/nodes/element/NamedNodeMap.test.ts
@@ -196,6 +196,17 @@ describe('NamedNodeMap', () => {
 			expect(element.getAttribute('key')).toBe('value2');
 		});
 
+		it('Replaces an attribute whose name contains a colon but has no namespace.', () => {
+			// Regression test: names like "hx-on:click" aren't namespaced (no prefix is
+			// registered for "hx-on"), so re-setting them must still replace the previous
+			// value instead of accumulating stale duplicates.
+			element.setAttribute('hx-on:click', 'value1');
+			element.setAttribute('hx-on:click', 'value2');
+
+			expect(element.getAttribute('hx-on:click')).toBe('value2');
+			expect(element.getAttributeNames()).toEqual(['hx-on:click']);
+		});
+
 		it("Doesn't replace item with different namespace.", () => {
 			element.setAttribute('key', 'value1');
 			const attr = document.createAttributeNS('namespace', 'key');

--- a/packages/happy-dom/test/nodes/element/NamedNodeMap.test.ts
+++ b/packages/happy-dom/test/nodes/element/NamedNodeMap.test.ts
@@ -52,8 +52,8 @@ describe('NamedNodeMap', () => {
 		});
 
 		it('Returns iterator using the same local name with different prefix.', () => {
-			element.setAttribute('ns1:key', 'value1');
-			element.setAttribute('ns2:key', 'value1');
+			element.setAttributeNS('namespace', 'ns1:key', 'value1');
+			element.setAttributeNS('namespace2', 'ns2:key', 'value1');
 			element.setAttribute('key1', 'value1');
 			element.setAttribute('key2', '');
 
@@ -112,8 +112,8 @@ describe('NamedNodeMap', () => {
 		});
 
 		it('Returns item by index using the same local name with different prefix.', () => {
-			element.setAttribute('ns1:key', 'value1');
-			element.setAttribute('ns2:key', 'value1');
+			element.setAttributeNS('namespace', 'ns1:key', 'value1');
+			element.setAttributeNS('namespace2', 'ns2:key', 'value1');
 			element.setAttribute('key1', 'value1');
 			element.setAttribute('key2', '');
 


### PR DESCRIPTION
### Description

Resolves #2229

`Document.createAttribute()` (and, through it, `Element.setAttribute()`'s HTML-namespace path) was splitting the qualified name on `:` into `prefix`/`localName`, even though that's only correct for `createAttributeNS()`/`setAttributeNS()`. Per spec, plain `createAttribute()` must keep the qualified name whole, with `prefix = null` and no namespace.

This produced an `Attr` with a `prefix` but no `namespaceURI` — a combination `NamedNodeMap#getNamedItemNS()` correctly refuses to resolve, since real namespaced attributes always have both. That made `setNamedItem()` unable to find the previous attribute to replace, so it kept appending instead of overwriting: `getAttribute()` on any colon-containing, non-namespaced attribute name (e.g. `hx-on:click`, used by htmx 4, or any custom `foo:bar`-style attribute) would forever return the very first value ever set via `setAttribute()`, no matter how many times it was called afterward.

Fix: `createAttribute()` now always sets `localName` to the full qualified name and `prefix` to `null`, matching the DOM spec and real browser behavior. `createAttributeNS()`/`setAttributeNS()` are untouched — they already implement the namespace-aware split correctly.

Also tidied up three existing tests (`Element.test.ts` / `NamedNodeMap.test.ts`) that were titled around "same local name, different prefix" but exercised via plain `setAttribute()` — which never namespaces anything, so they weren't actually testing that case. Rewrote them to use `setAttributeNS()` with real distinct namespaces, which was previously uncovered.

<!-- PLEASE DON'T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

## AI disclosure

Per the project's AI Contributions policy: Claude (Anthropic) assisted in diagnosing the bug, writing the fix, and drafting this description. I guided and reviewed the change myself at every step.
```