### PR TITLE
feat: [#2213] Expose waitForNavigation() on window.happyDOM

### DIFF
--- a/packages/happy-dom/src/window/DetachedWindowAPI.ts
+++ b/packages/happy-dom/src/window/DetachedWindowAPI.ts
@@ -46,6 +46,15 @@ export default class DetachedWindowAPI {
 	}
 
 	/**
+	 * Waits for the frame to navigate and the response HTML to be written to the document.
+	 *
+	 * @returns Promise.
+	 */
+	public waitForNavigation(): Promise<void> {
+		return this.#browserFrame.waitForNavigation();
+	}
+
+	/**
 	 * Waits for all async tasks to complete.
 	 *
 	 * @deprecated Use waitUntilComplete() instead.

--- a/packages/happy-dom/test/window/DetachedWindowAPI.test.ts
+++ b/packages/happy-dom/test/window/DetachedWindowAPI.test.ts
@@ -288,6 +288,12 @@ describe('DetachedWindowAPI', () => {
 		});
 	});
 
+	describe('waitForNavigation()', () => {
+		it('Exposes waitForNavigation() from the browser frame.', () => {
+			expect(typeof window.happyDOM?.waitForNavigation).toBe('function');
+		});
+	});
+
 	describe('setURL()', () => {
 		it('Sets URL.', () => {
 			window.happyDOM?.setURL('https://localhost:8080');


### PR DESCRIPTION
Fixes #2213. Exposes `waitForNavigation()` on `DetachedWindowAPI` (accessible via `window.happyDOM`), delegating to the browser frame's existing implementation. This matches the pattern already used by `waitUntilComplete()` and allows Vitest users to await navigation without polling.