### PR TITLE
fix: [#2253] Use proxy as parent node in Node.connectedToNode()

### DIFF
--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -987,7 +987,7 @@ export default class Node extends EventTarget {
 		// HTMLFormElement and HTMLSelectElement return a Proxy from their constructor.
 		// The proxy is the identity handed out by the public API, so it has to be stored
 		// as the parent of the child nodes, the same way as in appendChild() and insertBefore().
-		const self = (<any>this)[PropertySymbol.proxy] || this;
+		const self = this[PropertySymbol.proxy] || this;
 
 		const childNodes = this[PropertySymbol.nodeArray].slice();
 		for (let i = 0, max = childNodes.length; i < max; i++) {

--- a/packages/happy-dom/src/nodes/node/Node.ts
+++ b/packages/happy-dom/src/nodes/node/Node.ts
@@ -984,9 +984,14 @@ export default class Node extends EventTarget {
 			}
 		}
 
+		// HTMLFormElement and HTMLSelectElement return a Proxy from their constructor.
+		// The proxy is the identity handed out by the public API, so it has to be stored
+		// as the parent of the child nodes, the same way as in appendChild() and insertBefore().
+		const self = (<any>this)[PropertySymbol.proxy] || this;
+
 		const childNodes = this[PropertySymbol.nodeArray].slice();
 		for (let i = 0, max = childNodes.length; i < max; i++) {
-			childNodes[i][PropertySymbol.parentNode] = this;
+			childNodes[i][PropertySymbol.parentNode] = self;
 			childNodes[i][PropertySymbol.connectedToNode]();
 		}
 

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -1081,6 +1081,28 @@ describe('Element', () => {
 			expect(b.closest('div .span b') === b).toBe(true);
 			expect(b.closest('div .span article b') === b).toBe(true);
 		});
+
+		it('Finds the closest HTMLFormElement when it is inserted after its child nodes have been appended (issue #2253).', () => {
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+			const input = document.createElement('input');
+
+			form.appendChild(div);
+			div.appendChild(input);
+			document.body.appendChild(form);
+
+			expect(input.closest('form') === form).toBe(true);
+		});
+
+		it('Finds the closest HTMLSelectElement when it is inserted after its child nodes have been appended (issue #2253).', () => {
+			const select = document.createElement('select');
+			const option = document.createElement('option');
+
+			select.appendChild(option);
+			document.body.appendChild(select);
+
+			expect(option.closest('select') === select).toBe(true);
+		});
 	});
 
 	describe('querySelectorAll()', () => {

--- a/packages/happy-dom/test/nodes/node/Node.test.ts
+++ b/packages/happy-dom/test/nodes/node/Node.test.ts
@@ -255,6 +255,40 @@ describe('Node', () => {
 			expect(htmlElement.parentNode).toBe(document);
 			expect(htmlElement.parentElement).toBe(null);
 		});
+
+		it('Returns HTMLFormElement when it is inserted with child nodes already appended to it (issue #2253).', () => {
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+
+			form.appendChild(div);
+			document.body.appendChild(form);
+
+			expect(div.parentNode).toBe(form);
+			expect(div.parentElement).toBe(form);
+		});
+
+		it('Returns HTMLSelectElement when it is inserted with child nodes already appended to it (issue #2253).', () => {
+			const select = document.createElement('select');
+			const option = document.createElement('option');
+
+			select.appendChild(option);
+			document.body.appendChild(select);
+
+			expect(option.parentNode).toBe(select);
+			expect(option.parentElement).toBe(select);
+		});
+
+		it('Returns HTMLFormElement when it is inserted into a node that is not connected to the document (issue #2253).', () => {
+			const parent = document.createElement('div');
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+
+			form.appendChild(div);
+			parent.appendChild(form);
+
+			expect(div.parentNode).toBe(form);
+			expect(div.parentElement).toBe(form);
+		});
 	});
 
 	describe('get baseURI()', () => {
@@ -387,6 +421,44 @@ describe('Node', () => {
 			expect(form.contains(input)).toBe(true);
 			expect(form.contains(div)).toBe(true);
 			expect(div.contains(input)).toBe(true);
+		});
+
+		it('Returns "true" for nested elements within an HTMLFormElement that is inserted after its child nodes have been appended (issue #2253).', () => {
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+			const input = document.createElement('input');
+
+			form.appendChild(div);
+			div.appendChild(input);
+			document.body.appendChild(form);
+
+			expect(form.contains(input)).toBe(true);
+			expect(form.contains(div)).toBe(true);
+		});
+
+		it('Returns "true" for nested elements within an HTMLSelectElement that is inserted after its child nodes have been appended (issue #2253).', () => {
+			const select = document.createElement('select');
+			const optgroup = document.createElement('optgroup');
+			const option = document.createElement('option');
+
+			select.appendChild(optgroup);
+			optgroup.appendChild(option);
+			document.body.appendChild(select);
+
+			expect(select.contains(option)).toBe(true);
+			expect(select.contains(optgroup)).toBe(true);
+		});
+
+		it('Returns "false" for a node that is not a descendant of an inserted HTMLFormElement (issue #2253).', () => {
+			const form = document.createElement('form');
+			const div = document.createElement('div');
+			const sibling = document.createElement('input');
+
+			form.appendChild(div);
+			document.body.appendChild(form);
+			document.body.appendChild(sibling);
+
+			expect(form.contains(sibling)).toBe(false);
 		});
 	});
 
@@ -1265,6 +1337,27 @@ describe('Node', () => {
 				'c:DIV'
 			]);
 		});
