### PR TITLE
feat: [#2284] Adds support for cascade layers (@layer)

### DIFF
--- a/packages/happy-dom/src/PropertySymbol.ts
+++ b/packages/happy-dom/src/PropertySymbol.ts
@@ -96,6 +96,7 @@ export const clientWidth = Symbol('clientWidth');
 export const clientLeft = Symbol('clientLeft');
 export const clientTop = Symbol('clientTop');
 export const name = Symbol('name');
+export const nameList = Symbol('nameList');
 export const specified = Symbol('specified');
 export const adoptedStyleSheets = Symbol('adoptedStyleSheets');
 export const implementation = Symbol('implementation');

--- a/packages/happy-dom/src/css/declaration/computed-style/CSSStyleDeclarationComputedStyle.ts
+++ b/packages/happy-dom/src/css/declaration/computed-style/CSSStyleDeclarationComputedStyle.ts
@@ -20,6 +20,8 @@ import MediaQueryList from '../../../match-media/MediaQueryList.js';
 import WindowBrowserContext from '../../../window/WindowBrowserContext.js';
 import type CSSSupportsRule from '../../rules/CSSSupportsRule.js';
 import CSSScopeRule from '../../rules/CSSScopeRule.js';
+import CSSLayerBlockRule from '../../rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from '../../rules/CSSLayerStatementRule.js';
 import type CSSStyleSheet from '../../CSSStyleSheet.js';
 
 const CSS_MEASUREMENT_REGEXP = /[0-9.]+(px|rem|em|vw|vh|%|vmin|vmax|cm|mm|in|pt|pc|Q)/g;
@@ -27,9 +29,14 @@ const HOST_REGEXP = /:host\s*\(([^)]+)\)|:host-context\s*\(([^)]+)\)/;
 const SINGLE_CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+)\)/;
 const CSS_VARIABLE_REGEXP = /var\( *(--[^), ]+), *([^), ]+)\)/;
 
