### PR TITLE
fix: [#2247] Improved contenteditable focus and selection behavior

### DIFF
--- a/packages/happy-dom/src/event/events/IInputEventInit.ts
+++ b/packages/happy-dom/src/event/events/IInputEventInit.ts
@@ -1,9 +1,11 @@
 import type DataTransfer from '../DataTransfer.js';
 import type IUIEventInit from '../IUIEventInit.js';
+import type StaticRange from '../../range/StaticRange.js';
 
 export default interface IInputEventInit extends IUIEventInit {
 	inputType?: string;
 	data?: string;
 	dataTransfer?: DataTransfer;
 	isComposing?: boolean;
+	targetRanges?: StaticRange[];
 }

--- a/packages/happy-dom/src/event/events/InputEvent.ts
+++ b/packages/happy-dom/src/event/events/InputEvent.ts
@@ -1,5 +1,6 @@
 import type DataTransfer from '../DataTransfer.js';
 import UIEvent from '../UIEvent.js';
+import type StaticRange from '../../range/StaticRange.js';
 import type IInputEventInit from './IInputEventInit.js';
 
 /**
@@ -10,6 +11,7 @@ export default class InputEvent extends UIEvent {
 	public readonly dataTransfer: DataTransfer | null;
 	public readonly inputType: string;
 	public readonly isComposing: boolean;
+	readonly #targetRanges: StaticRange[];
 
 	/**
 	 * Constructor.
@@ -24,5 +26,15 @@ export default class InputEvent extends UIEvent {
 		this.dataTransfer = eventInit?.dataTransfer ?? null;
 		this.inputType = eventInit?.inputType ?? '';
 		this.isComposing = eventInit?.isComposing ?? false;
+		this.#targetRanges = eventInit?.targetRanges ?? [];
+	}
+
+	/**
+	 * Returns the ranges that this event will affect.
+	 *
+	 * @returns A copy of the target ranges array.
+	 */
+	public getTargetRanges(): StaticRange[] {
+		return this.#targetRanges.slice();
 	}
 }

--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -181,6 +181,7 @@ import XMLDocument from './nodes/xml-document/XMLDocument.js';
 import PermissionStatus from './permissions/PermissionStatus.js';
 import Permissions from './permissions/Permissions.js';
 import Range from './range/Range.js';
+import StaticRange from './range/StaticRange.js';
 import ResizeObserver from './resize-observer/ResizeObserver.js';
 import Screen from './screen/Screen.js';
 import ScreenDetailed from './screen/ScreenDetailed.js';
