### PR TITLE
fix: [#2290] Dispatches loadstart/load/loadend/abort as ProgressEvent

### DIFF
--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
@@ -384,7 +384,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#readyState = XMLHttpRequestReadyStateEnum.loading;
 
 		this.#dispatchEvent(new Event('readystatechange'));
-		this.#dispatchEvent(new Event('loadstart'));
+		this.#dispatchEvent(new ProgressEvent('loadstart'));
 
 		if (body) {
 			this.#request = new window.Request(this.#request!.url, {
@@ -399,8 +399,8 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#abortController!.signal.addEventListener('abort', () => {
 			this.#aborted = true;
 			this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
-			this.#dispatchEvent(new Event('abort'));
-			this.#dispatchEvent(new Event('loadend'));
+			this.#dispatchEvent(new ProgressEvent('abort'));
+			this.#dispatchEvent(new ProgressEvent('loadend'));
 			this.#dispatchEvent(new Event('readystatechange'));
 			asyncTaskManager.endTask(taskID);
 		});
@@ -411,12 +411,12 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 					return;
 				}
 				this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
-				this.#dispatchEvent(new Event('abort'));
+				this.#dispatchEvent(new ProgressEvent('abort'));
 			} else {
 				this.#readyState = XMLHttpRequestReadyStateEnum.done;
 				this.#dispatchEvent(new ErrorEvent('error', { error, message: error.message }));
 			}
-			this.#dispatchEvent(new Event('loadend'));
+			this.#dispatchEvent(new ProgressEvent('loadend'));
 			this.#dispatchEvent(new Event('readystatechange'));
 			asyncTaskManager.endTask(taskID);
 		};
@@ -488,9 +488,15 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 
 		asyncTaskManager.endTask(taskID);
 
+		const eventInit = {
+			lengthComputable: contentLengthNumber !== null,
+			loaded,
+			total: contentLengthNumber ?? 0
+		};
+
 		this.#dispatchEvent(new Event('readystatechange'));
-		this.#dispatchEvent(new Event('load'));
-		this.#dispatchEvent(new Event('loadend'));
+		this.#dispatchEvent(new ProgressEvent('load', eventInit));
+		this.#dispatchEvent(new ProgressEvent('loadend', eventInit));
 	}
 
 	/**
@@ -532,7 +538,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			this.#dispatchEvent(
 				new ErrorEvent('error', { error: <Error>error, message: (<Error>error).message })
 			);
-			this.#dispatchEvent(new Event('loadend'));
+			this.#dispatchEvent(new ProgressEvent('loadend'));
 			this.#dispatchEvent(new Event('readystatechange'));
 			return;
 		}
@@ -551,9 +557,18 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 
 		this.#readyState = XMLHttpRequestReadyStateEnum.done;
 
+		const contentLength = this.#response.headers.get('Content-Length');
+		const contentLengthNumber =
+			contentLength !== null && !isNaN(Number(contentLength)) ? Number(contentLength) : null;
+		const eventInit = {
+			lengthComputable: contentLengthNumber !== null,
+			loaded: this.#response.body?.length ?? 0,
+			total: contentLengthNumber ?? 0
+		};
+
 		this.#dispatchEvent(new Event('readystatechange'));
-		this.#dispatchEvent(new Event('load'));
-		this.#dispatchEvent(new Event('loadend'));
+		this.#dispatchEvent(new ProgressEvent('load', eventInit));
+		this.#dispatchEvent(new ProgressEvent('loadend', eventInit));
 	}
 
 	/**


### PR DESCRIPTION
### Description

XMLHttpRequest dispatched `loadstart`, `load`, `loadend` and `abort` as plain `Event` instances. The specification's send() algorithm fires all of these as `ProgressEvent`, so listeners can read `event.loaded`, `event.total` and `event.lengthComputable`.

`load`/`loadend` now carry the number of bytes received and the `Content-Length` total (when known).

Resolves #2290

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
