### PR TITLE
fix: [#2292] Adds support for XMLHttpRequest upload progress events

### DIFF
--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -35,6 +35,7 @@ import PreloadUtility from './preload/PreloadUtility.js';
 import type IFetchRequestHeaders from './types/IFetchRequestHeaders.js';
 
 const LAST_CHUNK = Buffer.from('0\r\n\r\n');
+const REQUEST_BODY_CHUNK_SIZE = 65536;
 
 /**
  * Handles fetch requests.
@@ -64,6 +65,8 @@ export default class Fetch {
 	private disableCache: boolean;
 	private disableSameOriginPolicy: boolean;
 	private disablePreload: boolean;
+	private onRequestProgress: ((transmitted: number) => void) | null;
+	private onRequestEnd: ((transmitted: number) => void) | null;
 	#browserFrame: IBrowserFrame;
 	#window: BrowserWindow;
 	#unfilteredHeaders: Headers | null = null;
@@ -82,6 +85,8 @@ export default class Fetch {
 	 * @param [options.disableSameOriginPolicy] Disables the Same-Origin policy.
 	 * @param [options.unfilteredHeaders] Unfiltered headers - necessary for preflight requests.
 	 * @param [options.disablePreload] Disables the use of preloaded responses.
+	 * @param [options.onRequestProgress] Callback invoked with the number of request body bytes transmitted so far.
+	 * @param [options.onRequestEnd] Callback invoked when the request body has been fully transmitted.
 	 */
 	constructor(options: {
 		browserFrame: IBrowserFrame;
@@ -94,6 +99,8 @@ export default class Fetch {
 		disableSameOriginPolicy?: boolean;
 		unfilteredHeaders?: Headers;
 		disablePreload?: boolean;
+		onRequestProgress?: (transmitted: number) => void;
+		onRequestEnd?: (transmitted: number) => void;
 	}) {
 		this.#browserFrame = options.browserFrame;
 		this.#window = options.window;
@@ -114,6 +121,8 @@ export default class Fetch {
 		this.interceptor = this.#browserFrame.page.context.browser.settings.fetch.interceptor;
 		this.requestHeaders = this.#browserFrame.page.context.browser.settings.fetch.requestHeaders;
 		this.disablePreload = options.disablePreload ?? false;
+		this.onRequestProgress = options.onRequestProgress ?? null;
+		this.onRequestEnd = options.onRequestEnd ?? null;
 	}
 
 	/**
@@ -154,6 +163,7 @@ export default class Fetch {
 			});
 			this.#browserFrame[PropertySymbol.asyncTaskManager].endTask(taskID);
 			if (response instanceof Response) {
+				this.completeRequestBodyWithoutNetwork();
 				return response;
 			}
 		}
@@ -182,6 +192,7 @@ export default class Fetch {
 						request: this.request
 					})
 				: undefined;
+			this.completeRequestBodyWithoutNetwork();
 			return interceptedResponse instanceof Response ? interceptedResponse : this.response;
 		}
 
@@ -204,6 +215,7 @@ export default class Fetch {
 			const cachedResponse = await this.getCachedResponse();
 
 			if (cachedResponse) {
+				this.completeRequestBodyWithoutNetwork();
 				return cachedResponse;
 			}
 		}
@@ -222,6 +234,7 @@ export default class Fetch {
 				this.#window.document[PropertySymbol.preloads].delete(preloadKey);
 
 				if (preloadEntry.response) {
+					this.completeRequestBodyWithoutNetwork();
 					return preloadEntry.response;
 				}
 
@@ -230,6 +243,7 @@ export default class Fetch {
 
 				this.#browserFrame[PropertySymbol.asyncTaskManager].endTask(taskID);
 
+				this.completeRequestBodyWithoutNetwork();
 				return response;
 			}
 		}
@@ -237,6 +251,7 @@ export default class Fetch {
 		const virtualServerResponse = await this.getVirtualServerResponse();
 
 		if (virtualServerResponse) {
+			this.completeRequestBodyWithoutNetwork();
 			return virtualServerResponse;
 		}
 
@@ -620,16 +635,50 @@ export default class Fetch {
 			this.nodeRequest.on('socket', this.onSocket.bind(this));
 			this.nodeRequest.on('response', this.onResponse.bind(this));
 
+			const onPipelineComplete = (error: NodeJS.ErrnoException | null): void => {
+				if (error) {
+					this.onError(error);
+				}
+			};
+
 			if (this.request.body === null) {
 				this.nodeRequest.end();
-			} else {
-				Stream.pipeline(this.request.body, this.nodeRequest, (error) => {
-					if (error) {
-						this.onError(error);
+			} else if (this.onRequestProgress || this.onRequestEnd) {
+				const onRequestProgress = this.onRequestProgress;
+				let transmitted = 0;
+				this.nodeRequest.once('finish', () => this.onRequestEnd?.(transmitted));
+
+				// The body is split into socket sized chunks, so that progress is reported while it is transmitted.
+				const counter = new Stream.Transform({
+					transform(chunk: Buffer, _encoding, callback) {
+						for (let offset = 0; offset < chunk.length; offset += REQUEST_BODY_CHUNK_SIZE) {
+							this.push(chunk.subarray(offset, offset + REQUEST_BODY_CHUNK_SIZE));
+						}
+						callback();
 					}
 				});
+
+				counter.on('data', (chunk: Buffer) => {
+					transmitted += chunk.length;
+					if (onRequestProgress) {
+						onRequestProgress(transmitted);
+					}
+				});
+
+				Stream.pipeline(this.request.body, counter, this.nodeRequest, onPipelineComplete);
+			} else {
+				Stream.pipeline(this.request.body, this.nodeRequest, onPipelineComplete);
 			}
 		});
+	}
+
+	/**
+	 * Signals that a request body was handled by a fetch path that did not use the network.
+	 */
+	private completeRequestBodyWithoutNetwork(): void {
+		if (this.request.body !== null) {
+			this.onRequestEnd?.(this.request[PropertySymbol.contentLength] ?? 0);
+		}
 	}
 
 	/**
@@ -1004,7 +1053,9 @@ export default class Fetch {
 					init: requestInit,
 					redirectCount: this.redirectCount + 1,
 					disableSameOriginPolicy: this.disableSameOriginPolicy,
-					contentType: !shouldBecomeGetRequest ? this.request[PropertySymbol.contentType] : null
+					contentType: !shouldBecomeGetRequest ? this.request[PropertySymbol.contentType] : null,
+					onRequestProgress: this.onRequestProgress ?? undefined,
+					onRequestEnd: this.onRequestEnd ?? undefined
 				});
 
 				this.finalizeRequest();

--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
@@ -56,6 +56,9 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	#accumulatedData: Buffer = Buffer.from([]);
 	#readyState: XMLHttpRequestReadyStateEnum = XMLHttpRequestReadyStateEnum.unsent;
 	#overriddenMimeType: string | null = null;
+	#uploadComplete = true;
+	#uploadListener = false;
+	#uploadTransmitted = 0;
 
 	/**
 	 * Constructor.
@@ -232,6 +235,9 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#response = null;
 		this.#responseBody = null;
 		this.#accumulatedData = Buffer.from([]);
+		this.#uploadComplete = true;
+		this.#uploadListener = false;
+		this.#uploadTransmitted = 0;
 		this.#abortController = new window.AbortController();
 		this.#request = new window.Request(url, {
 			method,
@@ -315,6 +321,10 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			);
 		}
 
+		if (this.#request!.method === 'GET' || this.#request!.method === 'HEAD') {
+			body = undefined;
+		}
+
 		// When body is a Document, serialize it to a string.
 		if (
 			typeof body === 'object' &&
@@ -381,12 +391,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		const asyncTaskManager = browserFrame[PropertySymbol.asyncTaskManager];
 		const taskID = asyncTaskManager.startTask(() => this.abort());
 
-		this.#readyState = XMLHttpRequestReadyStateEnum.loading;
-
-		this.#dispatchEvent(new Event('readystatechange'));
-		this.#dispatchEvent(new Event('loadstart'));
-
-		if (body) {
+		if (body !== undefined && body !== null) {
 			this.#request = new window.Request(this.#request!.url, {
 				method: this.#request!.method,
 				headers: this.#request!.headers,
@@ -396,9 +401,16 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			});
 		}
 
+		const requestBodyLength = this.#request![PropertySymbol.contentLength] ?? 0;
+
+		// The upload listener flag is captured here, as listeners registered after send() must not be notified.
+		this.#uploadComplete = this.#request![PropertySymbol.body] === null;
+		this.#uploadListener = this.#hasUploadListeners();
+
 		this.#abortController!.signal.addEventListener('abort', () => {
 			this.#aborted = true;
 			this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
+			this.#dispatchUploadRequestError('abort');
 			this.#dispatchEvent(new Event('abort'));
 			this.#dispatchEvent(new Event('loadend'));
 			this.#dispatchEvent(new Event('readystatechange'));
@@ -411,9 +423,11 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 					return;
 				}
 				this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
+				this.#dispatchUploadRequestError('abort');
 				this.#dispatchEvent(new Event('abort'));
 			} else {
 				this.#readyState = XMLHttpRequestReadyStateEnum.done;
+				this.#dispatchUploadRequestError('error');
 				this.#dispatchEvent(new ErrorEvent('error', { error, message: error.message }));
 			}
 			this.#dispatchEvent(new Event('loadend'));
@@ -421,17 +435,66 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			asyncTaskManager.endTask(taskID);
 		};
 
+		this.#readyState = XMLHttpRequestReadyStateEnum.loading;
+
+		this.#dispatchEvent(new Event('readystatechange'));
+		this.#dispatchEvent(new Event('loadstart'));
+
+		if (this.#aborted) {
+			return;
+		}
+
+		if (!this.#uploadComplete && this.#uploadListener) {
+			this.#dispatchEvent(
+				new ProgressEvent('loadstart', {
+					lengthComputable: requestBodyLength !== 0,
+					loaded: 0,
+					total: requestBodyLength
+				}),
+				this.upload
+			);
+		}
+
+		if (this.#aborted) {
+			return;
+		}
+
+		const reportsUploadProgress = !this.#uploadComplete && this.#uploadListener;
+
 		const fetch = new Fetch({
 			browserFrame: browserFrame,
 			window: window,
 			url: this.#request!.url,
-			init: this.#request!
+			init: this.#request!,
+			onRequestProgress: reportsUploadProgress
+				? (transmitted: number) => {
+						if (this.#uploadComplete) {
+							return;
+						}
+						this.#uploadTransmitted = transmitted;
+						this.#dispatchEvent(
+							new ProgressEvent('progress', {
+								lengthComputable: requestBodyLength !== 0,
+								loaded: transmitted,
+								total: requestBodyLength
+							}),
+							this.upload
+						);
+					}
+				: undefined,
+			onRequestEnd: reportsUploadProgress
+				? (transmitted: number) => this.#dispatchUploadComplete(requestBodyLength, transmitted)
+				: undefined
 		});
 
 		try {
 			this.#response = await fetch.send();
 		} catch (error) {
 			onError(<Error>error);
+			return;
+		}
+
+		if (this.#aborted) {
 			return;
 		}
 
@@ -557,13 +620,88 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	}
 
 	/**
+	 * Returns "true" if the upload object had any event listener registered when send() was called.
+	 *
+	 * @returns "true" if the upload object has listeners.
+	 */
+	#hasUploadListeners(): boolean {
+		for (const listener of this.upload[PropertySymbol.propertyEventListeners].values()) {
+			if (listener) {
+				return true;
+			}
+		}
+		for (const listeners of this.upload[PropertySymbol.listeners].bubbling.values()) {
+			if (listeners.length > 0) {
+				return true;
+			}
+		}
+		for (const listeners of this.upload[PropertySymbol.listeners].capturing.values()) {
+			if (listeners.length > 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Dispatches the events indicating that the request body has been fully transmitted.
+	 *
+	 * @param requestBodyLength Length of the request body.
+	 * @param transmitted Number of transmitted bytes.
+	 */
+	#dispatchUploadComplete(requestBodyLength: number, transmitted: number): void {
+		if (this.#uploadComplete) {
+			return;
+		}
+
+		this.#uploadComplete = true;
+
+		if (!this.#uploadListener) {
+			return;
+		}
+
+		this.#uploadTransmitted = transmitted;
+
+		const eventInit = {
+			lengthComputable: requestBodyLength !== 0,
+			loaded: this.#uploadTransmitted,
+			total: requestBodyLength
+		};
+
+		this.#dispatchEvent(new ProgressEvent('progress', eventInit), this.upload);
+		this.#dispatchEvent(new ProgressEvent('load', eventInit), this.upload);
+		this.#dispatchEvent(new ProgressEvent('loadend', eventInit), this.upload);
+	}
+
+	/**
+	 * Dispatches an abort or error event on the upload object for a request that failed mid-upload.
+	 *
+	 * @param type Event type.
+	 */
+	#dispatchUploadRequestError(type: string): void {
+		if (this.#uploadComplete) {
+			return;
+		}
+
+		this.#uploadComplete = true;
+
+		if (!this.#uploadListener) {
+			return;
+		}
+
+		this.#dispatchEvent(new ProgressEvent(type), this.upload);
+		this.#dispatchEvent(new ProgressEvent('loadend'), this.upload);
+	}
+
+	/**
 	 * Dispatches an event with try/catch.
 	 *
 	 * This is necessary to prevent errors from setting XMLHttpRequest in an invalid state.
 	 *
 	 * @param event Event.
+	 * @param [target] Target to dispatch the event at. Defaults to the XMLHttpRequest object.
 	 */
-	#dispatchEvent(event: Event): void {
+	#dispatchEvent(event: Event, target: XMLHttpRequestEventTarget = this): void {
 		const browserFrame = new WindowBrowserContext(this[PropertySymbol.window]).getBrowserFrame();
 		if (!browserFrame?.page?.context?.browser?.settings?.errorCapture) {
 			return;
@@ -571,7 +709,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		const settings = browserFrame.page.context.browser.settings;
 		const errorCapture = settings.errorCapture;
 		settings.errorCapture = BrowserErrorCaptureEnum.tryAndCatch;
-		this.dispatchEvent(event);
+		target.dispatchEvent(event);
 		settings.errorCapture = errorCapture;
 	}
 }

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -20,6 +20,8 @@ import FetchHTTPSCertificate from '../../src/fetch/certificate/FetchHTTPSCertifi
 import * as PropertySymbol from '../../src/PropertySymbol.js';
 import { fail } from 'assert';
 import Browser from '../../src/browser/Browser.js';
+import Fetch from '../../src/fetch/Fetch.js';
+import WindowBrowserContext from '../../src/window/WindowBrowserContext.js';
 
 const LAST_CHUNK = Buffer.from('0\r\n\r\n');
 
@@ -100,6 +102,51 @@ describe('Fetch', () => {
 	});
 
 	describe('send()', () => {
+		it('Reports request body progress in chunks and signals the end of the upload.', async () => {
+			const window = new Window({ url: 'https://localhost:8080/' });
+			const body = 'x'.repeat(65536 * 2 + 1);
+			const progress: number[] = [];
+			let requestEnd = 0;
+
+			mockModule('https', {
+				request: () => {
+					const nodeRequest = new Stream.Writable({
+						write(_chunk, _encoding, callback) {
+							callback();
+						}
+					});
+					(<ClientRequest>nodeRequest).setTimeout = () => nodeRequest;
+
+					nodeRequest.on('finish', () => {
+						const response = <HTTP.IncomingMessage>Stream.Readable.from([]);
+						response.statusCode = 200;
+						response.statusMessage = 'OK';
+						response.headers = {};
+						response.rawHeaders = [];
+						nodeRequest.emit('response', response);
+					});
+
+					return nodeRequest;
+				}
+			});
+
+			const fetch = new Fetch({
+				browserFrame: new WindowBrowserContext(window).getBrowserFrame()!,
+				window,
+				url: '/upload',
+				init: { method: 'POST', body },
+				onRequestProgress: (transmitted) => progress.push(transmitted),
+				onRequestEnd: (transmitted) => {
+					requestEnd = transmitted;
+				}
+			});
+
+			await fetch.send();
+
+			expect(progress).toEqual([65536, 65536 * 2, body.length]);
+			expect(requestEnd).toBe(body.length);
+		});
+
 		it('Rejects with error if url is protocol relative.', async () => {
 			const window = new Window();
 			const url = '//example.com/';

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -48,6 +48,11 @@ const FORBIDDEN_REQUEST_HEADERS = [
 	'via'
 ];
 
+interface IFetchUploadCallbacks {
+	onRequestProgress: ((transmitted: number) => void) | null;
+	onRequestEnd?: ((transmitted: number) => void) | null;
+}
+
 describe('XMLHttpRequest', () => {
 	let window: Window;
 	let request: XMLHttpRequest;
@@ -716,6 +721,177 @@ describe('XMLHttpRequest', () => {
 			expect(() => request.send()).toThrow(
 				`Failed to execute 'send' on 'XMLHttpRequest': Connection must be opened before send() is called.`
 			);
+		});
+
+		it('Dispatches upload progress events while the request body is transmitted.', async () => {
+			let resolveResponse: (response: Response) => void;
+			let fetchUploadCallbacks: IFetchUploadCallbacks;
+			const events: Array<{
+				type: string;
+				lengthComputable: boolean;
+				loaded: number;
+				total: number;
+			}> = [];
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(function () {
+				fetchUploadCallbacks = <IFetchUploadCallbacks>(<unknown>this);
+				return new Promise((resolve) => {
+					resolveResponse = resolve;
+				});
+			});
+
+			for (const type of ['loadstart', 'progress', 'load', 'loadend']) {
+				request.upload.addEventListener(type, (event) => {
+					const progressEvent = <ProgressEvent>event;
+					events.push({
+						type,
+						lengthComputable: progressEvent.lengthComputable,
+						loaded: progressEvent.loaded,
+						total: progressEvent.total
+					});
+				});
+			}
+
+			request.open('POST', REQUEST_URL, true);
+			request.send('test');
+
+			fetchUploadCallbacks!.onRequestProgress!(2);
+			fetchUploadCallbacks!.onRequestEnd?.(4);
+
+			const eventsBeforeResponse = events.slice();
+
+			resolveResponse!(<Response>{ headers: <Headers>new Headers() });
+			await window.happyDOM?.waitUntilComplete();
+
+			const expectedEvents = [
+				{ type: 'loadstart', lengthComputable: true, loaded: 0, total: 4 },
+				{ type: 'progress', lengthComputable: true, loaded: 2, total: 4 },
+				{ type: 'progress', lengthComputable: true, loaded: 4, total: 4 },
+				{ type: 'load', lengthComputable: true, loaded: 4, total: 4 },
+				{ type: 'loadend', lengthComputable: true, loaded: 4, total: 4 }
+			];
+
+			expect(eventsBeforeResponse).toEqual(expectedEvents);
+			expect(events).toEqual(expectedEvents);
+		});
+
+		it('Does not dispatch upload events to listeners added after send().', async () => {
+			let resolveResponse: (response: Response) => void;
+			const events: string[] = [];
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(
+				() =>
+					new Promise((resolve) => {
+						resolveResponse = resolve;
+					})
+			);
+
+			request.open('POST', REQUEST_URL, true);
+			request.send('test');
+
+			for (const type of ['loadstart', 'progress', 'load', 'loadend']) {
+				request.upload.addEventListener(type, () => events.push(type));
+			}
+
+			resolveResponse!(<Response>{ headers: <Headers>new Headers() });
+			await window.happyDOM?.waitUntilComplete();
+
+			expect(events).toEqual([]);
+		});
+
+		it('Does not dispatch upload events when a body is passed to a GET request.', async () => {
+			const events: string[] = [];
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(async function () {
+				expect(this.request.body).toBeNull();
+				return <Response>{ headers: <Headers>new Headers() };
+			});
+
+			request.upload.addEventListener('loadstart', () => events.push('loadstart'));
+			request.upload.addEventListener('progress', () => events.push('progress'));
+			request.upload.addEventListener('load', () => events.push('load'));
+			request.upload.addEventListener('loadend', () => events.push('loadend'));
+
+			request.open('GET', REQUEST_URL, true);
+			request.send('test');
+
+			await window.happyDOM?.waitUntilComplete();
+
+			expect(events).toEqual([]);
+		});
+
+		it('Does not count a removed upload listener when send() captures the listener flag.', async () => {
+			let resolveResponse: (response: Response) => void;
+			const events: string[] = [];
+			const removedListener = (): void => {};
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(
+				() =>
+					new Promise((resolve) => {
+						resolveResponse = resolve;
+					})
+			);
+
+			request.upload.addEventListener('progress', removedListener);
+			request.upload.removeEventListener('progress', removedListener);
+			request.open('POST', REQUEST_URL, true);
+			request.send('test');
+			request.upload.addEventListener('progress', () => events.push('progress'));
+
+			resolveResponse!(<Response>{ headers: <Headers>new Headers() });
+			await window.happyDOM?.waitUntilComplete();
+
+			expect(events).toEqual([]);
+		});
+
+		it('Dispatches error and loadend when a request fails before the upload completes.', async () => {
+			const events: Array<{ type: string; loaded: number; total: number }> = [];
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(async function () {
+				(<IFetchUploadCallbacks>(<unknown>this)).onRequestProgress!(2);
+				throw new Error('Request failed.');
+			});
+
+			for (const type of ['loadstart', 'progress', 'error', 'loadend']) {
+				request.upload.addEventListener(type, (event) => {
+					const progressEvent = <ProgressEvent>event;
+					events.push({ type, loaded: progressEvent.loaded, total: progressEvent.total });
+				});
+			}
+
+			request.open('POST', REQUEST_URL, true);
+			request.send('test');
+
+			await window.happyDOM?.waitUntilComplete();
+
+			expect(events).toEqual([
+				{ type: 'loadstart', loaded: 0, total: 4 },
+				{ type: 'progress', loaded: 2, total: 4 },
+				{ type: 'error', loaded: 0, total: 0 },
+				{ type: 'loadend', loaded: 0, total: 0 }
+			]);
+		});
+
+		it('Aborts the upload when abort() is called from the upload loadstart listener.', async () => {
+			const events: string[] = [];
+			const fetchSpy = vi
+				.spyOn(Fetch.prototype, 'send')
+				.mockResolvedValue(<Response>{ headers: <Headers>new Headers() });
+
+			request.upload.onloadstart = () => {
+				events.push('loadstart');
+				request.abort();
+			};
+			request.upload.onabort = () => events.push('abort');
+			request.upload.onloadend = () => events.push('loadend');
+
+			request.open('POST', REQUEST_URL, true);
+			request.send('test');
+
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(events).toEqual(['loadstart', 'abort', 'loadend']);
+			expect(fetchSpy).not.toHaveBeenCalled();
 		});
 
 		it('Performs a synchronous GET request with the HTTP protocol.', () => {


### PR DESCRIPTION
### Description

`XMLHttpRequestUpload` existed but never dispatched any events, so `xhr.upload.onprogress` and friends never fired for a request with a body.

This PR:

- Dispatches `loadstart` on the upload object during `send()`, and `progress` repeatedly while the request body is actually being transmitted (Fetch takes an optional `onRequestProgress` callback and splits the body into socket sized chunks to report this), followed by `load` and `loadend` once fully sent.
- Dispatches `abort`/`error` followed by `loadend` on the upload object for a request that fails before the body finishes sending.
- Implements the upload listener flag, so listeners registered on `xhr.upload` after `send()` has been called are not notified.
- Treats an empty string request body as a body, so upload events are also dispatched for `send('')`.

This helps prove out upload progress behavior in browsers - `fetch` still doesn't have a good solution for this, so quite often people fall back to using XHR.

Resolves #2292

> [!NOTE]
> The tests were created for me by AI model GPT-5.6 Sol to save time and ensure spec compliance

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
