### PR TITLE
fix: [#2273] Preserves case in XMLDocument.createElement

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1958,9 +1958,15 @@ export default class Document extends Node {
 					options && options.is ? String(options.is) : qualifiedName
 				);
 
+				const isXMLDocument =
+					this[PropertySymbol.contentType] === 'application/xml' ||
+					this[PropertySymbol.contentType] === 'text/xml';
+
 				if (customElementDefinition) {
 					const element = new customElementDefinition.elementClass();
-					element[PropertySymbol.tagName] = StringUtility.asciiUpperCase(qualifiedName);
+					element[PropertySymbol.tagName] = isXMLDocument
+						? qualifiedName
+						: StringUtility.asciiUpperCase(qualifiedName);
 					element[PropertySymbol.localName] = localName;
 					element[PropertySymbol.prefix] = prefix;
 					element[PropertySymbol.namespaceURI] = namespaceURI;
@@ -1976,7 +1982,9 @@ export default class Document extends Node {
 				if (elementClass) {
 					const element = NodeFactory.createNode<Element>(this, elementClass);
 
-					element[PropertySymbol.tagName] = StringUtility.asciiUpperCase(qualifiedName);
+					element[PropertySymbol.tagName] = isXMLDocument
+						? qualifiedName
+						: StringUtility.asciiUpperCase(qualifiedName);
 					element[PropertySymbol.localName] = localName;
 					element[PropertySymbol.prefix] = prefix;
 					element[PropertySymbol.namespaceURI] = namespaceURI;
@@ -1992,7 +2000,9 @@ export default class Document extends Node {
 
 				const unknownElement = NodeFactory.createNode<Element>(this, unknownElementClass);
 
-				unknownElement[PropertySymbol.tagName] = StringUtility.asciiUpperCase(qualifiedName);
+				unknownElement[PropertySymbol.tagName] = isXMLDocument
+					? qualifiedName
+					: StringUtility.asciiUpperCase(qualifiedName);
 				unknownElement[PropertySymbol.localName] = localName;
 				unknownElement[PropertySymbol.prefix] = prefix;
 				unknownElement[PropertySymbol.namespaceURI] = namespaceURI;

--- a/packages/happy-dom/src/nodes/xml-document/XMLDocument.ts
+++ b/packages/happy-dom/src/nodes/xml-document/XMLDocument.ts
@@ -1,5 +1,7 @@
 import Document from '../document/Document.js';
 import * as PropertySymbol from '../../PropertySymbol.js';
+import NamespaceURI from '../../config/NamespaceURI.js';
+import type HTMLElement from '../html-element/HTMLElement.js';
 
 /**
  * Document.
@@ -7,4 +9,17 @@ import * as PropertySymbol from '../../PropertySymbol.js';
 export default class XMLDocument extends Document {
 	// Internal properties
 	public [PropertySymbol.contentType]: string = 'application/xml';
+
+	/* eslint-disable jsdoc/valid-types */
+	/**
+	 * Creates an element. Preserves case for XML documents (element names are case-sensitive in XML).
+	 *
+	 * @param qualifiedName Tag name.
+	 * @param [options] Options.
+	 * @param [options.is] Tag name of a custom element previously defined via customElements.define().
+	 * @returns Element.
+	 */
+	public override createElement(qualifiedName: string, options?: { is?: string }): HTMLElement {
+		return <HTMLElement>this.createElementNS(NamespaceURI.html, String(qualifiedName), options);
+	}
 }

--- a/packages/happy-dom/test/nodes/xml-document/XMLDocument.test.ts
+++ b/packages/happy-dom/test/nodes/xml-document/XMLDocument.test.ts
@@ -1,0 +1,35 @@
+import Window from '../../../src/window/Window.js';
+import DOMParser from '../../../src/dom-parser/DOMParser.js';
+import { describe, it, expect } from 'vitest';
+
+describe('XMLDocument', () => {
+	describe('createElement()', () => {
+		it('Preserves case of element names in XML documents.', () => {
+			const window = new Window();
+			const domParser = new window.DOMParser();
+			const xmlDocument = domParser.parseFromString('<root/>', 'text/xml');
+			const element = xmlDocument.createElement('myNode');
+
+			expect(element.nodeName).toBe('myNode');
+			expect(element.tagName).toBe('myNode');
+		});
+
+		it('Preserves mixed case element names in XML documents.', () => {
+			const window = new Window();
+			const domParser = new window.DOMParser();
+			const xmlDocument = domParser.parseFromString('<root/>', 'text/xml');
+			const element = xmlDocument.createElement('MyNode');
+
+			expect(element.nodeName).toBe('MyNode');
+			expect(element.tagName).toBe('MyNode');
+		});
+
+		it('HTML documents still uppercase element names.', () => {
+			const window = new Window();
+			const element = window.document.createElement('myNode');
+
+			expect(element.nodeName).toBe('MYNODE');
+			expect(element.tagName).toBe('MYNODE');
+		});
+	});
+});


### PR DESCRIPTION
XMLDocument.createElement() was uppercasing element names because it inherited Document.createElement() which lowercases and then createElementNS() which uppercases. For XML documents element names are case-sensitive per spec.

Fix: Override createElement() in XMLDocument to skip lowercasing, and preserve original case in createElementNS() when the document is an XML document (checked via contentType).

Closes #2273