### PR TITLE
fix: allow explicit element types for querySelector

### DIFF
--- a/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
+++ b/packages/happy-dom/src/nodes/document-fragment/DocumentFragment.ts
@@ -146,7 +146,7 @@ export default class DocumentFragment extends Node {
 	 * @param selector CSS selector.
 	 * @returns Matching elements.
 	 */
-	public querySelectorAll(selector: string): NodeList<Element>;
+	public querySelectorAll<E extends Element = Element>(selector: string): NodeList<E>;
 
 	/**
 	 * Query CSS selector to find matching elments.
@@ -184,7 +184,7 @@ export default class DocumentFragment extends Node {
 	 * @param selector CSS selector.
 	 * @returns Matching element.
 	 */
-	public querySelector(selector: string): Element | null;
+	public querySelector<E extends Element = Element>(selector: string): E | null;
 
 	/**
 	 * Query CSS Selector to find a matching element.

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -1484,7 +1484,7 @@ export default class Document extends Node {
 	 * @param selector CSS selector.
 	 * @returns Matching elements.
 	 */
-	public querySelectorAll(selector: string): NodeList<Element>;
+	public querySelectorAll<E extends Element = Element>(selector: string): NodeList<E>;
 
 	/**
 	 * Query CSS selector to find matching elements.
@@ -1522,7 +1522,7 @@ export default class Document extends Node {
 	 * @param selector CSS selector.
 	 * @returns Matching element.
 	 */
-	public querySelector(selector: string): Element | null;
+	public querySelector<E extends Element = Element>(selector: string): E | null;
 
 	/**
 	 * Query CSS Selector to find matching node.

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -1089,7 +1089,7 @@ export default class Element
 	 * @param selector CSS selector.
 	 * @returns Matching elements.
 	 */
-	public querySelectorAll(selector: string): NodeList<Element>;
+	public querySelectorAll<E extends Element = Element>(selector: string): NodeList<E>;
 
 	/**
 	 * Query CSS selector to find matching elements.
@@ -1127,7 +1127,7 @@ export default class Element
 	 * @param selector CSS selector.
 	 * @returns Matching element.
 	 */
-	public querySelector(selector: string): Element | null;
+	public querySelector<E extends Element = Element>(selector: string): E | null;
 
 	/**
 	 * Query CSS Selector to find matching node.

--- a/packages/happy-dom/src/nodes/parent-node/IParentNode.ts
+++ b/packages/happy-dom/src/nodes/parent-node/IParentNode.ts
@@ -37,7 +37,7 @@ export default interface IParentNode extends Node {
 	querySelector<K extends keyof ISVGElementTagNameMap>(
 		selector: K
 	): ISVGElementTagNameMap[K] | null;
-	querySelector(selector: string): Element | null;
+	querySelector<E extends Element = Element>(selector: string): E | null;
 
 	/**
 	 * Query CSS selector to find matching nodes.
@@ -51,7 +51,7 @@ export default interface IParentNode extends Node {
 	querySelectorAll<K extends keyof ISVGElementTagNameMap>(
 		selector: K
 	): NodeList<ISVGElementTagNameMap[K]>;
-	querySelectorAll(selector: string): NodeList<Element>;
+	querySelectorAll<E extends Element = Element>(selector: string): NodeList<E>;
 
 	/**
 	 * Query CSS selector to find matching nodes.
@@ -59,7 +59,7 @@ export default interface IParentNode extends Node {
 	 * @param selector CSS selector.
 	 * @returns Matching elements.
 	 */
-	querySelectorAll(selector: string): NodeList<Element>;
+	querySelectorAll<E extends Element = Element>(selector: string): NodeList<E>;
 
 	/**
 	 * Returns an elements by class name.

--- a/packages/happy-dom/src/query-selector/QuerySelector.ts
+++ b/packages/happy-dom/src/query-selector/QuerySelector.ts
@@ -61,10 +61,10 @@ export default class QuerySelector {
 	 * @param selector Selector.
 	 * @returns HTML elements.
 	 */
-	public static querySelectorAll(
+	public static querySelectorAll<E extends Element = Element>(
 		node: Element | Document | DocumentFragment,
 		selector: string
-	): NodeList<Element>;
+	): NodeList<E>;
 
 	/**
 	 * Finds elements based on a query selector.
@@ -194,10 +194,10 @@ export default class QuerySelector {
 	 * @param selector Selector.
 	 * @returns HTML element.
 	 */
-	public static querySelector(
+	public static querySelector<E extends Element = Element>(
 		node: Element | Document | DocumentFragment,
 		selector: string
-	): Element | null;
+	): E | null;
 
 	/**
 	 * Finds an element based on a query selector.


### PR DESCRIPTION
## Summary

Fixes #2282

Allows explicit element type arguments on string-selector overloads, so calls like `document.querySelector<HTMLInputElement>("#id")` type-check instead of requiring the generic to be a tag-name key.

## Testing

- `npx vitest run test/query-selector/QuerySelector.test.ts`
- `npm run compile`
- `git diff --check HEAD~1..HEAD`

I also ran local TypeScript smoke checks while developing the overload change.
