### PR TITLE
fix: [#1491] Skip CORS preflight for simple requests

### DIFF
--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -448,6 +448,10 @@ export default class Fetch {
 			return true;
 		}
 
+		if (!FetchCORSUtility.isPreflightRequired(this.request)) {
+			return true;
+		}
+
 		const cachedPreflightResponse = this.#browserFrame.page.context.preflightResponseCache.get(
 			this.request
 		);
@@ -532,6 +536,29 @@ export default class Fetch {
 		// TODO: Add support for more Access-Control-Allow-* headers.
 
 		return true;
+	}
+
+	/**
+	 * Checks if the response complies with the Cross-Origin policy.
+	 *
+	 * Only simple requests are validated here, as requests that require a preflight have already had
+	 * their origin validated by the preflight response.
+	 *
+	 * @param responseHeaders Response headers.
+	 * @returns True if it complies with the policy.
+	 */
+	private compliesWithCrossOriginResponsePolicy(responseHeaders: Headers): boolean {
+		if (
+			this.disableSameOriginPolicy ||
+			!FetchCORSUtility.isCORS(this.#window.location.href, this.request[PropertySymbol.url]) ||
+			FetchCORSUtility.isPreflightRequired(this.request)
+		) {
+			return true;
+		}
+
+		const allowOrigin = responseHeaders.get('Access-Control-Allow-Origin');
+
+		return allowOrigin === '*' || allowOrigin === this.#window.location.origin;
 	}
 
 	/**
@@ -759,6 +786,22 @@ export default class Fetch {
 		});
 
 		if (this.handleRedirectResponse(nodeResponse, this.responseHeaders)) {
+			return;
+		}
+
+		// A redirect that was followed has already been validated by the Fetch instance that performed
+		// it, so only responses read directly off the wire are validated here.
+		if (!this.compliesWithCrossOriginResponsePolicy(this.responseHeaders)) {
+			this.finalizeRequest();
+			this.#browserFrame.page.console.warn(
+				`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at "${this.request.url}".`
+			);
+			this.reject!(
+				new this.#window.DOMException(
+					`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at "${this.request.url}".`,
+					DOMExceptionNameEnum.networkError
+				)
+			);
 			return;
 		}
 

--- a/packages/happy-dom/src/fetch/SyncFetch.ts
+++ b/packages/happy-dom/src/fetch/SyncFetch.ts
@@ -380,6 +380,10 @@ export default class SyncFetch {
 			return true;
 		}
 
+		if (!FetchCORSUtility.isPreflightRequired(this.request)) {
+			return true;
+		}
+
 		const cachedPreflightResponse = this.#browserFrame.page.context.preflightResponseCache.get(
 			this.request
 		);
@@ -467,6 +471,29 @@ export default class SyncFetch {
 	}
 
 	/**
+	 * Checks if the response complies with the Cross-Origin policy.
+	 *
+	 * Only simple requests are validated here, as requests that require a preflight have already had
+	 * their origin validated by the preflight response.
+	 *
+	 * @param responseHeaders Response headers.
+	 * @returns True if it complies with the policy.
+	 */
+	private compliesWithCrossOriginResponsePolicy(responseHeaders: Headers): boolean {
+		if (
+			this.disableSameOriginPolicy ||
+			!FetchCORSUtility.isCORS(this.#window.location.href, this.request[PropertySymbol.url]) ||
+			FetchCORSUtility.isPreflightRequired(this.request)
+		) {
+			return true;
+		}
+
+		const allowOrigin = responseHeaders.get('Access-Control-Allow-Origin');
+
+		return allowOrigin === '*' || allowOrigin === this.#window.location.origin;
+	}
+
+	/**
 	 * Sends request.
 	 *
 	 * @returns Response.
@@ -535,7 +562,24 @@ export default class SyncFetch {
 			})
 		};
 
-		const redirectedResponse = this.handleRedirectResponse(response) || response;
+		const followedRedirectResponse = this.handleRedirectResponse(response);
+
+		// A redirect that was followed has already been validated by the SyncFetch instance that
+		// performed it, so only responses read directly off the wire are validated here.
+		if (
+			!followedRedirectResponse &&
+			!this.compliesWithCrossOriginResponsePolicy(response.headers)
+		) {
+			this.#window.console.warn(
+				`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at "${this.request.url}".`
+			);
+			throw new this.#window.DOMException(
+				`Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at "${this.request.url}".`,
+				DOMExceptionNameEnum.networkError
+			);
+		}
+
+		const redirectedResponse = followedRedirectResponse || response;
 
 		if (!this.disableCache && !redirectedResponse.redirected) {
 			this.#browserFrame.page.context.responseCache.add(this.request, {

--- a/packages/happy-dom/src/fetch/utilities/FetchCORSUtility.ts
+++ b/packages/happy-dom/src/fetch/utilities/FetchCORSUtility.ts
@@ -1,9 +1,103 @@
 import { URL } from 'url';
+import WhatwgMIMEType from 'whatwg-mimetype';
+import type Request from '../Request.js';
+
+// These lists are part of the preflight decision defined by the Fetch Standard:
+// https://fetch.spec.whatwg.org/#cors-safelisted-request-header
+// A request must satisfy the method and header checks together, so a safelisted Content-Type alone
+// does not make it a simple request.
+const CORS_SAFELISTED_METHODS = new Set(['GET', 'HEAD', 'POST']);
+const CORS_SAFELISTED_REQUEST_HEADER_NAMES = new Set([
+	'accept',
+	'accept-language',
+	'content-language',
+	'content-type',
+	'range'
+]);
+const CORS_SAFELISTED_CONTENT_TYPES = new Set([
+	'application/x-www-form-urlencoded',
+	'multipart/form-data',
+	'text/plain'
+]);
 
 /**
  * Fetch CORS utility.
  */
 export default class FetchCORSUtility {
+	/**
+	 * Returns whether a request requires a CORS preflight request.
+	 *
+	 * @param request Request.
+	 * @returns True if the request requires a preflight request.
+	 */
+	public static isPreflightRequired(request: Request): boolean {
+		if (!CORS_SAFELISTED_METHODS.has(request.method)) {
+			return true;
+		}
+
+		let safelistedValueSize = 0;
+
+		for (const [name, value] of request.headers) {
+			if (!this.isCORSsafelistedRequestHeader(name, value)) {
+				return true;
+			}
+
+			safelistedValueSize += Buffer.byteLength(value);
+		}
+
+		return safelistedValueSize > 1024;
+	}
+
+	/**
+	 * Returns whether a header is CORS-safelisted.
+	 *
+	 * @param name Header name.
+	 * @param value Header value.
+	 * @returns True if the header is CORS-safelisted.
+	 */
+	private static isCORSsafelistedRequestHeader(name: string, value: string): boolean {
+		if (Buffer.byteLength(value) > 128) {
+			return false;
+		}
+
+		const lowerName = name.toLowerCase();
+
+		if (!CORS_SAFELISTED_REQUEST_HEADER_NAMES.has(lowerName)) {
+			return false;
+		}
+
+		switch (lowerName) {
+			case 'accept':
+				return !this.containsCORSUnsafeRequestHeaderByte(value);
+			case 'accept-language':
+			case 'content-language':
+				return /^[0-9a-z *,\-.;=]*$/i.test(value);
+			case 'content-type': {
+				if (this.containsCORSUnsafeRequestHeaderByte(value)) {
+					return false;
+				}
+
+				const mimeType = WhatwgMIMEType.parse(value);
+
+				return !!mimeType && CORS_SAFELISTED_CONTENT_TYPES.has(mimeType.essence);
+			}
+			case 'range':
+				return /^bytes=\d+-\d*$/.test(value);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns whether a header value contains a CORS-unsafe request-header byte.
+	 *
+	 * @param value Header value.
+	 * @returns True if the value contains a CORS-unsafe byte.
+	 */
+	private static containsCORSUnsafeRequestHeaderByte(value: string): boolean {
+		return /[\x00-\x08\x0a-\x1f"():<>?@[\]\\{}\x7f]/.test(value);
+	}
+
 	/**
 	 * Validates request headers.
 	 *

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -20,6 +20,7 @@ import FetchHTTPSCertificate from '../../src/fetch/certificate/FetchHTTPSCertifi
 import * as PropertySymbol from '../../src/PropertySymbol.js';
 import { fail } from 'assert';
 import Browser from '../../src/browser/Browser.js';
+import type IRequestInit from '../../src/fetch/types/IRequestInit.js';
 
 const LAST_CHUNK = Buffer.from('0\r\n\r\n');
 
@@ -49,6 +50,7 @@ describe('Fetch', () => {
 			responseText?: string | string[];
 			responseProperties?: Record<string, unknown>;
 			beforeResponse?: IBeforeResponse;
+			onDestroy?: () => void;
 		}
 	): IMockNetwork {
 		const requestHistory: IRequestHistoryEntry[] = [];
@@ -83,7 +85,9 @@ describe('Fetch', () => {
 						}
 					},
 					setTimeout: () => {},
-					destroy: () => {}
+					destroy: () => {
+						specification?.onDestroy?.();
+					}
 				};
 			}
 		});
@@ -544,6 +548,142 @@ describe('Fetch', () => {
 					}
 				}
 			]);
+		});
+
+		it.each<{
+			description: string;
+			init: IRequestInit;
+			method: string;
+		}>([
+			{ description: 'GET', init: {}, method: 'GET' },
+			{ description: 'HEAD', init: { method: 'HEAD' }, method: 'HEAD' },
+			{
+				description: 'text/plain POST',
+				init: { method: 'POST', body: 'Hello world' },
+				method: 'POST'
+			},
+			{
+				description: 'application/x-www-form-urlencoded POST',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: 'name=Happy+DOM'
+				},
+				method: 'POST'
+			},
+			{
+				description: 'multipart/form-data POST',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'multipart/form-data; boundary=boundary' },
+					body: '--boundary--'
+				},
+				method: 'POST'
+			}
+		])('Does not preflight a cross-origin simple $description request.', async (testCase) => {
+			const originURL = 'http://localhost:8080';
+			const window = new Window({ url: originURL });
+			const url = 'http://other.origin.com/some/path';
+			const network = mockNetwork('http', {
+				beforeResponse({ response }) {
+					response.rawHeaders = ['Access-Control-Allow-Origin', '*'];
+				}
+			});
+
+			await window.fetch(url, testCase.init);
+
+			expect(network.requestHistory.map((request) => request.options.method)).toEqual([
+				testCase.method
+			]);
+		});
+
+		it('Rejects a cross-origin simple GET response without Access-Control-Allow-Origin.', async () => {
+			const window = new Window({ url: 'http://localhost:8080' });
+			const url = 'http://other.origin.com/some/path';
+			const network = mockNetwork('http');
+
+			await expect(window.fetch(url)).rejects.toThrow('Cross-Origin Request Blocked');
+
+			expect(network.requestHistory.map((request) => request.options.method)).toEqual(['GET']);
+		});
+
+		it('Does not cache a rejected cross-origin simple GET response.', async () => {
+			const window = new Window({ url: 'http://localhost:8080' });
+			const url = 'http://other.origin.com/some/path';
+			let allowsOrigin = false;
+			const network = mockNetwork('http', {
+				beforeResponse({ response }) {
+					response.rawHeaders = [
+						'Cache-Control',
+						'max-age=600',
+						...(allowsOrigin ? ['Access-Control-Allow-Origin', '*'] : [])
+					];
+				}
+			});
+
+			await expect(window.fetch(url)).rejects.toThrow('Cross-Origin Request Blocked');
+
+			allowsOrigin = true;
+			await window.fetch(url);
+
+			expect(network.requestHistory.map((request) => request.options.method)).toEqual([
+				'GET',
+				'GET'
+			]);
+		});
+
+		it('Allows a cross-origin simple GET request that redirects to a same-origin URL.', async () => {
+			const originURL = 'http://localhost:8080';
+			const window = new Window({ url: originURL });
+			const url = 'http://other.origin.com/some/path';
+			const redirectURL = `${originURL}/redirected/path`;
+			const network = mockNetwork('http', {
+				beforeResponse({ request, response }) {
+					if (request.url === url) {
+						response.statusCode = 302;
+						response.rawHeaders = ['Location', redirectURL, 'Access-Control-Allow-Origin', '*'];
+					}
+				}
+			});
+
+			const response = await window.fetch(url);
+
+			expect(response.status).toBe(200);
+			expect(network.requestHistory.map((request) => request.url)).toEqual([url, redirectURL]);
+		});
+
+		it('Rejects a cross-origin simple GET request that redirects without Access-Control-Allow-Origin.', async () => {
+			const originURL = 'http://localhost:8080';
+			const window = new Window({ url: originURL });
+			const url = 'http://other.origin.com/some/path';
+			const redirectURL = 'http://other.origin.com/redirected/path';
+			const network = mockNetwork('http', {
+				beforeResponse({ request, response }) {
+					if (request.url === url) {
+						response.statusCode = 302;
+						response.rawHeaders = ['Location', redirectURL, 'Access-Control-Allow-Origin', '*'];
+					}
+				}
+			});
+
+			await expect(window.fetch(url)).rejects.toThrow('Cross-Origin Request Blocked');
+
+			expect(network.requestHistory.map((request) => request.url)).toEqual([url, redirectURL]);
+		});
+
+		it('Destroys the request when a cross-origin simple GET response is rejected.', async () => {
+			const window = new Window({ url: 'http://localhost:8080' });
+			const url = 'http://other.origin.com/some/path';
+			let destroyCount = 0;
+			mockNetwork('http', {
+				onDestroy() {
+					destroyCount++;
+				}
+			});
+
+			await expect(window.fetch(url)).rejects.toThrow('Cross-Origin Request Blocked');
+
+			expect(destroyCount).toBe(1);
 		});
 
 		it('Allows cross-origin request if "Browser.settings.fetch.disableSameOriginPolicy" is set to "true".', async () => {

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -17,6 +17,7 @@ import Path from 'path';
 import '../types.d.js';
 import { fail } from 'node:assert';
 import { PropertySymbol } from '../../src/index.js';
+import type IRequestInit from '../../src/fetch/types/IRequestInit.js';
 
 const PLATFORM =
 	'X11; ' +
@@ -927,6 +928,222 @@ describe('SyncFetch', () => {
 					body: Buffer.from(body)
 				})
 			);
+		});
+
+		it('Does not preflight a cross-origin simple GET request.', () => {
+			const originURL = 'http://localhost:8080';
+			browserFrame.url = originURL;
+			const url = 'http://other.origin.com/some/path';
+			const requestArgs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					requestArgs.push(args[1]);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: 200,
+							statusMessage: 'OK',
+							rawHeaders: ['Access-Control-Allow-Origin', '*'],
+							data: ''
+						}
+					});
+				}
+			});
+
+			new SyncFetch({ browserFrame, window, url }).send();
+
+			expect(requestArgs).toEqual([
+				SyncFetchScriptBuilder.getScript({
+					url: new URL(url),
+					method: 'GET',
+					headers: {
+						Accept: '*/*',
+						Connection: 'close',
+						'User-Agent': window.navigator.userAgent,
+						'Accept-Encoding': 'gzip, deflate, br',
+						Origin: originURL,
+						Referer: originURL + '/'
+					}
+				})
+			]);
+		});
+
+		it.each<{
+			description: string;
+			init: IRequestInit;
+			method: string;
+		}>([
+			{ description: 'HEAD', init: { method: 'HEAD' }, method: 'HEAD' },
+			{
+				description: 'text/plain POST',
+				init: { method: 'POST', body: 'Hello world' },
+				method: 'POST'
+			},
+			{
+				description: 'application/x-www-form-urlencoded POST',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: 'name=Happy+DOM'
+				},
+				method: 'POST'
+			},
+			{
+				description: 'multipart/form-data POST',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'multipart/form-data; boundary=boundary' },
+					body: '--boundary--'
+				},
+				method: 'POST'
+			}
+		])('Does not preflight a cross-origin simple $description request.', (testCase) => {
+			browserFrame.url = 'http://localhost:8080';
+			const url = 'http://other.origin.com/some/path';
+			const requestArgs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					requestArgs.push(args[1]);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: 200,
+							statusMessage: 'OK',
+							rawHeaders: ['Access-Control-Allow-Origin', '*'],
+							data: ''
+						}
+					});
+				}
+			});
+
+			new SyncFetch({ browserFrame, window, url, init: testCase.init }).send();
+
+			expect(requestArgs).toHaveLength(1);
+			expect(requestArgs[0]).toContain(`"method": "${testCase.method}"`);
+		});
+
+		it('Rejects a cross-origin simple GET response without Access-Control-Allow-Origin.', () => {
+			browserFrame.url = 'http://localhost:8080';
+			const url = 'http://other.origin.com/some/path';
+			const requestArgs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					requestArgs.push(args[1]);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: 200,
+							statusMessage: 'OK',
+							rawHeaders: [],
+							data: ''
+						}
+					});
+				}
+			});
+
+			expect(() => new SyncFetch({ browserFrame, window, url }).send()).toThrow(
+				'Cross-Origin Request Blocked'
+			);
+			expect(requestArgs).toHaveLength(1);
+		});
+
+		it('Does not cache a rejected cross-origin simple GET response.', () => {
+			browserFrame.url = 'http://localhost:8080';
+			const url = 'http://other.origin.com/some/path';
+			let allowsOrigin = false;
+			const requestArgs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					requestArgs.push(args[1]);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: 200,
+							statusMessage: 'OK',
+							rawHeaders: [
+								'Cache-Control',
+								'max-age=600',
+								...(allowsOrigin ? ['Access-Control-Allow-Origin', '*'] : [])
+							],
+							data: ''
+						}
+					});
+				}
+			});
+
+			expect(() => new SyncFetch({ browserFrame, window, url }).send()).toThrow(
+				'Cross-Origin Request Blocked'
+			);
+
+			allowsOrigin = true;
+			new SyncFetch({ browserFrame, window, url }).send();
+
+			expect(requestArgs).toHaveLength(2);
+		});
+
+		it('Allows a cross-origin simple GET request that redirects to a same-origin URL.', () => {
+			const originURL = 'http://localhost:8080';
+			browserFrame.url = originURL;
+			const url = 'http://other.origin.com/some/path';
+			const redirectURL = `${originURL}/redirected/path`;
+			const requestedURLs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					const isFirstRequest = requestedURLs.length === 0;
+					requestedURLs.push(isFirstRequest ? url : redirectURL);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: isFirstRequest ? 302 : 200,
+							statusMessage: 'OK',
+							rawHeaders: isFirstRequest
+								? ['Location', redirectURL, 'Access-Control-Allow-Origin', '*']
+								: [],
+							data: ''
+						}
+					});
+				}
+			});
+
+			const response = new SyncFetch({ browserFrame, window, url }).send();
+
+			expect(response.status).toBe(200);
+			expect(requestedURLs).toEqual([url, redirectURL]);
+		});
+
+		it('Rejects a cross-origin simple GET request that redirects without Access-Control-Allow-Origin.', () => {
+			browserFrame.url = 'http://localhost:8080';
+			const url = 'http://other.origin.com/some/path';
+			const redirectURL = 'http://other.origin.com/redirected/path';
+			const requestedURLs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					const isFirstRequest = requestedURLs.length === 0;
+					requestedURLs.push(isFirstRequest ? url : redirectURL);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: isFirstRequest ? 302 : 200,
+							statusMessage: 'OK',
+							rawHeaders: isFirstRequest
+								? ['Location', redirectURL, 'Access-Control-Allow-Origin', '*']
+								: [],
+							data: ''
+						}
+					});
+				}
+			});
+
+			expect(() => new SyncFetch({ browserFrame, window, url }).send()).toThrow(
+				'Cross-Origin Request Blocked'
+			);
+			expect(requestedURLs).toEqual([url, redirectURL]);
 		});
 
 		it('Allows cross-origin request if "Browser.settings.fetch.disableSameOriginPolicy" is set to "true".', async () => {

--- a/packages/happy-dom/test/fetch/utilities/FetchCORSUtility.test.ts
+++ b/packages/happy-dom/test/fetch/utilities/FetchCORSUtility.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import Window from '../../../src/window/Window.js';
+import FetchCORSUtility from '../../../src/fetch/utilities/FetchCORSUtility.js';
+import type IRequestInit from '../../../src/fetch/types/IRequestInit.js';
+
+describe('FetchCORSUtility', () => {
+	describe('isPreflightRequired()', () => {
+		const window = new Window();
+
+		const testCases: Array<{
+			description: string;
+			init: IRequestInit;
+			requiresPreflight: boolean;
+		}> = [
+			{
+				description: 'a GET request without author-controlled headers',
+				init: {},
+				requiresPreflight: false
+			},
+			{
+				description: 'a HEAD request with CORS-safelisted headers',
+				init: {
+					method: 'HEAD',
+					headers: {
+						Accept: 'application/json',
+						'Accept-Language': 'en-US',
+						'Content-Language': 'en'
+					}
+				},
+				requiresPreflight: false
+			},
+			{
+				description: 'a POST request with a text/plain body',
+				init: { method: 'POST', body: 'Hello world' },
+				requiresPreflight: false
+			},
+			{
+				description: 'a POST request with application/x-www-form-urlencoded content',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+					body: 'name=Happy+DOM'
+				},
+				requiresPreflight: false
+			},
+			{
+				description: 'a POST request with multipart/form-data content',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'multipart/form-data; boundary=boundary' },
+					body: '--boundary--'
+				},
+				requiresPreflight: false
+			},
+			{
+				description: 'a PATCH request',
+				init: { method: 'PATCH' },
+				requiresPreflight: true
+			},
+			{
+				description: 'a request with a custom header',
+				init: { headers: { 'X-Custom-Header': 'yes' } },
+				requiresPreflight: true
+			},
+			{
+				description: 'a request with an invalid CORS-safelisted header value',
+				init: { headers: { Accept: 'application/json:application/xml' } },
+				requiresPreflight: true
+			},
+			{
+				description: 'a request with more than 128 bytes in a CORS-safelisted header',
+				init: { headers: { Accept: 'a'.repeat(129) } },
+				requiresPreflight: true
+			},
+			{
+				description: 'a request with a single byte range header',
+				init: { headers: { Range: 'bytes=256-' } },
+				requiresPreflight: false
+			},
+			{
+				description: 'a request with a suffix byte range header',
+				init: { headers: { Range: 'bytes=-500' } },
+				requiresPreflight: true
+			},
+			{
+				description: 'a POST request with application/json content',
+				init: {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: '{"name":"Happy DOM"}'
+				},
+				requiresPreflight: true
+			}
+		];
+
+		it.each(testCases)('returns $requiresPreflight for $description', (testCase) => {
+			const request = new window.Request('https://other.origin.test/', testCase.init);
+
+			expect(FetchCORSUtility.isPreflightRequired(request)).toBe(testCase.requiresPreflight);
+		});
+	});
+});