+
+		it('Dispatches an event that bubbles to an HTMLFormElement that is inserted after its child nodes have been appended (issue #2253).', () => {
+			const form = document.createElement('form');
+			const input = document.createElement('input');
+			const event = new Event('click', { bubbles: true });
+			let formEventTarget: EventTarget | null = null;
+			let formEventCurrentTarget: EventTarget | null = null;
+
+			form.appendChild(input);
+			document.body.appendChild(form);
+
+			form.addEventListener('click', (event) => {
+				formEventTarget = event.target;
+				formEventCurrentTarget = event.currentTarget;
+			});
+
+			expect(input.dispatchEvent(event)).toBe(true);
+
+			expect(formEventTarget).toBe(input);
+			expect(formEventCurrentTarget).toBe(form);
+		});
 	});
 
 	describe('compareDocumentPosition()', () => {
@@ -1345,6 +1438,17 @@ describe('Node', () => {
 				.getElementById('child')
 				?.compareDocumentPosition(<Node>document.getElementById('parent'));
 			expect(position).toEqual(10);
+		});
+
+		it('Returns 20 if a is an HTMLFormElement that is inserted after its child nodes have been appended (issue #2253)', () => {
+			const form = document.createElement('form');
+			const input = document.createElement('input');
+
+			form.appendChild(input);
+			document.body.appendChild(form);
+
+			expect(form.compareDocumentPosition(input)).toEqual(20);
+			expect(input.compareDocumentPosition(form)).toEqual(10);
 		});
 	});
 


### PR DESCRIPTION
### Description

`HTMLFormElement` and `HTMLSelectElement` return a `Proxy` from their constructor, and that proxy is the identity the public API hands out — `createElement()`, `querySelector()`, `.children`, framework refs.

`Node[PropertySymbol.appendChild]()` and `insertBefore()` already store that proxy as the child's parent via `const self = this[PropertySymbol.proxy] || this`. But `Node[PropertySymbol.connectedToNode]()` re-points every direct child at bare `this`, which is the **raw target** — `ClassMethodBinder` binds symbol-keyed methods to the target, so `this` is the underlying node even when the method is reached through the proxy.

So whenever a `<form>`/`<select>` **that already has children** is inserted into any parent, its children's parent pointer holds an object that is `!==` the one user code holds, and everything reading the parent chain returns or compares against the wrong object:

```js
const form = document.createElement('form');
const div = document.createElement('div');
const input = document.createElement('input');

form.appendChild(div);
div.appendChild(input);
document.body.appendChild(form); // <- form already has children when inserted

div.parentNode === form;             // false (expected true)
div.parentElement === form;          // false (expected true)
input.closest('form') === form;      // false (expected true)
form.contains(input);                // false (expected true)
form.compareDocumentPosition(input); // 2     (expected 20)
```

Event propagation walks the same chain, so a listener on the `<form>` receives the raw target as `currentTarget`. The same applies to `<select>`/`<option>`.

Connection to the document is not required — `insertBefore()` and `replaceChild()` into a detached parent hit it too. Appending children *after* the element is already in place is fine, which is why `innerHTML`-parsed markup works and framework renders do not: React/Vue/Svelte build the subtree first and insert it afterwards, so a plain React render reproduces all of it with no manual DOM calls.

Resolves #2253

### Fix

Normalize to the proxy in `connectedToNode()`, the same way `appendChild()` and `insertBefore()` already do. Non-proxied nodes are unchanged, since `this[PropertySymbol.proxy]` is undefined for them.

This also appears to be the root cause of #2170 — `contains()` returning `false` for a descendant of a proxied `<form>`/`<select>`. #2176 fixes that by normalizing both sides of the comparison inside `NodeUtility.isInclusiveAncestor`, which repairs `contains()` but leaves the parent pointer holding the raw target, so `parentElement`, `closest()`, `compareDocumentPosition()` and `event.currentTarget` stay wrong. Fixing the parent pointer repairs `contains()` at the source: the #2170 reproduction passes with this diff alone and no change to `NodeUtility`.

### Verification

Behaviour was checked against real browsers before writing the tests — Chromium 148, Firefox 150 and WebKit 26.4 (via Playwright), plus jsdom 29.1.1 as a second reference. All of them return the expected values for every assertion above, including `compareDocumentPosition()` in both directions (`20` parent→child, `10` child→parent). happy-dom was the only outlier.

- `npm test` in `packages/happy-dom`: **7638 passed / 297 files**, no failures.
- The 10 added tests: 9 fail on `master` without the source change and pass with it. The 10th is a negative case (a sibling is not reported as a descendant) that passes either way, guarding the normalization against false positives.
- `npm run lint`: clean.

The `@happy-dom/node-canvas-adapter` suite has 9 pre-existing failures on this machine (native-canvas PNG snapshot mismatches). I confirmed they fail identically on unmodified `master`, so they are unrelated to this change.

### Tests

Added to `Node.test.ts` and `Element.test.ts`, covering the public API only:

- `get parentElement()` — `<form>` and `<select>` inserted with children already appended, plus insertion into a parent that is not connected to the document
- `contains()` — nested elements in an inserted `<form>`/`<select>`, plus the negative sibling case
- `compareDocumentPosition()` — `20` parent→child and `10` child→parent
- `dispatchEvent()` — `target`/`currentTarget` for an event bubbling to a `<form>`
- `closest()` — `<form>` and `<select>` ancestors

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

Disclosure: I used Claude Code as an assistant on this PR — for the root-cause investigation, the browser and jsdom cross-checks, and drafting the patch and tests. Every verification step described above was run locally against this branch. Happy to discuss or adjust any part of it.