@@ -446,6 +447,7 @@ export {
 	ProgressEvent,
 	PropertySymbol,
 	Range,
+	StaticRange,
 	RemotePlayback,
 	Request,
 	ResizeObserver,

--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -2,6 +2,8 @@ import Element from '../element/Element.js';
 import * as PropertySymbol from '../../PropertySymbol.js';
 import CSSStyleDeclaration from '../../css/declaration/CSSStyleDeclaration.js';
 import PointerEvent from '../../event/events/PointerEvent.js';
+import MouseEvent from '../../event/events/MouseEvent.js';
+import EventPhaseEnum from '../../event/EventPhaseEnum.js';
 import NodeTypeEnum from '../node/NodeTypeEnum.js';
 import type Event from '../../event/Event.js';
 import HTMLElementUtility from './HTMLElementUtility.js';
@@ -968,6 +970,36 @@ export default class HTMLElement extends Element {
 	 */
 	public focus(): void {
 		HTMLElementUtility.focus(this);
+	}
+
+	/**
+	 * @override
+	 */
+	public override dispatchEvent(event: Event): boolean {
+		const returnValue = super.dispatchEvent(event);
+
+		if (
+			event[PropertySymbol.defaultPrevented] ||
+			event.type !== 'mousedown' ||
+			event[PropertySymbol.eventPhase] !== EventPhaseEnum.none ||
+			!(event instanceof MouseEvent) ||
+			event.button !== 0
+		) {
+			return returnValue;
+		}
+
+		const root = HTMLElementUtility.getContentEditableRoot(this);
+		if (!root) {
+			return returnValue;
+		}
+
+		const document = root[PropertySymbol.ownerDocument];
+		if (document[PropertySymbol.activeElement] !== root) {
+			HTMLElementUtility.focus(root);
+		}
+		HTMLElementUtility.placeCaretInContentEditable(root);
+
+		return returnValue;
 	}
 
 	/**

--- a/packages/happy-dom/src/nodes/html-element/HTMLElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElementUtility.ts
@@ -102,14 +102,42 @@ export default class HTMLElementUtility {
 		);
 
 		if ((<HTMLElement>target).isContentEditable) {
-			const firstText = HTMLElementUtility.findFirstEditableTextNode(<HTMLElement>target);
-			const sel = target[PropertySymbol.ownerDocument].getSelection();
-			if (firstText) {
-				sel?.collapse(firstText, 0);
-			} else {
-				sel?.collapse(<HTMLElement>target, 0);
-			}
+			HTMLElementUtility.placeCaretInContentEditable(<HTMLElement>target);
 		}
+	}
+
+	/**
+	 * Places a collapsed selection at the first editable text node in a contenteditable root.
+	 *
+	 * @param root Contenteditable root element.
+	 */
+	public static placeCaretInContentEditable(root: HTMLElement): void {
+		const firstText = HTMLElementUtility.findFirstEditableTextNode(root);
+		const sel = root[PropertySymbol.ownerDocument].getSelection();
+		if (firstText) {
+			sel?.collapse(firstText, 0);
+		} else {
+			sel?.collapse(root, 0);
+		}
+	}
+
+	/**
+	 * Returns the outermost contenteditable root for a node.
+	 *
+	 * @param node Node.
+	 * @returns Contenteditable root element, or null if none exists.
+	 */
+	public static getContentEditableRoot(node: Node): HTMLElement | null {
+		let current: Node | null = node;
+		let root: HTMLElement | null = null;
+		while (current && current.nodeType === NodeTypeEnum.elementNode) {
+			const el = <HTMLElement>current;
+			if (el.isContentEditable) {
+				root = el;
+			}
+			current = el[PropertySymbol.parentNode];
+		}
+		return root;
 	}
 
 	/**
@@ -124,7 +152,7 @@ export default class HTMLElementUtility {
 				if (
 					node !== root &&
 					node.nodeType === NodeTypeEnum.elementNode &&
-					(<Element>node).contentEditable === 'false'
+					(<HTMLElement>node).contentEditable === 'false'
 				) {
 					return NodeFilter.FILTER_REJECT;
 				}

--- a/packages/happy-dom/src/nodes/html-element/HTMLElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElementUtility.ts
@@ -3,7 +3,9 @@ import * as PropertySymbol from '../../PropertySymbol.js';
 import NodeFilter from '../../tree-walker/NodeFilter.js';
 import NodeTypeEnum from '../node/NodeTypeEnum.js';
 import type HTMLElement from '../html-element/HTMLElement.js';
+import type Node from '../node/Node.js';
 import type SVGElement from '../svg-element/SVGElement.js';
+import type Text from '../text/Text.js';
 
 /**
  * HTMLElement utility.

--- a/packages/happy-dom/src/nodes/html-element/HTMLElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElementUtility.ts
@@ -1,5 +1,7 @@
 import FocusEvent from '../../event/events/FocusEvent.js';
 import * as PropertySymbol from '../../PropertySymbol.js';
+import NodeFilter from '../../tree-walker/NodeFilter.js';
+import NodeTypeEnum from '../node/NodeTypeEnum.js';
 import type HTMLElement from '../html-element/HTMLElement.js';
 import type SVGElement from '../svg-element/SVGElement.js';
 
@@ -96,6 +98,40 @@ export default class HTMLElementUtility {
 				composed: true
 			})
 		);
+
+		if ((<HTMLElement>target).isContentEditable) {
+			const firstText = HTMLElementUtility.findFirstEditableTextNode(<HTMLElement>target);
+			const sel = target[PropertySymbol.ownerDocument].getSelection();
+			if (firstText) {
+				sel?.collapse(firstText, 0);
+			} else {
+				sel?.collapse(<HTMLElement>target, 0);
+			}
+		}
+	}
+
+	/**
+	 * Returns the first Text node that is not inside a contenteditable=false subtree.
+	 *
+	 * @param root Root element to search within.
+	 * @returns First editable Text node, or null if none exists.
+	 */
+	private static findFirstEditableTextNode(root: HTMLElement): Text | null {
+		const walker = root[PropertySymbol.ownerDocument].createTreeWalker(root, NodeFilter.SHOW_ALL, {
+			acceptNode(node: Node): number {
+				if (
+					node !== root &&
+					node.nodeType === NodeTypeEnum.elementNode &&
+					(<Element>node).contentEditable === 'false'
+				) {
+					return NodeFilter.FILTER_REJECT;
+				}
+				return node.nodeType === NodeTypeEnum.textNode
+					? NodeFilter.FILTER_ACCEPT
+					: NodeFilter.FILTER_SKIP;
+			}
+		});
+		return <Text | null>walker.nextNode();
 	}
 
 	/**

--- a/packages/happy-dom/src/range/StaticRange.ts
+++ b/packages/happy-dom/src/range/StaticRange.ts
@@ -1,3 +1,5 @@
+import type Node from '../nodes/node/Node.js';
+
 /**
  * Range object that does not update when the node tree mutates.
  *

--- a/packages/happy-dom/src/range/StaticRange.ts
+++ b/packages/happy-dom/src/range/StaticRange.ts
@@ -1,0 +1,41 @@
+/**
+ * Range object that does not update when the node tree mutates.
+ *
+ * @see https://dom.spec.whatwg.org/#staticrange
+ */
+export default class StaticRange {
+	public readonly startContainer: Node;
+	public readonly startOffset: number;
+	public readonly endContainer: Node;
+	public readonly endOffset: number;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param init Initialization options.
+	 * @param init.startContainer Node containing the start of the range.
+	 * @param init.startOffset Start offset.
+	 * @param init.endContainer Node containing the end of the range.
+	 * @param init.endOffset End offset.
+	 */
+	constructor(init: {
+		startContainer: Node;
+		startOffset: number;
+		endContainer: Node;
+		endOffset: number;
+	}) {
+		this.startContainer = init.startContainer;
+		this.startOffset = init.startOffset;
+		this.endContainer = init.endContainer;
+		this.endOffset = init.endOffset;
+	}
+
+	/**
+	 * Returns true if this range is collapsed (start and end are the same point).
+	 *
+	 * @returns True if collapsed; otherwise false.
+	 */
+	public get collapsed(): boolean {
+		return this.startContainer === this.endContainer && this.startOffset === this.endOffset;
+	}
+}

--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -183,6 +183,7 @@ import type XMLDocument from '../nodes/xml-document/XMLDocument.js';
 import type PermissionStatus from '../permissions/PermissionStatus.js';
 import Permissions from '../permissions/Permissions.js';
 import type Range from '../range/Range.js';
+import StaticRange from '../range/StaticRange.js';
 import ResizeObserver from '../resize-observer/ResizeObserver.js';
 import Screen from '../screen/Screen.js';
 import ScreenDetails from '../screen/ScreenDetails.js';
@@ -709,6 +710,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	public readonly XMLSerializer = XMLSerializer;
 	public readonly ClipboardItem = ClipboardItem;
 	public readonly Selection = Selection;
+	public readonly StaticRange = StaticRange;
 	public readonly CSSUnitValue = CSSUnitValue;
 	public readonly SVGAngle = SVGAngle;
 	public readonly SVGAnimatedAngle = SVGAnimatedAngle;

--- a/packages/happy-dom/test/event/events/InputEvent.test.ts
+++ b/packages/happy-dom/test/event/events/InputEvent.test.ts
@@ -1,0 +1,34 @@
+import InputEvent from '../../../src/event/events/InputEvent.js';
+import StaticRange from '../../../src/range/StaticRange.js';
+import Window from '../../../src/window/Window.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('InputEvent', () => {
+	let window: Window;
+
+	beforeEach(() => {
+		window = new Window();
+	});
+
+	describe('getTargetRanges()', () => {
+		it('Returns an empty array by default.', () => {
+			const event = new InputEvent('input');
+			expect(event.getTargetRanges()).toEqual([]);
+		});
+
+		it('Returns the StaticRange instances passed in the constructor.', () => {
+			const doc = window.document;
+			const textNode = doc.createTextNode('hello');
+			const range = new StaticRange({
+				startContainer: textNode,
+				startOffset: 0,
+				endContainer: textNode,
+				endOffset: 5
+			});
+			const event = new InputEvent('beforeinput', { targetRanges: [range] });
+			const result = event.getTargetRanges();
+			expect(result).toHaveLength(1);
+			expect(result[0]).toBe(range);
+		});
+	});
+});

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -742,6 +742,76 @@ describe('HTMLElement', () => {
 		});
 	});
 
