### PR TITLE
fix: [#1490] Different ports/parent domains are different origins

### DIFF
--- a/packages/happy-dom/src/fetch/utilities/FetchCORSUtility.ts
+++ b/packages/happy-dom/src/fetch/utilities/FetchCORSUtility.ts
@@ -18,10 +18,6 @@ export default class FetchCORSUtility {
 			return false;
 		}
 
-		return (
-			(originURL.hostname !== targetURL.hostname &&
-				!originURL.hostname.endsWith(targetURL.hostname)) ||
-			originURL.protocol !== targetURL.protocol
-		);
+		return originURL.origin !== targetURL.origin;
 	}
 }

--- a/packages/happy-dom/test/fetch/FetchCORSUtility.test.ts
+++ b/packages/happy-dom/test/fetch/FetchCORSUtility.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import FetchCORSUtility from '../../src/fetch/utilities/FetchCORSUtility.js';
+
+describe('FetchCORSUtility', () => {
+	describe('isCORS()', () => {
+		it('Treats requests to a different port as cross-origin.', () => {
+			expect(FetchCORSUtility.isCORS('http://localhost:1234', 'http://localhost:9876')).toBe(true);
+		});
+
+		it('Treats a parent domain as cross-origin from its subdomain.', () => {
+			expect(FetchCORSUtility.isCORS('http://sub.some.host', 'http://some.host')).toBe(true);
+		});
+	});
+});

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -992,7 +992,7 @@ describe('SyncFetch', () => {
 		});
 
 		it('Disables validation of certificates if "Browser.settings.fetch.disableStrictSSL" is set to "true".', async () => {
-			const originURL = 'https://localhost:8080';
+			const originURL = 'https://localhost';
 
 			browserFrame.url = originURL;
 			browserFrame.page.context.browser.settings.fetch.disableStrictSSL = true;


### PR DESCRIPTION
### Description

The CORS check is currently wrong about at least two scenarios:

- A request to the same hostname but different protocol **should** be treated as "not the same origin", but is not
- A request from a subdomain to a parent **should** be treated as "not the same origin", but is not

This PR uses the `origin` property on the URL for a cheap and simple comparison.

Resolves #1490

> [!WARNING]
> **Theoretically** this could be seen as a breaking change, but it not follows the spec. I'm not sure whether or not to consider that breaking, so will leave the decision up to you.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
