### PR TITLE
fix: [#2249] Headers iteration yield sorted, lowercase header names

### DIFF
--- a/packages/@happy-dom/server-renderer/src/ServerRendererServer.ts
+++ b/packages/@happy-dom/server-renderer/src/ServerRendererServer.ts
@@ -271,8 +271,8 @@ export default class ServerRendererServer {
 		response.statusCode = fetchResponse.status;
 
 		if (fetchResponse.headers.get('Content-Encoding')) {
-			response.setHeader('Content-Encoding', 'gzip');
-			response.removeHeader('Content-Length');
+			response.setHeader('content-encoding', 'gzip');
+			response.removeHeader('content-length');
 			try {
 				await Stream.pipeline(fetchResponse.body!, ZLib.createGzip(), response);
 			} catch (error) {

--- a/packages/@happy-dom/server-renderer/test/ServerRendererBrowser.test.ts
+++ b/packages/@happy-dom/server-renderer/test/ServerRendererBrowser.test.ts
@@ -160,7 +160,7 @@ describe('ServerRendererBrowser', () => {
 				requestHeaders.push(headers);
 				return <Response>{
 					ok: true,
-					headers: new Headers({ key1: 'value', 'Cache-Control': 'max-age=3600' }),
+					headers: new Headers({ key1: 'value', 'cache-control': 'max-age=3600' }),
 					status: 200,
 					statusText: 'OK',
 					text: async () => MockedPageHTML
@@ -209,7 +209,7 @@ describe('ServerRendererBrowser', () => {
 					url,
 					content: null,
 					error: null,
-					headers: { key1: 'value', 'Cache-Control': 'max-age=3600' },
+					headers: { key1: 'value', 'cache-control': 'max-age=3600' },
 					outputFile: `./test-output/test-${index + 1}.html`,
 					pageConsole: '',
 					pageErrors: [],
@@ -219,7 +219,7 @@ describe('ServerRendererBrowser', () => {
 			);
 			expect(requestHeaders).toEqual([
 				{},
-				{ 'Request-Header-1': 'Value1', 'Request-Header-2': 'Value2' },
+				{ 'request-header-1': 'Value1', 'request-header-2': 'Value2' },
 				{},
 				{},
 				{},
@@ -676,7 +676,7 @@ Timer #1
 			vi.spyOn(Fetch.prototype, 'send').mockImplementation(async () => {
 				return <Response>{
 					ok: true,
-					headers: new Headers({ key1: 'value', 'Cache-Control': 'max-age=3600' }),
+					headers: new Headers({ key1: 'value', 'cache-control': 'max-age=3600' }),
 					status: 200,
 					statusText: 'OK',
 					text: async () => MockedPageHTML

--- a/packages/@happy-dom/server-renderer/test/ServerRendererServer.test.ts
+++ b/packages/@happy-dom/server-renderer/test/ServerRendererServer.test.ts
@@ -794,9 +794,9 @@ describe('ServerRendererServer', () => {
 				expect(responseStatusCode).toBe(200);
 
 				expect(responseHeaders).toEqual({
-					'Content-Encoding': 'gzip',
-					'Content-Type': 'image/png',
-					'X-Happy-DOM': 'true'
+					'content-encoding': 'gzip',
+					'content-type': 'image/png',
+					'x-happy-dom': 'true'
 				});
 
 				expect(await GZIP_TO_STRING(responseBody)).toBe('chunk1chunk2chunk3');
@@ -894,8 +894,8 @@ describe('ServerRendererServer', () => {
 				expect(responseStatusCode).toBe(200);
 
 				expect(responseHeaders).toEqual({
-					'Content-Type': 'image/png',
-					'X-Happy-DOM': 'true'
+					'content-type': 'image/png',
+					'x-happy-dom': 'true'
 				});
 
 				let string = '';

--- a/packages/happy-dom/src/fetch/Headers.ts
+++ b/packages/happy-dom/src/fetch/Headers.ts
@@ -126,8 +126,8 @@ export default class Headers {
 		thisArg?: any
 	): void {
 		const thisArgValue = thisArg ?? this[PropertySymbol.window];
-		for (const header of Object.values(this[PropertySymbol.entries])) {
-			callback.call(thisArgValue, header.value.join(', '), header.name, this);
+		for (const name of Object.keys(this[PropertySymbol.entries]).sort()) {
+			callback.call(thisArgValue, this[PropertySymbol.entries][name].value.join(', '), name, this);
 		}
 	}
 
@@ -137,8 +137,8 @@ export default class Headers {
 	 * @returns Iterator.
 	 */
 	public *keys(): ArrayIterator<string> {
-		for (const header of Object.values(this[PropertySymbol.entries])) {
-			yield header.name;
+		for (const name of Object.keys(this[PropertySymbol.entries]).sort()) {
+			yield name;
 		}
 	}
 
@@ -148,8 +148,8 @@ export default class Headers {
 	 * @returns Iterator.
 	 */
 	public *values(): ArrayIterator<string> {
-		for (const header of Object.values(this[PropertySymbol.entries])) {
-			yield header.value.join(', ');
+		for (const name of Object.keys(this[PropertySymbol.entries]).sort()) {
+			yield this[PropertySymbol.entries][name].value.join(', ');
 		}
 	}
 
@@ -159,8 +159,8 @@ export default class Headers {
 	 * @returns Iterator.
 	 */
 	public *entries(): ArrayIterator<[string, string]> {
-		for (const header of Object.values(this[PropertySymbol.entries])) {
-			yield [header.name, header.value.join(', ')];
+		for (const name of Object.keys(this[PropertySymbol.entries]).sort()) {
+			yield [name, this[PropertySymbol.entries][name].value.join(', ')];
 		}
 	}
 
@@ -170,8 +170,8 @@ export default class Headers {
 	 * @returns Iterator.
 	 */
 	public *[Symbol.iterator](): ArrayIterator<[string, string]> {
-		for (const header of Object.values(this[PropertySymbol.entries])) {
-			yield [header.name, header.value.join(', ')];
+		for (const name of Object.keys(this[PropertySymbol.entries]).sort()) {
+			yield [name, this[PropertySymbol.entries][name].value.join(', ')];
 		}
 	}
 }

--- a/packages/happy-dom/src/fetch/cache/response/ResponseCacheFileSystem.ts
+++ b/packages/happy-dom/src/fetch/cache/response/ResponseCacheFileSystem.ts
@@ -1,4 +1,5 @@
 import type ICachedResponse from './ICachedResponse.js';
+import * as PropertySymbol from '../../../PropertySymbol.js';
 import Headers from '../../Headers.js';
 import FS from 'fs';
 import Path from 'path';
@@ -126,12 +127,16 @@ export default class ResponseCacheFileSystem implements IResponseCacheFileSystem
 					const responseHeaders: { [k: string]: string } = {};
 					const requestHeaders: { [k: string]: string } = {};
 
-					for (const [key, value] of cachedResponse.response.headers.entries()) {
-						responseHeaders[key] = value;
+					for (const header of Object.values(
+						cachedResponse.response.headers[PropertySymbol.entries]
+					)) {
+						responseHeaders[header.name] = header.value.join(', ');
 					}
 
-					for (const [key, value] of cachedResponse.request.headers.entries()) {
-						requestHeaders[key] = value;
+					for (const header of Object.values(
+						cachedResponse.request.headers[PropertySymbol.entries]
+					)) {
+						requestHeaders[header.name] = header.value.join(', ');
 					}
 
 					const cacheableEntry = {

--- a/packages/happy-dom/src/fetch/utilities/FetchRequestHeaderUtility.ts
+++ b/packages/happy-dom/src/fetch/utilities/FetchRequestHeaderUtility.ts
@@ -79,9 +79,9 @@ export default class FetchRequestHeaderUtility {
 		baseHeaders?: Headers | null;
 	}): { [key: string]: string } {
 		const headers = new options.window.Headers(options.baseHeaders);
-		options.request.headers.forEach((value, key) => {
-			headers.set(key, value);
-		});
+		for (const header of Object.values(options.request.headers[PropertySymbol.entries])) {
+			headers.set(header.name, header.value.join(', '));
+		}
 
 		const originURL = new URL(options.window.location.href);
 		const isCORS = FetchCORSUtility.isCORS(originURL, options.request[PropertySymbol.url]);

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -3811,8 +3811,8 @@ describe('Fetch', () => {
 			expect(headers2).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
-				'Cache-Control': 'max-age=1',
-				'Last-Modified': 'Mon, 11 Dec 2023 02:00:00 GMT'
+				'cache-control': 'max-age=1',
+				'last-modified': 'Mon, 11 Dec 2023 02:00:00 GMT'
 			});
 
 			expect(requestArgs).toEqual([
@@ -4145,8 +4145,8 @@ describe('Fetch', () => {
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
 				'cache-control': `max-age=0.0001`,
-				'Last-Modified': 'Mon, 11 Dec 2023 02:00:00 GMT',
-				ETag: etag2
+				'last-modified': 'Mon, 11 Dec 2023 02:00:00 GMT',
+				etag: etag2
 			});
 
 			expect(requestArgs).toEqual([

--- a/packages/happy-dom/test/fetch/Headers.test.ts
+++ b/packages/happy-dom/test/fetch/Headers.test.ts
@@ -12,16 +12,16 @@ describe('Headers', () => {
 
 			const headers2 = new Headers(headers1);
 
-			const entries: Record<string, string> = {};
+			const entries: Array<[string, string]> = [];
 
 			for (const [key, value] of headers2) {
-				entries[key] = value;
+				entries.push([key, value]);
 			}
 
-			expect(entries).toEqual({
-				'Content-Type': 'application/json',
-				'Content-Encoding': 'gzip'
-			});
+			expect(entries).toEqual([
+				['content-encoding', 'gzip'],
+				['content-type', 'application/json']
+			]);
 		});
 	});
 
@@ -40,8 +40,8 @@ describe('Headers', () => {
 			}
 
 			expect(entries).toEqual({
-				'Content-Type': 'application/json, x-www-form-urlencoded',
-				'Content-Encoding': 'gzip'
+				'content-type': 'application/json, x-www-form-urlencoded',
+				'content-encoding': 'gzip'
 			});
 		});
 	});
@@ -63,7 +63,7 @@ describe('Headers', () => {
 			}
 
 			expect(entries).toEqual({
-				'Content-Encoding': 'gzip'
+				'content-encoding': 'gzip'
 			});
 		});
 
@@ -102,8 +102,8 @@ describe('Headers', () => {
 				}
 
 				expect(entries).toEqual({
-					'Content-Type': 'x-www-form-urlencoded',
-					'Content-Encoding': 'gzip'
+					'content-type': 'x-www-form-urlencoded',
+					'content-encoding': 'gzip'
 				});
 			});
 		});
@@ -191,25 +191,25 @@ describe('Headers', () => {
 				expect(thisArgs[0]).toBe(window);
 				expect(thisArgs[1]).toBe(window);
 			});
-			it('Calls a callback for each entry.', () => {
+			it('Calls a callback for each entry with lowercase header names in sorted order.', () => {
 				const headers = new Headers();
 
 				headers.append('Content-Type', 'application/json');
 				headers.append('Content-Type', 'x-www-form-urlencoded');
 				headers.append('Content-Encoding', 'gzip');
 
-				const entries: Record<string, string> = {};
+				const entries: Array<[string, string]> = [];
 				const thisArg = {};
 				headers.forEach(function (this: Headers, value, key, parent) {
 					expect(this).toBe(thisArg);
 					expect(parent).toBe(headers);
-					entries[key] = value;
+					entries.push([key, value]);
 				}, thisArg);
 
-				expect(entries).toEqual({
-					'Content-Type': 'application/json, x-www-form-urlencoded',
-					'Content-Encoding': 'gzip'
-				});
+				expect(entries).toEqual([
+					['content-encoding', 'gzip'],
+					['content-type', 'application/json, x-www-form-urlencoded']
+				]);
 			});
 		});
 
@@ -227,7 +227,16 @@ describe('Headers', () => {
 					keys.push(key);
 				}
 
-				expect(keys).toEqual(['Content-Type', 'Content-Encoding']);
+				expect(keys).toEqual(['content-encoding', 'content-type']);
+			});
+
+			it('Returns lowercase header names sorted lexicographically.', () => {
+				const headers = new Headers({
+					'X-Custom-Header': 'value',
+					Authorization: 'Bearer token'
+				});
+
+				expect([...headers.keys()]).toEqual(['authorization', 'x-custom-header']);
 			});
 		});
 
@@ -245,49 +254,49 @@ describe('Headers', () => {
 					values.push(value);
 				}
 
-				expect(values).toEqual(['application/json, x-www-form-urlencoded', 'gzip']);
+				expect(values).toEqual(['gzip', 'application/json, x-www-form-urlencoded']);
 			});
 		});
 
 		describe('*entries()', () => {
-			it('Returns an iterator for keys and values.', () => {
+			it('Returns an iterator for keys and values with lowercase header names in sorted order.', () => {
 				const headers = new Headers();
 
 				headers.set('Content-Type', 'application/json');
 				headers.set('Content-Type', 'x-www-form-urlencoded');
 				headers.set('Content-Encoding', 'gzip');
 
-				const entries: Record<string, string> = {};
+				const entries: Array<[string, string]> = [];
 
 				for (const [key, value] of headers.entries()) {
-					entries[key] = value;
+					entries.push([key, value]);
 				}
 
-				expect(entries).toEqual({
-					'Content-Type': 'x-www-form-urlencoded',
-					'Content-Encoding': 'gzip'
-				});
+				expect(entries).toEqual([
+					['content-encoding', 'gzip'],
+					['content-type', 'x-www-form-urlencoded']
+				]);
 			});
 		});
 
 		describe('*[Symbol.iterator]()', () => {
-			it('Returns an iterator for keys and values.', () => {
+			it('Returns an iterator for keys and values with lowercase header names in sorted order.', () => {
 				const headers = new Headers();
 
 				headers.set('Content-Type', 'application/json');
 				headers.set('Content-Type', 'x-www-form-urlencoded');
 				headers.set('Content-Encoding', 'gzip');
 
-				const entries: Record<string, string> = {};
+				const entries: Array<[string, string]> = [];
 
 				for (const [key, value] of headers) {
-					entries[key] = value;
+					entries.push([key, value]);
 				}
 
-				expect(entries).toEqual({
-					'Content-Type': 'x-www-form-urlencoded',
-					'Content-Encoding': 'gzip'
-				});
+				expect(entries).toEqual([
+					['content-encoding', 'gzip'],
+					['content-type', 'x-www-form-urlencoded']
+				]);
 			});
 		});
 	});

--- a/packages/happy-dom/test/fetch/Request.test.ts
+++ b/packages/happy-dom/test/fetch/Request.test.ts
@@ -203,8 +203,8 @@ describe('Request', () => {
 			expect(otherRequest.headers === headers).toBe(false);
 			expect(request.headers === headers).toBe(false);
 			expect(headerEntries).toEqual({
-				'X-Test': 'Hello World',
-				'X-Test-2': 'Hello World 2'
+				'x-test': 'Hello World',
+				'x-test-2': 'Hello World 2'
 			});
 		});
 
@@ -223,8 +223,8 @@ describe('Request', () => {
 
 			expect(request.headers === headers).toBe(false);
 			expect(headerEntries).toEqual({
-				'X-Test': 'Hello World',
-				'X-Test-2': 'Hello World 2'
+				'x-test': 'Hello World',
+				'x-test-2': 'Hello World 2'
 			});
 		});
 

--- a/packages/happy-dom/test/fetch/Response.test.ts
+++ b/packages/happy-dom/test/fetch/Response.test.ts
@@ -84,7 +84,10 @@ describe('Response', () => {
 			}
 
 			expect(headers === response.headers).toBe(false);
-			expect(headerEntries).toEqual(headerValues);
+			expect(headerEntries).toEqual({
+				'content-type': 'text/plain',
+				'content-length': '123'
+			});
 		});
 
 		it('Sets body from init object.', async () => {

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -427,7 +427,7 @@ describe('SyncFetch', () => {
 			}
 
 			expect(headers).toEqual({
-				'Content-Type': 'text/plain'
+				'content-type': 'text/plain'
 			});
 		});
 
@@ -521,7 +521,7 @@ describe('SyncFetch', () => {
 			}
 
 			expect(headers).toEqual({
-				'Content-Type': 'text/plain'
+				'content-type': 'text/plain'
 			});
 		});
 
@@ -3021,8 +3021,8 @@ describe('SyncFetch', () => {
 			expect(headers2).toEqual({
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
-				'Cache-Control': 'max-age=1',
-				'Last-Modified': 'Mon, 11 Dec 2023 02:00:00 GMT'
+				'cache-control': 'max-age=1',
+				'last-modified': 'Mon, 11 Dec 2023 02:00:00 GMT'
 			});
 
 			expect(requestArgs).toEqual([
@@ -3315,8 +3315,8 @@ describe('SyncFetch', () => {
 				'content-type': 'text/html',
 				'content-length': String(responseText.length),
 				'cache-control': `max-age=0.0001`,
-				'Last-Modified': 'Mon, 11 Dec 2023 02:00:00 GMT',
-				ETag: etag2
+				'last-modified': 'Mon, 11 Dec 2023 02:00:00 GMT',
+				etag: etag2
 			});
 
 			expect(requestArgs).toEqual([

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -697,7 +697,7 @@ describe('XMLHttpRequest', () => {
 
 				request.addEventListener('load', () => {
 					expect(request.getAllResponseHeaders()).toBe(
-						'Content-Length: 4\r\nkey1: value1\r\nkey2: value2'
+						'content-length: 4\r\nkey1: value1\r\nkey2: value2'
 					);
 					resolve(null);
 				});


### PR DESCRIPTION
### Description

`Headers` iteration (`forEach()`, `keys()`, `values()`, `entries()`, `Symbol.iterator`) yielded header names with their original casing, in insertion order. Per the fetch spec's ["sort and combine"](https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine) step, iteration should yield lowercase names sorted lexicographically. Browsers and Node.js (undici) both do this.

The internal entries map is already keyed by lowercase name, so the fix is to iterate the sorted keys instead of the stored original-cased `name`:

```js
const headers = new Headers({ 'X-Custom-Header': 'value', Authorization: 'Bearer token' });

console.log([...headers.keys()]);
// Before: [ 'X-Custom-Header', 'Authorization' ]
// After:  [ 'authorization', 'x-custom-header' ] (matches browsers and Node.js)
```

Two internal consumers used the public iterators and were switched to read the internal entries map directly, so their behavior is unchanged:

- `FetchRequestHeaderUtility` copied request headers via `forEach()`. Outgoing HTTP requests still send the original header casing, as before.
- `ResponseCacheFileSystem` serialized cached headers via `entries()`. Cache files written to disk are identical to before.

`XMLHttpRequest.getAllResponseHeaders()` iterates the response headers, so it now returns lowercase sorted names as well. That matches the [XHR spec](https://xhr.spec.whatwg.org/#the-getallresponseheaders()-method), which uses the same sort and combine step but _could_ be considered breaking.

Existing tests that asserted the old iteration behavior has been updated, and new tests cover the lowercase and sorted-order behavior, including the reproduction case from the issue. 

Resolves #2249

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster.

### Tests

- [x] Make sure to add tests for your changes.
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description".
- [x] The title should be concise and descriptive.