+	describe('focus() on contenteditable', () => {
+		it('Places a collapsed selection at the first editable text node.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			div.textContent = 'hello';
+			document.body.appendChild(div);
+
+			div.focus();
+
+			const sel = document.getSelection();
+			expect(sel?.isCollapsed).toBe(true);
+			expect(sel?.anchorNode).toBe(div.firstChild);
+			expect(sel?.anchorOffset).toBe(0);
+		});
+
+		it('Skips contenteditable=false subtrees when finding the first text node.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			const inner = document.createElement('span');
+			inner.contentEditable = 'false';
+			inner.textContent = 'non-editable';
+			const editable = document.createElement('span');
+			editable.textContent = 'editable';
+			div.appendChild(inner);
+			div.appendChild(editable);
+			document.body.appendChild(div);
+
+			div.focus();
+
+			const sel = document.getSelection();
+			expect(sel?.anchorNode).toBe(editable.firstChild);
+		});
+
+		it('Collapses to the element itself when no text nodes exist.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			document.body.appendChild(div);
+
+			div.focus();
+
+			const sel = document.getSelection();
+			expect(sel?.isCollapsed).toBe(true);
+			expect(sel?.anchorNode).toBe(div);
+		});
+
+		it('Does not throw on an empty contenteditable element.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			document.body.appendChild(div);
+
+			expect(() => div.focus()).not.toThrow();
+		});
+
+		it('Fires selectionchange when focusing a contenteditable element.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			div.textContent = 'hello';
+			document.body.appendChild(div);
+
+			let fired = false;
+			document.addEventListener('selectionchange', () => {
+				fired = true;
+			});
+
+			div.focus();
+
+			expect(fired).toBe(true);
+		});
+	});
+
 	describe('setAttributeNode()', () => {
 		it('Sets css text of existing CSSStyleDeclaration.', () => {
 			element.style.background = 'green';

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -1,3 +1,4 @@
+import MouseEvent from '../../../src/event/events/MouseEvent.js';
 import PointerEvent from '../../../src/event/events/PointerEvent.js';
 import type Document from '../../../src/nodes/document/Document.js';
 import HTMLElement from '../../../src/nodes/html-element/HTMLElement.js';
@@ -743,7 +744,7 @@ describe('HTMLElement', () => {
 	});
 
 	describe('focus() on contenteditable', () => {
-		it('Places a collapsed selection at the first editable text node.', () => {
+		it('Places a collapsed selection when focused.', () => {
 			const div = <HTMLElement>document.createElement('div');
 			div.contentEditable = 'true';
 			div.textContent = 'hello';
@@ -756,59 +757,99 @@ describe('HTMLElement', () => {
 			expect(sel?.anchorNode).toBe(div.firstChild);
 			expect(sel?.anchorOffset).toBe(0);
 		});
+	});
 
-		it('Skips contenteditable=false subtrees when finding the first text node.', () => {
-			const div = <HTMLElement>document.createElement('div');
-			div.contentEditable = 'true';
-			const inner = document.createElement('span');
-			inner.contentEditable = 'false';
-			inner.textContent = 'non-editable';
-			const editable = document.createElement('span');
-			editable.textContent = 'editable';
-			div.appendChild(inner);
-			div.appendChild(editable);
-			document.body.appendChild(div);
+	describe('dispatchEvent()', () => {
+		describe('mousedown on contenteditable', () => {
+			it('focuses the element and places a caret', () => {
+				const div = <HTMLElement>document.createElement('div');
+				div.contentEditable = 'true';
+				div.textContent = 'hello';
+				document.body.appendChild(div);
 
-			div.focus();
+				div.dispatchEvent(
+					new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 })
+				);
 
-			const sel = document.getSelection();
-			expect(sel?.anchorNode).toBe(editable.firstChild);
-		});
-
-		it('Collapses to the element itself when no text nodes exist.', () => {
-			const div = <HTMLElement>document.createElement('div');
-			div.contentEditable = 'true';
-			document.body.appendChild(div);
-
-			div.focus();
-
-			const sel = document.getSelection();
-			expect(sel?.isCollapsed).toBe(true);
-			expect(sel?.anchorNode).toBe(div);
-		});
-
-		it('Does not throw on an empty contenteditable element.', () => {
-			const div = <HTMLElement>document.createElement('div');
-			div.contentEditable = 'true';
-			document.body.appendChild(div);
-
-			expect(() => div.focus()).not.toThrow();
-		});
-
-		it('Fires selectionchange when focusing a contenteditable element.', () => {
-			const div = <HTMLElement>document.createElement('div');
-			div.contentEditable = 'true';
-			div.textContent = 'hello';
-			document.body.appendChild(div);
-
-			let fired = false;
-			document.addEventListener('selectionchange', () => {
-				fired = true;
+				const sel = document.getSelection();
+				expect(document.activeElement).toBe(div);
+				expect(sel?.isCollapsed).toBe(true);
+				expect(sel?.anchorNode).toBe(div.firstChild);
+				expect(sel?.anchorOffset).toBe(0);
 			});
 
-			div.focus();
+			it('still places a caret on already-focused contenteditable', () => {
+				const div = <HTMLElement>document.createElement('div');
+				div.contentEditable = 'true';
+				div.textContent = 'hello';
+				document.body.appendChild(div);
 
-			expect(fired).toBe(true);
+				div.focus();
+				document.getSelection()?.removeAllRanges();
+
+				div.dispatchEvent(
+					new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 })
+				);
+
+				const sel = document.getSelection();
+				expect(document.activeElement).toBe(div);
+				expect(sel?.isCollapsed).toBe(true);
+				expect(sel?.anchorNode).toBe(div.firstChild);
+				expect(sel?.anchorOffset).toBe(0);
+			});
+
+			it('does not place a caret when preventDefault() is called', () => {
+				const div = <HTMLElement>document.createElement('div');
+				div.contentEditable = 'true';
+				div.textContent = 'hello';
+				document.body.appendChild(div);
+
+				div.addEventListener('mousedown', (event) => {
+					event.preventDefault();
+				});
+
+				div.dispatchEvent(
+					new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 })
+				);
+
+				const sel = document.getSelection();
+				expect(document.activeElement).not.toBe(div);
+				expect(sel?.anchorNode).toBeNull();
+			});
+
+			it('resolves to the root and places caret when mousedown is on a child', () => {
+				const div = <HTMLElement>document.createElement('div');
+				div.contentEditable = 'true';
+				const span = document.createElement('span');
+				span.textContent = 'hello';
+				div.appendChild(span);
+				document.body.appendChild(div);
+
+				span.dispatchEvent(
+					new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 0 })
+				);
+
+				const sel = document.getSelection();
+				expect(document.activeElement).toBe(div);
+				expect(sel?.isCollapsed).toBe(true);
+				expect(sel?.anchorNode).toBe(span.firstChild);
+				expect(sel?.anchorOffset).toBe(0);
+			});
+
+			it('does not trigger default action for auxiliary buttons', () => {
+				const div = <HTMLElement>document.createElement('div');
+				div.contentEditable = 'true';
+				div.textContent = 'hello';
+				document.body.appendChild(div);
+
+				div.dispatchEvent(
+					new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 1 })
+				);
+
+				const sel = document.getSelection();
+				expect(document.activeElement).not.toBe(div);
+				expect(sel?.anchorNode).toBeNull();
+			});
 		});
 	});
 

--- a/packages/happy-dom/test/nodes/html-element/HTMLElementUtility.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElementUtility.test.ts
@@ -2,6 +2,7 @@ import type SVGElement from '../../../src/nodes/svg-element/SVGElement.js';
 import type FocusEvent from '../../../src/event/events/FocusEvent.js';
 import type Document from '../../../src/nodes/document/Document.js';
 import type HTMLElement from '../../../src/nodes/html-element/HTMLElement.js';
+import HTMLElementUtility from '../../../src/nodes/html-element/HTMLElementUtility.js';
 import Window from '../../../src/window/Window.js';
 import { beforeEach, describe, it, expect } from 'vitest';
 import type EventTarget from '../../../src/event/EventTarget.js';
@@ -299,6 +300,52 @@ describe('HTMLElementUtility', () => {
 				expect((<FocusEvent>(<unknown>triggeredFocusOutEvent)).type).toBe('focusout');
 				expect((<FocusEvent>(<unknown>triggeredFocusOutEvent)).relatedTarget).toBeNull();
 			}
+		});
+	});
+
+	describe('placeCaretInContentEditable()', () => {
+		it('Places a collapsed selection at the first editable text node.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			div.textContent = 'hello';
+			document.body.appendChild(div);
+
+			HTMLElementUtility.placeCaretInContentEditable(div);
+
+			const sel = document.getSelection();
+			expect(sel?.isCollapsed).toBe(true);
+			expect(sel?.anchorNode).toBe(div.firstChild);
+			expect(sel?.anchorOffset).toBe(0);
+		});
+
+		it('Skips contenteditable=false subtrees when finding the first text node.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			const inner = document.createElement('span');
+			inner.contentEditable = 'false';
+			inner.textContent = 'non-editable';
+			const editable = document.createElement('span');
+			editable.textContent = 'editable';
+			div.appendChild(inner);
+			div.appendChild(editable);
+			document.body.appendChild(div);
+
+			HTMLElementUtility.placeCaretInContentEditable(div);
+
+			const sel = document.getSelection();
+			expect(sel?.anchorNode).toBe(editable.firstChild);
+		});
+
+		it('Collapses to the element itself when no text nodes exist.', () => {
+			const div = <HTMLElement>document.createElement('div');
+			div.contentEditable = 'true';
+			document.body.appendChild(div);
+
+			HTMLElementUtility.placeCaretInContentEditable(div);
+
+			const sel = document.getSelection();
+			expect(sel?.isCollapsed).toBe(true);
+			expect(sel?.anchorNode).toBe(div);
 		});
 	});
 });

