### PR TITLE
fix: [#2256] Preserve var() fallback values in inline style declarations

### DIFF
--- a/packages/happy-dom/src/css/declaration/property-manager/CSSStyleDeclarationValueParser.ts
+++ b/packages/happy-dom/src/css/declaration/property-manager/CSSStyleDeclarationValueParser.ts
@@ -429,10 +429,32 @@ export default class CSSStyleDeclarationValueParser {
 	 * @returns Parsed value.
 	 */
 	public static getVariable(value: string): string | null {
+		// Fast path: simple var(--name) without fallback
 		const cssVariableMatch = value.match(CSS_VARIABLE_REGEXP);
 		if (cssVariableMatch) {
 			return `var(${cssVariableMatch[1]})`;
 		}
+
+		// Slow path: var() with fallback or nested parens in value (e.g. var(--x, 10px), var(--x, rgb(0,0,0)))
+		if (value.startsWith('var(')) {
+			let depth = 0;
+			for (let i = 0; i < value.length; i++) {
+				if (value[i] === '(') {
+					depth++;
+				} else if (value[i] === ')') {
+					depth--;
+					if (depth === 0) {
+						// Verify there's a valid variable name between 'var(' and ',' or ')'
+						const inner = value.slice(4, i);
+						if (/^\s*--[^),]/.test(inner)) {
+							return value.slice(0, i + 1);
+						}
+						return null;
+					}
+				}
+			}
+		}
+
 		return null;
 	}
 

--- a/packages/happy-dom/test/css/declaration/CSSStyleDeclaration.test.ts
+++ b/packages/happy-dom/test/css/declaration/CSSStyleDeclaration.test.ts
@@ -3112,6 +3112,25 @@ describe('CSSStyleDeclaration', () => {
 				}).getPropertyValue('--test-key')
 			).toBe('value');
 		});
+		it('Preserves var() with fallback value in a CSS property.', () => {
+			const declaration = new CSSStyleDeclaration(PropertySymbol.illegalConstructor, window, {
+				element
+			});
+
+			declaration.setProperty('width', 'var(--x, 10px)');
+
+			expect(declaration.getPropertyValue('width')).toBe('var(--x, 10px)');
+		});
+
+		it('Preserves var() with nested fallback value (e.g. rgb()) in a CSS property.', () => {
+			const declaration = new CSSStyleDeclaration(PropertySymbol.illegalConstructor, window, {
+				element
+			});
+
+			declaration.setProperty('color', 'var(--primary, rgb(255, 0, 0))');
+
+			expect(declaration.getPropertyValue('color')).toBe('var(--primary, rgb(255, 0, 0))');
+		});
 	});
 
 	describe('removeProperty()', () => {


### PR DESCRIPTION
Fixes #2256.

The CSS variable parser in `CSSStyleDeclarationValueParser.getVariable()` only matched `var(--name)` without fallback values. When a value like `var(--x, 10px)` was set via inline style, the regex didn't match and the entire declaration was dropped.

Fixed by adding a balanced-parentheses parser fallback when the regex doesn't match, preserving the full `var()` expression including any fallback values with nested parentheses (e.g. `var(--primary, rgb(255, 0, 0))`).

Added two tests for fallback preservation.