### PR TITLE
fix: [#2238] Normalize font-weight keywords to numeric in computed style

### DIFF
--- a/packages/happy-dom/src/query-selector/QuerySelector.ts
+++ b/packages/happy-dom/src/query-selector/QuerySelector.ts
@@ -264,35 +264,40 @@ export default class QuerySelector {
 			(node[PropertySymbol.ownerDocument] || node)[PropertySymbol.affectsCache].push(cachedItem);
 		}
 
-		let bestMatch: DocumentPositionAndElement | null = null;
-		const matchesMap: Map<string, boolean> = new Map();
-		const scope =
-			node[PropertySymbol.nodeType] === NodeTypeEnum.documentNode
-				? (<Document>node).documentElement
-				: node;
+		try {
+			let bestMatch: DocumentPositionAndElement | null = null;
+			const matchesMap: Map<string, boolean> = new Map();
+			const scope =
+				node[PropertySymbol.nodeType] === NodeTypeEnum.documentNode
+					? (<Document>node).documentElement
+					: node;
 
-		for (const selectorItems of new SelectorParser({ window, scope }).getSelectorGroups(selector)) {
-			const rootElement =
-				node[PropertySymbol.nodeType] === NodeTypeEnum.elementNode ? <Element>node : null;
-			const children =
-				node[PropertySymbol.nodeType] === NodeTypeEnum.elementNode
-					? [<Element>node]
-					: (<Element>node)[PropertySymbol.elementArray];
-			const match = this.findFirst({ scope, rootElement, children, selectorItems, cachedItem });
+			for (const selectorItems of new SelectorParser({ window, scope }).getSelectorGroups(selector)) {
+				const rootElement =
+					node[PropertySymbol.nodeType] === NodeTypeEnum.elementNode ? <Element>node : null;
+				const children =
+					node[PropertySymbol.nodeType] === NodeTypeEnum.elementNode
+						? [<Element>node]
+						: (<Element>node)[PropertySymbol.elementArray];
+				const match = this.findFirst({ scope, rootElement, children, selectorItems, cachedItem });
 
-			if (match && !matchesMap.has(match.documentPosition)) {
-				matchesMap.set(match.documentPosition, true);
-				if (!bestMatch || match.documentPosition < bestMatch.documentPosition) {
-					bestMatch = match;
+				if (match && !matchesMap.has(match.documentPosition)) {
+					matchesMap.set(match.documentPosition, true);
+					if (!bestMatch || match.documentPosition < bestMatch.documentPosition) {
+						bestMatch = match;
+					}
 				}
 			}
+
+			const element = bestMatch?.element || null;
+
+			cachedItem.result = { element: element ? new WeakRef(element) : null };
+
+			return element;
+		} catch (error) {
+			node[PropertySymbol.cache].querySelector.delete(selector);
+			throw error;
 		}
-
-		const element = bestMatch?.element || null;
-
-		cachedItem.result = { element: element ? new WeakRef(element) : null };
-
-		return element;
 	}
 
 	/**

--- a/packages/happy-dom/test/query-selector/QuerySelector.test.ts
+++ b/packages/happy-dom/test/query-selector/QuerySelector.test.ts
@@ -2120,6 +2120,22 @@ describe('QuerySelector', () => {
 
 			expect(div.querySelector(`.${unicodeClassName}`)).toBe(element);
 		});
+
+		it('Throws consistently for invalid selectors that pass the quick-check regex.', () => {
+			const container = document.createElement('div');
+			// The selector '[' passes INVALID_SELECTOR_REGEXP check but fails actual CSS parsing
+			expect(() => container.querySelector('[')).toThrow(
+				new window.DOMException(
+					`Failed to execute 'querySelectorAll' on 'Element': '[' is not a valid selector.`
+				)
+			);
+			// Second call should also throw — cached null result must not suppress the error
+			expect(() => container.querySelector('[')).toThrow(
+				new window.DOMException(
+					`Failed to execute 'querySelectorAll' on 'Element': '[' is not a valid selector.`
+				)
+			);
+		});
 	});
 
 	describe('matches()', () => {


### PR DESCRIPTION
Fixes #2238

In browsers, `getComputedStyle(el).fontWeight` returns numeric values for keyword font-weights (e.g. `bold` → `700`, `normal` → `400`). happy-dom was returning the raw keyword value.

Added normalization in `CSSStyleDeclarationComputedStyle` so computed styles resolve font-weight keywords to their numeric equivalents. `element.style.fontWeight` continues to preserve the author's keyword value.