+type ICascadeLayer = {
+	children: Map<string, ICascadeLayer>;
+	index: number;
+};
+
 type IStyleAndElement = {
 	element: Element | ShadowRoot | Document | null;
-	cssTexts: Array<{ cssText: string; priorityWeight: number }>;
+	cssTexts: Array<{ cssText: string; priorityWeight: number; layer: ICascadeLayer }>;
 };
 
 /**
@@ -37,6 +44,13 @@ type IStyleAndElement = {
  */
 export default class CSSStyleDeclarationComputedStyle {
 	private element: Element;
+
+	// Root of the cascade layer tree. Its children are the layers in the order they are
+	// first declared, and it holds the unlayered rules itself, which is why it is numbered
+	// last: the rules of a layer rank before the rules of its parent.
+	private layerRoot: ICascadeLayer = { children: new Map(), index: 0 };
+	private anonymousLayers: WeakMap<CSSLayerBlockRule, ICascadeLayer> = new WeakMap();
+	private anonymousLayerCount: number = 0;
 
 	/**
 	 * Constructor.
@@ -157,6 +171,8 @@ export default class CSSStyleDeclarationComputedStyle {
 			}
 		}
 
+		this.assignLayerIndexes(this.layerRoot, 0);
+
 		// Concatenates all parent element CSS to one string.
 		const targetElement = parentElements[parentElements.length - 1];
 		const propertyManager = new CSSStyleDeclarationPropertyManager();
@@ -165,7 +181,9 @@ export default class CSSStyleDeclarationComputedStyle {
 		let parentFontSize: string | number = 16;
 
 		for (const parentElement of parentElements) {
-			parentElement.cssTexts.sort((a, b) => a.priorityWeight - b.priorityWeight);
+			parentElement.cssTexts.sort(
+				(a, b) => a.layer.index - b.layer.index || a.priorityWeight - b.priorityWeight
+			);
 
 			const defaultCSS = (<any>CSSStyleDeclarationElementDefaultCSS)[
 				(<Element>parentElement.element)[PropertySymbol.tagName]!
@@ -198,6 +216,36 @@ export default class CSSStyleDeclarationComputedStyle {
 			const rules = rulesAndProperties.rules;
 
 			Object.assign(cssProperties, rulesAndProperties.properties);
+
+			// An important declaration in an earlier layer beats one in a later layer, which
+			// is the opposite of the order the rules above were applied in. The important
+			// declarations are therefore applied a second time in the opposite layer order.
+			// The style attribute is appended again as it outranks every author rule.
+			const importantCSSTexts = parentElement.cssTexts.filter((cssText) =>
+				cssText.cssText.includes('!important')
+			);
+
+			if (importantCSSTexts.length > 1) {
+				importantCSSTexts.sort(
+					(a, b) => b.layer.index - a.layer.index || a.priorityWeight - b.priorityWeight
+				);
+
+				let importantCSSText = '';
+
+				for (const cssText of importantCSSTexts) {
+					importantCSSText += cssText.cssText;
+				}
+
+				if (elementStyleAttribute) {
+					importantCSSText += elementStyleAttribute;
+				}
+
+				for (const rule of CSSStyleDeclarationCSSParser.parse(importantCSSText).rules) {
+					if (rule.important) {
+						rules.push(rule);
+					}
+				}
+			}
 
 			for (const { name, value, important } of rules) {
 				if (
@@ -293,12 +341,14 @@ export default class CSSStyleDeclarationComputedStyle {
 	 * @param options.cssRules CSS rules.
 	 * @param [options.hostElement] Host element.
 	 * @param [options.scopeElement] Scope element.
+	 * @param [options.layer] Cascade layer the rules belong to.
 	 */
 	private parseCSSRules(options: {
 		cssRules: CSSRule[];
 		elements: IStyleAndElement[];
 		hostElement?: IStyleAndElement | null;
 		scopeElement?: IStyleAndElement | null;
+		layer?: ICascadeLayer | null;
 	}): void {
 		if (!options.hostElement && !options.elements.length) {
 			return;
@@ -343,7 +393,8 @@ export default class CSSStyleDeclarationComputedStyle {
 												if (match) {
 													element.cssTexts.push({
 														cssText: (<CSSStyleRule>rule)[PropertySymbol.cssText],
-														priorityWeight: 10 + match.priorityWeight
+														priorityWeight: 10 + match.priorityWeight,
+														layer: options.layer || this.layerRoot
 													});
 												}
 											}
@@ -357,7 +408,8 @@ export default class CSSStyleDeclarationComputedStyle {
 							if (isTargetHost) {
 								options.hostElement.cssTexts.push({
 									cssText: (<CSSStyleRule>rule)[PropertySymbol.cssText],
-									priorityWeight: 10
+									priorityWeight: 10,
+									layer: options.layer || this.layerRoot
 								});
 							}
 						}
@@ -370,7 +422,8 @@ export default class CSSStyleDeclarationComputedStyle {
 							if (match) {
 								element.cssTexts.push({
 									cssText: (<CSSStyleRule>rule)[PropertySymbol.cssText],
-									priorityWeight: match.priorityWeight
+									priorityWeight: match.priorityWeight,
+									layer: options.layer || this.layerRoot
 								});
 							}
 						}
@@ -389,7 +442,8 @@ export default class CSSStyleDeclarationComputedStyle {
 					elements: options.elements,
 					cssRules: (<CSSMediaRule>rule).cssRules,
 					hostElement: options.hostElement,
-					scopeElement: options.scopeElement
+					scopeElement: options.scopeElement,
+					layer: options.layer
 				});
 			} else if (rule.type === CSSRuleTypeEnum.supportsRule) {
 				if (window.CSS.supports((<CSSSupportsRule>rule).conditionText)) {
@@ -397,11 +451,27 @@ export default class CSSStyleDeclarationComputedStyle {
 						elements: options.elements,
 						cssRules: (<CSSSupportsRule>rule).cssRules,
 						hostElement: options.hostElement,
-						scopeElement: options.scopeElement
+						scopeElement: options.scopeElement,
+						layer: options.layer
 					});
 				}
 			} else if (rule.type === CSSRuleTypeEnum.containerRule) {
-				if (rule instanceof CSSScopeRule) {
+				if (rule instanceof CSSLayerStatementRule) {
+					// The statement only declares layers, which fixes their place in the order.
+					for (const name of rule.nameList) {
+						this.registerLayer(options.layer || this.layerRoot, name);
+					}
+				} else if (rule instanceof CSSLayerBlockRule) {
+					this.parseCSSRules({
+						elements: options.elements,
+						cssRules: rule.cssRules,
+						hostElement: options.hostElement,
+						scopeElement: options.scopeElement,
+						layer: rule.name
+							? this.registerLayer(options.layer || this.layerRoot, rule.name)
+							: this.registerAnonymousLayer(options.layer || this.layerRoot, rule)
+					});
+				} else if (rule instanceof CSSScopeRule) {
 					const scopedElements: IStyleAndElement[] = [];
 					let scope: IStyleAndElement | null = null;
 
@@ -441,13 +511,80 @@ export default class CSSStyleDeclarationComputedStyle {
 							elements: scopedElements,
 							cssRules: (<CSSScopeRule>rule).cssRules,
 							hostElement: options.hostElement,
-							scopeElement: scope
+							scopeElement: scope,
+							layer: options.layer
 						});
 					}
 				}
 				// TODO: Add support for CSSContainerRule, which would require element sizes to be measured.
 			}
 		}