--- a/packages/happy-dom/test/range/StaticRange.test.ts
+++ b/packages/happy-dom/test/range/StaticRange.test.ts
@@ -1,0 +1,54 @@
+import StaticRange from '../../src/range/StaticRange.js';
+import Window from '../../src/window/Window.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('StaticRange', () => {
+	let window: Window;
+
+	beforeEach(() => {
+		window = new Window();
+	});
+
+	describe('constructor()', () => {
+		it('Sets startContainer, startOffset, endContainer, endOffset.', () => {
+			const doc = window.document;
+			const textNode = doc.createTextNode('hello');
+			const range = new StaticRange({
+				startContainer: textNode,
+				startOffset: 1,
+				endContainer: textNode,
+				endOffset: 3
+			});
+			expect(range.startContainer).toBe(textNode);
+			expect(range.startOffset).toBe(1);
+			expect(range.endContainer).toBe(textNode);
+			expect(range.endOffset).toBe(3);
+		});
+	});
+
+	describe('collapsed', () => {
+		it('Returns true when start and end are the same container and offset.', () => {
+			const doc = window.document;
+			const textNode = doc.createTextNode('hello');
+			const range = new StaticRange({
+				startContainer: textNode,
+				startOffset: 2,
+				endContainer: textNode,
+				endOffset: 2
+			});
+			expect(range.collapsed).toBe(true);
+		});
+
+		it('Returns false when start and end differ.', () => {
+			const doc = window.document;
+			const textNode = doc.createTextNode('hello');
+			const range = new StaticRange({
+				startContainer: textNode,
+				startOffset: 0,
+				endContainer: textNode,
+				endOffset: 3
+			});
+			expect(range.collapsed).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
### Description

This branch adds some additional selection behavior to `contenteditable` elements. I needed this stuff to be able to test the DOM behavior in a [Slate](https://www.slatejs.org/)-based document editor I am writing.

Builds on the basic `contenteditable` attribute behavior added in #1757 and previous Selection work (#1953, #1954).

Resolves #2247

### Changes

1. **Caret placement on `focus()`** — when a `contenteditable` element gains focus, HappyDOM now collapses the selection to the start of the first editable text node, matching the behavior required by the Selection API spec.
2. **`StaticRange`** — a new class implementing the [StaticRange interface](https://developer.mozilla.org/en-US/docs/Web/API/StaticRange), which is a prerequisite for `InputEvent.getTargetRanges()`.
3. **`InputEvent.getTargetRanges()`** — adds the missing method and the corresponding `targetRanges` init option, allowing test code and tools like `@testing-library/user-event` to construct `beforeinput` events with proper target range data.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### Rationale

#### Why I'm testing in Happy DOM and not a browser

It makes sense that Slate itself would want to use real browsers for its regression tests. It is a low level cross-browser library that deals with browser quirks.

But for actual editors based on top of Slate, there is still a lot of tricky DOM behaviors that aren't browser-specific: Toolbars are built when you make a selection. Keyboard events affect `Range`/`Selection` and DOM contents. These behaviors are not primarily visual, so testing DOM state makes sense.

#### Why this behavior belongs in Happy DOM

Caret placement on focus is explicitly required by the [Selection API spec](https://w3c.github.io/selection-api/): 

> When an editing host gains focus, if the selection has no range inside it, the user agent must place the caret at the beginning of the editing host.

This is a side effect of the `focus()` DOM method itself — the same category as firing `focusin` or updating `document.activeElement`, both of which Happy DOM already handles correctly in `HTMLElementUtility.focus()`.

`StaticRange` and `getTargetRanges()` are pure spec additions with no behavioral side effects.

