### PR TITLE
fix: Make document.links return a live HTMLCollection

### DIFF
--- a/packages/happy-dom/src/PropertySymbol.ts
+++ b/packages/happy-dom/src/PropertySymbol.ts
@@ -171,6 +171,7 @@ export const elementArray = Symbol('elementArray');
 export const cache = Symbol('cache');
 export const affectsCache = Symbol('affectsCache');
 export const forms = Symbol('forms');
+export const links = Symbol('links');
 export const affectsComputedStyleCache = Symbol('affectsComputedStyleCache');
 export const query = Symbol('query');
 export const computedStyle = Symbol('computedStyle');

--- a/packages/happy-dom/src/nodes/document/Document.ts
+++ b/packages/happy-dom/src/nodes/document/Document.ts
@@ -37,6 +37,7 @@ import type ISVGElementTagNameMap from '../../config/ISVGElementTagNameMap.js';
 import type SVGElement from '../svg-element/SVGElement.js';
 import type HTMLFormElement from '../html-form-element/HTMLFormElement.js';
 import type HTMLAnchorElement from '../html-anchor-element/HTMLAnchorElement.js';
+import type HTMLAreaElement from '../html-area-element/HTMLAreaElement.js';
 import HTMLElementConfig from '../../config/HTMLElementConfig.js';
 import type HTMLHtmlElement from '../html-html-element/HTMLHtmlElement.js';
 import type HTMLBodyElement from '../html-body-element/HTMLBodyElement.js';
@@ -75,6 +76,7 @@ export default class Document extends Node {
 	public [PropertySymbol.referrer] = '';
 	public [PropertySymbol.defaultView]: BrowserWindow | null = null;
 	public [PropertySymbol.forms]: HTMLCollection<HTMLFormElement> | null = null;
+	public [PropertySymbol.links]: HTMLCollection<HTMLAnchorElement | HTMLAreaElement> | null = null;
 	public [PropertySymbol.affectsComputedStyleCache]: ICachedComputedStyleResult[] = [];
 	public [PropertySymbol.ownerDocument]: Document = <Document>(<unknown>null);
 	public [PropertySymbol.elementIdMap]: Map<
@@ -1139,8 +1141,17 @@ export default class Document extends Node {
 	/**
 	 * Returns a collection of all area elements and a elements in a document with a value for the href attribute.
 	 */
-	public get links(): NodeList<HTMLAnchorElement | HTMLElement> {
-		return <NodeList<HTMLElement>>QuerySelector.querySelectorAll(this, 'a[href],area[href]');
+	public get links(): HTMLCollection<HTMLAnchorElement | HTMLAreaElement> {
+		if (!this[PropertySymbol.links]) {
+			this[PropertySymbol.links] = new HTMLCollection<HTMLAnchorElement | HTMLAreaElement>(
+				PropertySymbol.illegalConstructor,
+				() =>
+					<(HTMLAnchorElement | HTMLAreaElement)[]>(
+						QuerySelector.querySelectorAll(this, 'a[href],area[href]')[PropertySymbol.items]
+					)
+			);
+		}
+		return this[PropertySymbol.links];
 	}
 
 	/**
@@ -2214,6 +2225,7 @@ export default class Document extends Node {
 		this[PropertySymbol.defaultView] = null;
 		this[PropertySymbol.adoptedStyleSheets] = [];
 		this[PropertySymbol.forms] = null;
+		this[PropertySymbol.links] = null;
 		this[PropertySymbol.affectsComputedStyleCache] = [];
 		this[PropertySymbol.elementIdMap].clear();
 		this[PropertySymbol.xmlProcessingInstruction] = null;

--- a/packages/happy-dom/test/nodes/document/Document.test.ts
+++ b/packages/happy-dom/test/nodes/document/Document.test.ts
@@ -244,13 +244,14 @@ describe('Document', () => {
 			document.body.appendChild(link1);
 			document.body.appendChild(link2);
 
-			let links = document.links;
+			const links = document.links;
 
+			expect(links).toBeInstanceOf(HTMLCollection);
 			expect(links.length).toBe(1);
 			expect(links[0]).toBe(link1);
 
 			link2.setAttribute('href', '');
-			links = document.links;
+			expect(document.links).toBe(links);
 			expect(links.length).toBe(2);
 			expect(links[0]).toBe(link1);
 			expect(links[1]).toBe(link2);


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This change fixes `document.links` to match browser behavior. It also updates the return type to be more accurate.

I used GPT-5.6 Sol to generate the initial groundwork code and to assist with the review and verification. I then manually checked and verified everything myself.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