### PR DESCRIPTION
### Description

`fetch()` and `XMLHttpRequest` currently send an `OPTIONS` preflight before every cross-origin request. Browsers only do that for requests falling outside the [CORS-safelisted](https://fetch.spec.whatwg.org/#cors-safelisted-request-header) set. A cross-origin `GET` with no custom headers should go straight out on the wire, and fail afterwards if the response is missing an `access-control-allow-origin` header covering the requesting origin.

This PR adds `FetchCORSUtility.isPreflightRequired()`, which implements the spec's decision. The method has to be `GET`, `HEAD` or `POST`, and every header has to be CORS-safelisted: name on the safelist, value under 128 bytes, and value contents valid for that specific header. `Content-Type` is parsed with `whatwg-mimetype`, so only `application/x-www-form-urlencoded`, `multipart/form-data` and `text/plain` pass. `Fetch` and `SyncFetch` calls it in two places: to skip the preflight, and to decide whether the response needs an `access-control-allow-origin` check.

That response check only runs from this instance's own HTTP response - a redirect that gets followed is validated by the `Fetch` instance performing it, against the URL it actually requested. So a cross-origin request that redirects to a same-origin URL is not judged against the original request's origin.

I didn't know whether or not to consider this a breaking change - if someone _relies_ on the OPTIONS request being sent, then this will be breaking. But it now conforms (more, at least) to the spec.

Resolves #1491

**Note:** There's a couple more CORS-related issues I ran into that I didn't solve as part of this - the larger the PR the harder it is to review, after all - but I might open some PR's/issues for those as well:
  - Requests that _do_ require a preflight are still validated only by the preflight response. Browsers also require `access-control-allow-origin` on the actual response
  - Individual redirect hops are not validated, only the final response. Browsers want the header on every hop.
  - `credentials: 'include'` still accepts a wildcard `access-control-allow-origin`. Browsers reject that, and also expect `access-control-allow-credentials`. The preflight path has the same gap and an existing `TODO` about it.

**Note 2:** #2286 overlaps a bit with this - but mostly they are separate issues.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
