### PR TITLE
fix: [#0] Fix DocumentFragment nodeName

### DIFF
--- a/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
+++ b/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
@@ -19,6 +19,15 @@ export default class DocumentFragment extends Node {
 	public declare cloneNode: (deep?: boolean) => DocumentFragment;
 
 	/**
+	 * Node name.
+	 *
+	 * @returns Node name.
+	 */
+	public get nodeName(): string {
+		return '#document-fragment';
+	}
+
+	/**
 	 * Returns the document fragment children.
 	 */
 	public get children(): HTMLCollection<Element> {

--- a/packages/happy-dom/test/nodes/document-fragment/DocumentFragment.test.ts
+++ b/packages/happy-dom/test/nodes/document-fragment/DocumentFragment.test.ts
@@ -26,6 +26,12 @@ describe('DocumentFragment', () => {
 		vi.restoreAllMocks();
 	});
 
+	describe('get nodeName()', () => {
+		it('Returns "#document-fragment".', () => {
+			expect(documentFragment.nodeName).toBe('#document-fragment');
+		});
+	});
+
 	describe('get children()', () => {
 		it('Returns Element child nodes.', () => {
 			const div = document.createElement('div');


### PR DESCRIPTION
### Description

Fixed the `nodeName` property for `DocumentFragment`

Refs:
- https://developer.mozilla.org/ru/docs/Web/API/Node/nodeName
- https://github.com/web-platform-tests/wpt/blob/master/dom/nodes/Node-nodeName.html#L28-L31

I didn't use AI tools
