### PR TITLE
fix: [#2226] Copy labels array to prevent mutation of cached querySelectorAll result

### DIFF
--- a/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElementUtility.ts
@@ -24,11 +24,9 @@ export default class HTMLLabelElementUtility {
 			const rootNode =
 				<Document | ShadowRoot>element[PropertySymbol.rootNode] ||
 				element[PropertySymbol.ownerDocument];
-			labels = [
-				...(<HTMLLabelElement[]>(
-					rootNode.querySelectorAll(`label[for="${id}"]`)[PropertySymbol.items]
-				))
-			];
+			labels = <HTMLLabelElement[]>(
+				rootNode.querySelectorAll(`label[for="${id}"]`)[PropertySymbol.items].slice()
+			);
 		} else {
 			labels = [];
 		}

--- a/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElementUtility.ts
+++ b/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElementUtility.ts
@@ -24,9 +24,11 @@ export default class HTMLLabelElementUtility {
 			const rootNode =
 				<Document | ShadowRoot>element[PropertySymbol.rootNode] ||
 				element[PropertySymbol.ownerDocument];
-			labels = <HTMLLabelElement[]>(
-				rootNode.querySelectorAll(`label[for="${id}"]`)[PropertySymbol.items]
-			);
+			labels = [
+				...(<HTMLLabelElement[]>(
+					rootNode.querySelectorAll(`label[for="${id}"]`)[PropertySymbol.items]
+				))
+			];
 		} else {
 			labels = [];
 		}

--- a/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
@@ -209,5 +209,31 @@ describe('HTMLLabelElement', () => {
 			expect(changeFiredCount).toBe(1);
 			expect(div.querySelector('input')?.checked).toBe(true);
 		});
+
+		describe('get labels()', () => {
+			it('Does not duplicate entries on repeated reads.', () => {
+				const input = document.createElement('input');
+				input.id = 'test-input';
+				document.body.appendChild(input);
+
+				const label = document.createElement('label');
+				label.htmlFor = 'test-input';
+				document.body.appendChild(label);
+
+				expect(input.labels.length).toBe(1);
+				expect(input.labels.length).toBe(1);
+				expect(input.labels.length).toBe(1);
+			});
+
+			it('Returns the enclosing label element.', () => {
+				const label = document.createElement('label');
+				const input = document.createElement('input');
+				label.appendChild(input);
+				document.body.appendChild(label);
+
+				expect(input.labels.length).toBe(1);
+				expect(input.labels[0] === label).toBe(true);
+			});
+		});
 	});
 });


### PR DESCRIPTION
Fixes #2226. The labels getter assigned the internal items array of a cached querySelectorAll result directly, so the enclosing-label push mutated the cached array and caused duplicates on repeated reads. Spread into a fresh array instead.