+	}
+
+	/**
+	 * Returns the layer a name refers to, creating it in declaration order if it is new.
+	 *
+	 * @param parent Parent layer.
+	 * @param name Layer name, which may be a path (e.g. "framework.base").
+	 * @returns Layer.
+	 */
+	private registerLayer(parent: ICascadeLayer, name: string): ICascadeLayer {
+		let layer = parent;
+
+		for (const part of name.split('.')) {
+			let child = layer.children.get(part);
+
+			if (!child) {
+				child = { children: new Map(), index: 0 };
+				layer.children.set(part, child);
+			}
+
+			layer = child;
+		}
+
+		return layer;
+	}
+
+	/**
+	 * Returns the layer an unnamed block refers to. Each block is a layer of its own that
+	 * nothing can refer to, so it is keyed by the rule rather than by a name.
+	 *
+	 * @param parent Parent layer.
+	 * @param rule Layer block rule.
+	 * @returns Layer.
+	 */
+	private registerAnonymousLayer(parent: ICascadeLayer, rule: CSSLayerBlockRule): ICascadeLayer {
+		let layer = this.anonymousLayers.get(rule);
+
+		if (!layer) {
+			layer = { children: new Map(), index: 0 };
+			this.anonymousLayers.set(rule, layer);
+			// A CSS identifier cannot contain a null character, so the key cannot collide
+			// with a layer name.
+			parent.children.set(`\u0000${this.anonymousLayerCount++}`, layer);
+		}
+
+		return layer;
+	}
+
+	/**
+	 * Numbers the layers in cascade order. A layer's own rules rank after the rules of its
+	 * sublayers, so a layer is numbered once its children are.
+	 *
+	 * @param layer Layer.
+	 * @param index Next index.
+	 * @returns Next index.
+	 */
+	private assignLayerIndexes(layer: ICascadeLayer, index: number): number {
+		let next = index;
+
+		for (const child of layer.children.values()) {
+			next = this.assignLayerIndexes(child, next);
+		}
+
+		layer.index = next;
+
+		return next + 1;
 	}
 
 	/**

--- a/packages/happy-dom/src/css/rules/CSSLayerBlockRule.ts
+++ b/packages/happy-dom/src/css/rules/CSSLayerBlockRule.ts
@@ -1,0 +1,40 @@
+import * as PropertySymbol from '../../PropertySymbol.js';
+import CSSRuleTypeEnum from '../CSSRuleTypeEnum.js';
+import CSSGroupingRule from './CSSGroupingRule.js';
+
+/**
+ * CSSLayerBlockRule interface.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSLayerBlockRule
+ */
+export default class CSSLayerBlockRule extends CSSGroupingRule {
+	public [PropertySymbol.name] = '';
+
+	/**
+	 * @override
+	 */
+	public override get type(): CSSRuleTypeEnum {
+		return CSSRuleTypeEnum.containerRule;
+	}
+
+	/**
+	 * Returns name.
+	 *
+	 * @returns Name. An anonymous layer has an empty name.
+	 */
+	public get name(): string {
+		return this[PropertySymbol.name];
+	}
+
+	/**
+	 * @override
+	 */
+	public override get cssText(): string {
+		let cssText = '';
+		for (const cssRule of this[PropertySymbol.cssRules]) {
+			cssText += '\n  ' + cssRule.cssText;
+		}
+		cssText += '\n';
+		return `@layer${this[PropertySymbol.name] ? ` ${this[PropertySymbol.name]}` : ''} {${cssText}}`;
+	}
+}

--- a/packages/happy-dom/src/css/rules/CSSLayerStatementRule.ts
+++ b/packages/happy-dom/src/css/rules/CSSLayerStatementRule.ts
@@ -1,0 +1,35 @@
+import * as PropertySymbol from '../../PropertySymbol.js';
+import CSSRuleTypeEnum from '../CSSRuleTypeEnum.js';
+import CSSRule from '../CSSRule.js';
+
+/**
+ * CSSLayerStatementRule interface.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CSSLayerStatementRule
+ */
+export default class CSSLayerStatementRule extends CSSRule {
+	public [PropertySymbol.nameList]: string[] = [];
+
+	/**
+	 * @override
+	 */
+	public override get type(): CSSRuleTypeEnum {
+		return CSSRuleTypeEnum.containerRule;
+	}
+
+	/**
+	 * Returns name list.
+	 *
+	 * @returns Names of the layers the rule declares, in the order declared.
+	 */
+	public get nameList(): readonly string[] {
+		return Object.freeze(this[PropertySymbol.nameList].slice());
+	}
+
+	/**
+	 * @override
+	 */
+	public override get cssText(): string {
+		return `@layer ${this[PropertySymbol.nameList].join(', ')};`;
+	}
+}

