### PR TITLE
fix: [#2267] Add Document.compatMode getter

### DIFF
--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1301,6 +1301,23 @@ export default class Document extends Node {
 	}
 
 	/**
+	 * Returns "CSS1Compat" for standards mode or "BackCompat" for quirks mode.
+	 *
+	 * @returns Compat mode.
+	 */
+	public get compatMode(): string {
+		if (this[PropertySymbol.contentType] === 'application/xml') {
+			return 'CSS1Compat';
+		}
+		for (const node of this[PropertySymbol.nodeArray]) {
+			if (node instanceof DocumentType) {
+				return 'CSS1Compat';
+			}
+		}
+		return 'BackCompat';
+	}
+
+	/**
 	 * Returns <body> element.
 	 *
 	 * @returns Element.

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -533,6 +533,18 @@ describe('Document', () => {
 		});
 	});
 
+	describe('get compatMode()', () => {
+		it('Returns "CSS1Compat" when document has a doctype.', () => {
+			document.write('<!DOCTYPE html>');
+			expect(document.compatMode).toBe('CSS1Compat');
+		});
+
+		it('Returns "BackCompat" when document has no doctype.', () => {
+			const window = new Window();
+			expect(window.document.compatMode).toBe('BackCompat');
+		});
+	});
+
 	describe('get styleSheets()', () => {
 		it('Returns all stylesheets loaded to the document.', async () => {
 			await new Promise((resolve) => {


### PR DESCRIPTION
Adds the missing `Document.compatMode` getter per the DOM spec.
Returns `CSS1Compat` when the document has a doctype (or is XML), `BackCompat` otherwise.
Fixes #2267.