### PR TITLE
fix: [#2264] MutationObserver callback being GC'd due to orphaned WeakRef

### DIFF
--- a/packages/happy-dom/src/mutation-observer/MutationObserverListener.ts
+++ b/packages/happy-dom/src/mutation-observer/MutationObserverListener.ts
@@ -18,6 +18,7 @@ export default class MutationObserverListener {
 	#records: MutationRecord[] = [];
 	#destroyed = false;
 	#microtaskQueued = false;
+	#listenerCallback: (record: MutationRecord) => void;
 
 	/**
 	 * Constructor.
@@ -38,9 +39,10 @@ export default class MutationObserverListener {
 	}) {
 		this.options = init.options;
 		this.target = init.target;
+		this.#listenerCallback = (record: MutationRecord) => this.report(record);
 		this.mutationListener = {
 			options: init.options,
-			callback: new WeakRef((record: MutationRecord) => this.report(record))
+			callback: new WeakRef(this.#listenerCallback)
 		};
 		this.#window = init.window;
 		this.#observer = init.observer;
@@ -103,6 +105,7 @@ export default class MutationObserverListener {
 		this.#destroyed = true;
 		this.options = null!;
 		this.target = null!;
+		this.#listenerCallback = null!;
 		this.mutationListener = null!;
 		this.#window = null!;
 		this.#observer = null!;

--- a/packages/happy-dom/test/mutation-observer/MutationObserver.test.ts
+++ b/packages/happy-dom/test/mutation-observer/MutationObserver.test.ts
@@ -1,6 +1,6 @@
 import Window from '../../src/window/Window.js';
 import type Document from '../../src/nodes/document/Document.js';
-import MutationObserver from '../../src/mutation-observer/MutationObserver.js';
+import type MutationObserver from '../../src/mutation-observer/MutationObserver.js';
 import type MutationRecord from '../../src/mutation-observer/MutationRecord.js';
 import { beforeEach, describe, it, expect } from 'vitest';
 
@@ -327,6 +327,25 @@ describe('MutationObserver', () => {
 					type: 'attributes'
 				}
 			]);
+		});
+
+		it('Continues delivering mutations after the listener closure is no longer externally referenced.', async () => {
+			const records: MutationRecord[] = [];
+			const div = document.createElement('div');
+			let observer: MutationObserver | null = new window.MutationObserver((mutationRecords) =>
+				records.push(...mutationRecords)
+			);
+			observer.observe(div, { attributes: true });
+			// Dereference observer — only internal MutationObserverListener holds the callback
+			observer = null;
+			div.setAttribute('attr1', 'value1');
+			div.setAttribute('attr2', 'value2');
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect(records.length).toBe(2);
+			expect(records[0].attributeName).toBe('attr1');
+			expect(records[1].attributeName).toBe('attr2');
 		});
 	});
 


### PR DESCRIPTION
## What

Fixes #2264 — MutationObserverListener wraps the mutation delivery callback in a WeakRef without a strong reference, allowing V8 to GC the callback at any time. When collected, deref() returns undefined permanently and mutation delivery silently stops.

## How

Added a #listenerCallback private field to hold a strong reference to the arrow function. The strong reference is cleared in destroy(). This maintains the original weak semantics between listener and node while preventing premature GC.

## Changes

- Store listener callback as private field alongside WeakRef
- Clear in destroy()
- Test: verifies mutations are delivered when observer is externally dereferenced

*AI assisted: Claude Code*