--- a/packages/happy-dom/src/css/utilities/CSSParser.ts
+++ b/packages/happy-dom/src/css/utilities/CSSParser.ts
@@ -11,6 +11,8 @@ import CSSFontFaceRule from '../rules/CSSFontFaceRule.js';
 import SelectorParser from '../../query-selector/SelectorParser.js';
 import CSSRuleTypeEnum from '../CSSRuleTypeEnum.js';
 import CSSScopeRule from '../rules/CSSScopeRule.js';
+import CSSLayerBlockRule from '../rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from '../rules/CSSLayerStatementRule.js';
 
 const COMMENT_REGEXP = /\/\*[\s\S]*?\*\//gm;
 
@@ -39,13 +41,76 @@ export default class CSSParser {
 		const window = parentStyleSheet[PropertySymbol.window];
 		const css = cssText.replace(COMMENT_REGEXP, '');
 		const cssRules = [];
-		const regExp = /{|}/gm;
+		const regExp = /{|}|;/gm;
 		const stack: CSSRule[] = [];
 		let parentRule: CSSRule | null = null;
 		let lastIndex = 0;
 		let match: RegExpMatchArray | null;
 
 		while ((match = regExp.exec(css))) {
+			if (match[0] === ';') {
+				// A semicolon inside a declaration block belongs to a declaration and is read
+				// when the block closes.
+				if (
+					parentRule &&
+					(parentRule.type === CSSRuleTypeEnum.styleRule ||
+						parentRule.type === CSSRuleTypeEnum.fontFaceRule ||
+						parentRule.type === CSSRuleTypeEnum.keyframeRule)
+				) {
+					continue;
+				}
+
+				const statementText = css.substring(lastIndex, match.index).trim();
+
+				// Only an at-rule ends at a semicolon. A stray semicolon stays part of the
+				// next rule's selector, which makes that selector invalid.
+				if (statementText[0] !== '@') {
+					continue;
+				}
+
+				lastIndex = match.index! + 1;
+
+				if (statementText.split(/\s+/)[0] !== '@layer') {
+					// Another statement at-rule. Its text is consumed so that it does not
+					// become part of the next rule's selector, but no rule is created for it.
+					continue;
+				}
+
+				const names = statementText
+					.slice('@layer'.length)
+					.split(',')
+					.map((name) => name.trim())
+					.filter((name) => !!name);
+
+				if (!names.length) {
+					continue;
+				}
+
+				const statementRule = new CSSLayerStatementRule(
+					PropertySymbol.illegalConstructor,
+					window,
+					this
+				);
+
+				statementRule[PropertySymbol.nameList] = names;
+				statementRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
+
+				if (parentRule) {
+					if (
+						parentRule.type === CSSRuleTypeEnum.mediaRule ||
+						parentRule.type === CSSRuleTypeEnum.containerRule ||
+						parentRule.type === CSSRuleTypeEnum.supportsRule
+					) {
+						statementRule[PropertySymbol.parentRule] = parentRule;
+						(<CSSMediaRule>parentRule).cssRules.push(statementRule);
+					}
+				} else {
+					cssRules.push(statementRule);
+				}
+
+				continue;
+			}
+
 			if (match[0] === '{') {
 				const selectorText = css.substring(lastIndex, match.index).trim();
 
@@ -213,6 +278,31 @@ export default class CSSParser {
 								cssRules.push(scopeRule);
 							}
 							parentRule = scopeRule;
+							break;
+						case '@layer':
+							const layerRule = new CSSLayerBlockRule(
+								PropertySymbol.illegalConstructor,
+								window,
+								this
+							);
+
+							layerRule[PropertySymbol.name] = ruleParameters;
+							layerRule[PropertySymbol.parentStyleSheet] = parentStyleSheet;
+
+							if (parentRule) {
+								if (
+									parentRule.type === CSSRuleTypeEnum.mediaRule ||
+									parentRule.type === CSSRuleTypeEnum.containerRule ||
+									parentRule.type === CSSRuleTypeEnum.supportsRule
+								) {
+									layerRule[PropertySymbol.parentRule] = parentRule;
+									(<CSSMediaRule>parentRule).cssRules.push(layerRule);
+								}
+							} else {
+								cssRules.push(layerRule);
+							}
+
+							parentRule = layerRule;
 							break;
 						default:
 							// Unknown rule.

--- a/packages/happy-dom/src/index.ts
+++ b/packages/happy-dom/src/index.ts
@@ -32,6 +32,8 @@ import CSSGroupingRule from './css/rules/CSSGroupingRule.js';
 import CSSKeyframeRule from './css/rules/CSSKeyframeRule.js';
 import CSSKeyframesRule from './css/rules/CSSKeyframesRule.js';
 import CSSMediaRule from './css/rules/CSSMediaRule.js';
+import CSSLayerBlockRule from './css/rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from './css/rules/CSSLayerStatementRule.js';
 import CSSScopeRule from './css/rules/CSSScopeRule.js';
 import CSSStyleRule from './css/rules/CSSStyleRule.js';
 import CSSSupportsRule from './css/rules/CSSSupportsRule.js';
@@ -312,6 +314,8 @@ export {
 	CSSKeywordValue,
 	CSSMediaRule,
 	CSSRule,
+	CSSLayerBlockRule,
+	CSSLayerStatementRule,
 	CSSScopeRule,
 	CSSStyleDeclaration,
 	CSSStyleRule,

--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -319,6 +319,8 @@ import CSSStyleValue from '../css/style-property-map/CSSStyleValue.js';
 import CSSConditionRule from '../css/rules/CSSConditionRule.js';
 import CSSGroupingRule from '../css/rules/CSSGroupingRule.js';
 import CSSScopeRule from '../css/rules/CSSScopeRule.js';
+import CSSLayerBlockRule from '../css/rules/CSSLayerBlockRule.js';
+import CSSLayerStatementRule from '../css/rules/CSSLayerStatementRule.js';
 import PopStateEvent from '../event/events/PopStateEvent.js';
 import type ITimerLoopsLimit from './ITimerLoopsLimit.js';
 import CloseEvent from '../event/events/CloseEvent.js';
@@ -676,6 +678,8 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	public readonly CSSConditionRule = CSSConditionRule;
 	public readonly CSSGroupingRule = CSSGroupingRule;
 	public readonly CSSScopeRule = CSSScopeRule;
+	public readonly CSSLayerBlockRule = CSSLayerBlockRule;
+	public readonly CSSLayerStatementRule = CSSLayerStatementRule;
 	public readonly DOMRect = DOMRect;
 	public readonly DOMRectReadOnly = DOMRectReadOnly;
 	public readonly Plugin = Plugin;

--- a/packages/happy-dom/test/css/CSSParser.test.ts
+++ b/packages/happy-dom/test/css/CSSParser.test.ts
@@ -7,6 +7,8 @@ import type CSSKeyframeRule from '../../src/css/rules/CSSKeyframeRule.js';
 import type CSSKeyframesRule from '../../src/css/rules/CSSKeyframesRule.js';
 import type CSSContainerRule from '../../src/css/rules/CSSContainerRule.js';
 import type CSSSupportsRule from '../../src/css/rules/CSSSupportsRule.js';
+import type CSSLayerBlockRule from '../../src/css/rules/CSSLayerBlockRule.js';
+import type CSSLayerStatementRule from '../../src/css/rules/CSSLayerStatementRule.js';
 import { describe, it, expect, beforeEach } from 'vitest';
 import type BrowserWindow from '../../src/window/BrowserWindow.js';
 import Window from '../../src/window/Window.js';
@@ -553,6 +555,124 @@ describe('CSSParser', () => {
 
 			expect(cssRules.length).toBe(1);
 			expect((<CSSKeyframesRule>cssRules[0]).cssText).toBe('@keyframes keyframes1 { \n}');
+		});
+		it('Supports @layer rule', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @layer base {
+                    .foo { color: red; }
+                }
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSLayerBlockRule>cssRules[0]).name).toBe('base');
+			expect((<CSSLayerBlockRule>cssRules[0]).parentRule).toBe(null);
+			expect((<CSSLayerBlockRule>cssRules[0]).parentStyleSheet).toBe(cssStyleSheet);
+			expect((<CSSLayerBlockRule>cssRules[0]).cssRules.length).toBe(1);
+			expect((<CSSStyleRule>(<CSSLayerBlockRule>cssRules[0]).cssRules[0]).selectorText).toBe(
+				'.foo'
+			);
+			expect((<CSSLayerBlockRule>cssRules[0]).cssText).toBe(
+				'@layer base {\n  .foo { color: red; }\n}'
+			);
+		});
+
+		it('Supports @layer rule without a name', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @layer {
+                    .foo { color: red; }
+                }
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSLayerBlockRule>cssRules[0]).name).toBe('');
+			expect((<CSSLayerBlockRule>cssRules[0]).cssText).toBe('@layer {\n  .foo { color: red; }\n}');
+		});
+
+		it('Supports @layer rule inside a @layer rule', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @layer base {
+                    @layer reset {
+                        .foo { color: red; }
+                    }
+                }
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSLayerBlockRule>cssRules[0]).cssRules.length).toBe(1);
+			expect((<CSSLayerBlockRule>(<CSSLayerBlockRule>cssRules[0]).cssRules[0]).name).toBe('reset');
+			expect((<CSSLayerBlockRule>cssRules[0]).cssText).toBe(
+				'@layer base {\n  @layer reset {\n  .foo { color: red; }\n}\n}'
+			);
+		});
+
+		it('Supports @layer rule inside a @media rule', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @media screen {
+                    @layer base {
+                        .foo { color: red; }
+                    }
+                }
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSMediaRule>cssRules[0]).cssText).toBe(
+				'@media screen {\n  @layer base {\n  .foo { color: red; }\n}\n}'
+			);
+		});
+
+		it('Ignores @layer rule inside a @keyframes rule', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @keyframes keyframes1 {
+                    @layer base {
+                        .foo { color: red; }
+                    }
+                }
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSKeyframesRule>cssRules[0]).cssText).toBe('@keyframes keyframes1 { \n}');
+		});
+
+		it('Supports @layer statement rule', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @layer base, theme;
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSLayerStatementRule>cssRules[0]).nameList).toEqual(['base', 'theme']);
+			expect((<CSSLayerStatementRule>cssRules[0]).parentStyleSheet).toBe(cssStyleSheet);
+			expect((<CSSLayerStatementRule>cssRules[0]).cssText).toBe('@layer base, theme;');
+		});
+
+		it('Supports @layer statement rule written over several lines', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @layer
+                    base,
+                    theme;
+            `);
+
+			expect(cssRules.length).toBe(1);
+			expect((<CSSLayerStatementRule>cssRules[0]).nameList).toEqual(['base', 'theme']);
+			expect((<CSSLayerStatementRule>cssRules[0]).cssText).toBe('@layer base, theme;');
+		});
+
+		it('Parses the rule following a statement at-rule', () => {
+			const cssStyleSheet = new window.CSSStyleSheet();
+			const cssRules = new CSSParser(cssStyleSheet).parseFromString(`
+                @layer base, theme;
+                .foo { color: red; }
+            `);
+
+			expect(cssRules.length).toBe(2);
+			expect((<CSSStyleRule>cssRules[1]).selectorText).toBe('.foo');
+			expect((<CSSStyleRule>cssRules[1]).style.color).toBe('red');
 		});
 	});
 });

--- a/packages/happy-dom/test/css/CSSStyleSheet.test.ts
+++ b/packages/happy-dom/test/css/CSSStyleSheet.test.ts
@@ -29,6 +29,18 @@ describe('CSSStyleSheet', () => {
 			expect(cssStyleSheet.insertRule('span { background-color: green }')).toBe(1);
 		});
 
+		it('Inserts a cascade layer block rule.', () => {
+			expect(cssStyleSheet.insertRule('@layer base { div { background-color: green } }')).toBe(0);
+			expect(cssStyleSheet.cssRules[0].cssText).toBe(
+				'@layer base {\n  div { background-color: green; }\n}'
+			);
+		});
+
+		it('Inserts a cascade layer statement rule.', () => {
+			expect(cssStyleSheet.insertRule('@layer base, theme;')).toBe(0);
+			expect(cssStyleSheet.cssRules[0].cssText).toBe('@layer base, theme;');
+		});
+
 		it('Throws an error when there are 0 arguments.', () => {
 			expect(() => {
 				// @ts-expect-error

--- a/packages/happy-dom/test/css/rules/CSSLayerBlockRule.test.ts
+++ b/packages/happy-dom/test/css/rules/CSSLayerBlockRule.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as PropertySymbol from '../../../src/PropertySymbol.js';
+import type BrowserWindow from '../../../src/window/BrowserWindow.js';
+import Window from '../../../src/window/Window.js';
+import CSSParser from '../../../src/css/utilities/CSSParser.js';
+import type CSSStyleSheet from '../../../src/css/CSSStyleSheet.js';
+import CSSRuleTypeEnum from '../../../src/css/CSSRuleTypeEnum.js';
+import CSSLayerBlockRule from '../../../src/css/rules/CSSLayerBlockRule.js';
+
+describe('CSSLayerBlockRule', () => {
+	let window: BrowserWindow;
+	let styleSheet: CSSStyleSheet;
+	let cssParser: CSSParser;
+
+	beforeEach(() => {
+		window = new Window();
+		styleSheet = new window.CSSStyleSheet();
+		cssParser = new CSSParser(styleSheet);
+	});
+
+	describe('get type()', () => {
+		it('Returns container rule type', () => {
+			const cssRule = new CSSLayerBlockRule(PropertySymbol.illegalConstructor, window, cssParser);
+			expect(cssRule.type).toBe(0);
+			expect(cssRule.type).toBe(CSSRuleTypeEnum.containerRule);
+		});
+	});
+
+	describe('get name()', () => {
+		it('Returns name', () => {
+			const cssRule = new CSSLayerBlockRule(PropertySymbol.illegalConstructor, window, cssParser);
+			expect(cssRule.name).toBe('');
+			cssRule[PropertySymbol.name] = 'base';
+			expect(cssRule.name).toBe('base');
+		});
+	});
+
+	describe('get cssText()', () => {
+		it('Returns CSS text', () => {
+			const cssRule = new CSSLayerBlockRule(PropertySymbol.illegalConstructor, window, cssParser);
+			expect(cssRule.cssText).toBe('@layer {\n}');
+			cssRule[PropertySymbol.name] = 'base';
+			expect(cssRule.cssText).toBe('@layer base {\n}');
+
+			cssRule.insertRule('div { color: red; }');
+
+			expect(cssRule.cssText).toBe('@layer base {\n  div { color: red; }\n}');
+
+			cssRule.insertRule('span { color: blue; }');
+
+			expect(cssRule.cssText).toBe(
+				'@layer base {\n  span { color: blue; }\n  div { color: red; }\n}'
+			);
+		});
+	});
+});

--- a/packages/happy-dom/test/css/rules/CSSLayerStatementRule.test.ts
+++ b/packages/happy-dom/test/css/rules/CSSLayerStatementRule.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as PropertySymbol from '../../../src/PropertySymbol.js';
+import type BrowserWindow from '../../../src/window/BrowserWindow.js';
+import Window from '../../../src/window/Window.js';
+import CSSParser from '../../../src/css/utilities/CSSParser.js';
+import type CSSStyleSheet from '../../../src/css/CSSStyleSheet.js';
+import CSSRuleTypeEnum from '../../../src/css/CSSRuleTypeEnum.js';
+import CSSLayerStatementRule from '../../../src/css/rules/CSSLayerStatementRule.js';
+
+describe('CSSLayerStatementRule', () => {
+	let window: BrowserWindow;
+	let styleSheet: CSSStyleSheet;
+	let cssParser: CSSParser;
+
+	beforeEach(() => {
+		window = new Window();
+		styleSheet = new window.CSSStyleSheet();
+		cssParser = new CSSParser(styleSheet);
+	});
+
+	describe('get type()', () => {
+		it('Returns container rule type', () => {
+			const cssRule = new CSSLayerStatementRule(
+				PropertySymbol.illegalConstructor,
+				window,
+				cssParser
+			);
+			expect(cssRule.type).toBe(0);
+			expect(cssRule.type).toBe(CSSRuleTypeEnum.containerRule);
+		});
+	});
+
+	describe('get nameList()', () => {
+		it('Returns name list', () => {
+			const cssRule = new CSSLayerStatementRule(
+				PropertySymbol.illegalConstructor,
+				window,
+				cssParser
+			);
+			expect(cssRule.nameList).toEqual([]);
+			cssRule[PropertySymbol.nameList] = ['base', 'theme'];
+			expect(cssRule.nameList).toEqual(['base', 'theme']);
+		});
+
+		it('Returns a frozen list', () => {
+			const cssRule = new CSSLayerStatementRule(
+				PropertySymbol.illegalConstructor,
+				window,
+				cssParser
+			);
+			cssRule[PropertySymbol.nameList] = ['base'];
+			expect(Object.isFrozen(cssRule.nameList)).toBe(true);
+		});
+	});
+
+	describe('get cssText()', () => {
+		it('Returns CSS text', () => {
+			const cssRule = new CSSLayerStatementRule(
+				PropertySymbol.illegalConstructor,
+				window,
+				cssParser
+			);
+			cssRule[PropertySymbol.nameList] = ['base', 'theme'];
+			expect(cssRule.cssText).toBe('@layer base, theme;');
+		});
+	});
+});

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -1492,6 +1492,152 @@ describe('BrowserWindow', () => {
 			expect(computedStyle.color).toBe('green');
 		});
 
+		it('Handles CSS in a cascade layer (@layer).', () => {
+			const div = document.createElement('div');
+			const style = document.createElement('style');
+
+			style.textContent = `
+              @layer base {
+                div {
+                  color: red;
+                }
+              }
+            `;
+
+			document.head.appendChild(style);
+			document.body.appendChild(div);
+
+			expect(window.getComputedStyle(div).color).toBe('red');
+		});
+
+		it('Handles an unlayered rule taking precedence over a layered rule (@layer).', () => {
+			const div = document.createElement('div');
+			const style = document.createElement('style');
+
+			style.textContent = `
+              div {
+                color: green;
+              }
+
+              @layer base {
+                div.class1 {
+                  color: red;
+                }
+              }
+            `;
+
+			div.className = 'class1';
+
+			document.head.appendChild(style);
+			document.body.appendChild(div);
+
+			expect(window.getComputedStyle(div).color).toBe('green');
+		});
+
+		it('Handles the order that cascade layers are declared in (@layer).', () => {
+			const div = document.createElement('div');
+			const style = document.createElement('style');
+
+			style.textContent = `
+              @layer base {
+                div.class1 {
+                  color: red;
+                }
+              }
+
+              @layer theme {
+                div {
+                  color: green;
+                }
+              }
+            `;
+
+			div.className = 'class1';
+
+			document.head.appendChild(style);
+			document.body.appendChild(div);
+
+			expect(window.getComputedStyle(div).color).toBe('green');
+		});
+
+		it('Handles cascade layers declared by a statement rule (@layer).', () => {
+			const div = document.createElement('div');
+			const style = document.createElement('style');
+
+			style.textContent = `
+              @layer theme, base;
+
+              @layer base {
+                div {
+                  color: red;
+                }
+              }
+
+              @layer theme {
+                div {
+                  color: green;
+                }
+              }
+            `;
+
+			document.head.appendChild(style);
+			document.body.appendChild(div);
+
+			expect(window.getComputedStyle(div).color).toBe('red');
+		});
+
+		it('Handles a cascade layer taking precedence over its own sublayer (@layer).', () => {
+			const div = document.createElement('div');
+			const style = document.createElement('style');
+
+			style.textContent = `
+              @layer base {
+                div {
+                  color: green;
+                }
+
+                @layer reset {
+                  div.class1 {
+                    color: red;
+                  }
+                }
+              }
+            `;
+
+			div.className = 'class1';
+
+			document.head.appendChild(style);
+			document.body.appendChild(div);
+
+			expect(window.getComputedStyle(div).color).toBe('green');
+		});
+
+		it('Handles "!important" reversing the cascade layer order (@layer).', () => {
+			const div = document.createElement('div');
+			const style = document.createElement('style');
+
+			style.textContent = `
+              @layer base {
+                div {
+                  color: green !important;
+                }
+              }
+
+              @layer theme {
+                div.class1 {
+                  color: red !important;
+                }
+              }
+            `;
+
+			div.className = 'class1';
+
+			document.head.appendChild(style);
+			document.body.appendChild(div);
+
+			expect(window.getComputedStyle(div).color).toBe('green');
+		});
+
 		for (const measurement of [
 			{ value: '100vw', result: '1024px' },
 			{ value: '100vh', result: '768px' },


### PR DESCRIPTION
Fixes #2284.

This adds support for cascade layers, both the block form and the statement form, and makes `getComputedStyle` respect the layer order.

There are two new rule classes. `CSSLayerBlockRule` extends `CSSGroupingRule` and carries `name`, and `CSSLayerStatementRule` extends `CSSRule` and carries `nameList`. Both return 0 from `type`, the same as `CSSScopeRule` and `CSSContainerRule` do for rules with no legacy type number.

In `CSSParser` the block form follows the shape of the `@scope` arm above it. The statement form (`@layer base, theme;`) needed the tokenizer to match `;` as well, and to consume the text before it only when that text starts with `@`, since a semicolon ends an at-rule and nothing else. A stray semicolon still invalidates the rule after it, as `CSSParserInput` expects, and `@charset` and `@import` now stop swallowing the rule that follows them.

In `CSSStyleDeclarationComputedStyle` the layers form a tree, numbered so that a layer's own rules rank after the rules of its sublayers and unlayered rules rank last, and the existing sort by specificity takes the layer index as its first key. `!important` inverts the layer order, so it gets a second pass over the sources that contain `!important`, with the style attribute appended again so an inline `!important` still wins. That pass only runs when more than one matched source carries `!important`.

The tests cover both parser forms, unnamed and nested layers, a layer inside `@media`, a layer ignored inside `@keyframes`, a file for each new rule class, `insertRule` for both forms, and six cases in `getComputedStyle`: a layered rule applying, an unlayered rule beating a layered one, order between two layers, a statement fixing that order, a layer beating its own sublayer, and `!important` reversing the order. Following the contributing guidelines I ran those six in Chrome 151 as well, taking the CSS and the expected values from the test file so the two can't drift apart, and it agrees with all six. Timing for stylesheets that use no layers is unchanged.

`@import ... layer()` and `revert-layer` aren't covered here.

A few things I'd like your opinion on:

1. `type` returning 0 follows `CSSScopeRule`, but it leaves `instanceof` as the only discriminator in `parseCSSRules`, which now has three cases behind one number. Happy to add an enum member if you'd prefer.
2. Layer order is worked out while walking the rules that match, so a layer declared only inside a media query that doesn't match never takes its place in the order. Walking every rule separately would close that, at the cost of an extra pass.
3. The second parse for `!important` is the part I'm least comfortable with, since `getComputedStyle` is a hot path.
4. Layers are per encapsulation context in the spec, and this keeps one tree per document, so a shadow root shares the document's layer order.
