### PR TITLE
fix: [#2227] Treat out-of-range index as null in HTMLSelectElement.add()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,9 +2400,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2420,9 +2417,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2440,9 +2434,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2460,9 +2451,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2480,9 +2468,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2500,9 +2485,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3557,9 +3539,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3574,9 +3553,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3591,9 +3567,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3608,9 +3581,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3625,9 +3595,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3642,9 +3609,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3659,9 +3623,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3676,9 +3637,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3693,9 +3651,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3710,9 +3665,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -9970,9 +9922,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9994,9 +9943,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -10018,9 +9964,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -10042,9 +9985,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/packages/happy-dom/src/nodes/html-select-element/HTMLSelectElement.ts
+++ b/packages/happy-dom/src/nodes/html-select-element/HTMLSelectElement.ts
@@ -574,6 +574,12 @@ export default class HTMLSelectElement extends HTMLElement {
 	public add(element: HTMLOptionElement, before?: number | HTMLOptionElement): void {
 		const options = QuerySelector.querySelectorAll(this, 'option')[PropertySymbol.items];
 
+		// Per spec: out-of-range numeric index is treated as null (append)
+		// https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-add
+		if (typeof before === 'number' && before >= options.length) {
+			before = undefined;
+		}
+
 		if (!before && before !== 0) {
 			const childNodes = this[PropertySymbol.nodeArray];
 

--- a/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
@@ -487,6 +487,22 @@ describe('HTMLSelectElement', () => {
 			expect(element.options[1] === option3).toBe(true);
 			expect(element.options[2] === option2).toBe(true);
 		});
+
+		it('Treats out-of-range numeric index as null (appends) per HTML spec.', () => {
+			const option1 = <HTMLOptionElement>document.createElement('option');
+			const option2 = <HTMLOptionElement>document.createElement('option');
+			const option3 = <HTMLOptionElement>document.createElement('option');
+
+			element.add(option1);
+			element.add(option2);
+			// Index 5 is out of range (> current length of 2) — should append
+			element.add(option3, 5);
+
+			expect(element.length).toBe(3);
+			expect(element[0] === option1).toBe(true);
+			expect(element[1] === option2).toBe(true);
+			expect(element[2] === option3).toBe(true);
+		});
 	});
 
 	describe(`item()`, () => {


### PR DESCRIPTION
Fixes #2227

When HTMLSelectElement.add(element, before) receives a numeric before index that is out of range (>= options.length), the HTML spec says it should be treated as null (i.e., appended to the end). Browsers and jsdom append; happy-dom was throwing a DOMException.

Added an early check that sets before to undefined when the index is out of range, which falls through to the existing append logic.