### PR TITLE
fix: [#2291] Runs the request error steps on abort() and network errors

### DIFF
--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
@@ -398,10 +398,9 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 
 		this.#abortController!.signal.addEventListener('abort', () => {
 			this.#aborted = true;
+			this.#readyState = XMLHttpRequestReadyStateEnum.done;
+			this.#dispatchRequestError(new Event('abort'));
 			this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
-			this.#dispatchEvent(new Event('abort'));
-			this.#dispatchEvent(new Event('loadend'));
-			this.#dispatchEvent(new Event('readystatechange'));
 			asyncTaskManager.endTask(taskID);
 		});
 
@@ -410,14 +409,13 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 				if (this.#aborted) {
 					return;
 				}
+				this.#readyState = XMLHttpRequestReadyStateEnum.done;
+				this.#dispatchRequestError(new Event('abort'));
 				this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
-				this.#dispatchEvent(new Event('abort'));
 			} else {
 				this.#readyState = XMLHttpRequestReadyStateEnum.done;
-				this.#dispatchEvent(new ErrorEvent('error', { error, message: error.message }));
+				this.#dispatchRequestError(new ErrorEvent('error', { error, message: error.message }));
 			}
-			this.#dispatchEvent(new Event('loadend'));
-			this.#dispatchEvent(new Event('readystatechange'));
 			asyncTaskManager.endTask(taskID);
 		};
 
@@ -439,6 +437,11 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 
 		this.#dispatchEvent(new Event('readystatechange'));
 
+		// A "readystatechange" listener may have called abort() synchronously, discarding the response.
+		if (this.#response === null) {
+			return;
+		}
+
 		const contentLength = this.#response.headers.get('Content-Length');
 		const contentLengthNumber =
 			contentLength !== null && !isNaN(Number(contentLength)) ? Number(contentLength) : null;
@@ -448,6 +451,10 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			let eventError: Error;
 			try {
 				for await (const chunk of this.#response.body) {
+					// A "progress" listener may have called abort() synchronously.
+					if (this.#response === null) {
+						return;
+					}
 					const chunkBuffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
 					this.#accumulatedData = Buffer.concat([this.#accumulatedData, chunkBuffer]);
 					loaded += chunk.length;
@@ -472,6 +479,11 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 				onError(<Error>error);
 				return;
 			}
+		}
+
+		// A "progress" listener may have called abort() synchronously during the last iteration.
+		if (this.#response === null) {
+			return;
 		}
 
 		this.#responseBody = XMLHttpRequestResponseDataParser.parse({
@@ -529,11 +541,9 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			this.#response = fetch.send();
 		} catch (error) {
 			this.#readyState = XMLHttpRequestReadyStateEnum.done;
-			this.#dispatchEvent(
+			this.#dispatchRequestError(
 				new ErrorEvent('error', { error: <Error>error, message: (<Error>error).message })
 			);
-			this.#dispatchEvent(new Event('loadend'));
-			this.#dispatchEvent(new Event('readystatechange'));
 			return;
 		}
 
@@ -553,6 +563,23 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 
 		this.#dispatchEvent(new Event('readystatechange'));
 		this.#dispatchEvent(new Event('load'));
+		this.#dispatchEvent(new Event('loadend'));
+	}
+
+	/**
+	 * Runs the request error steps: discards the response, then dispatches
+	 * "readystatechange" followed by the given event and finally "loadend".
+	 *
+	 * @see https://xhr.spec.whatwg.org/#request-error-steps
+	 * @param event Event to dispatch, e.g. an "abort" Event or an "error" ErrorEvent.
+	 */
+	#dispatchRequestError(event: Event): void {
+		this.#response = null;
+		this.#responseBody = null;
+		this.#accumulatedData = Buffer.from([]);
+
+		this.#dispatchEvent(new Event('readystatechange'));
+		this.#dispatchEvent(event);
 		this.#dispatchEvent(new Event('loadend'));
 	}
 


### PR DESCRIPTION
### Description

When a request was aborted or failed after the response headers had already been received, XMLHttpRequest did not run the specification's request error steps correctly: "readystatechange" was dispatched after "abort"/"error" and "loadend" instead of before, and the previously received response was never discarded, so status/response headers/responseURL kept reporting data from the failed request.

Both the async abort listener and the async/sync error paths now go through a shared #dispatchRequestError() helper that discards the response before dispatching readystatechange, then the given event, then loadend. Because that can synchronously trigger a nested abort() from a listener, the remaining response reads in #sendAsync() now check that the response has not been discarded in the meantime.

Resolves #2291

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
