### PR TITLE
feat: [#2293] Adds support for the XMLHttpRequest timeout attribute and timeout event

### DIFF
--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequest.ts
@@ -49,6 +49,9 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	#async = true;
 	#abortController: AbortController | null = null;
 	#aborted = false;
+	#timeout = 0;
+	#timedOut = false;
+	#timeoutTimer: NodeJS.Timeout | null = null;
 	#request: Request | null = null;
 	#response: Response | ISyncResponse | null = null;
 	#responseType: XMLHttpResponseTypeEnum | '' = '';
@@ -203,6 +206,32 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 	}
 
 	/**
+	 * Returns the number of milliseconds a request can take before automatically being terminated. A value of 0 means there is no timeout.
+	 *
+	 * @returns Timeout in milliseconds.
+	 */
+	public get timeout(): number {
+		return this.#timeout;
+	}
+
+	/**
+	 * Sets the number of milliseconds a request can take before automatically being terminated. A value of 0 means there is no timeout.
+	 *
+	 * @param value Timeout in milliseconds.
+	 * @throws {DOMException} If the request is synchronous.
+	 */
+	public set timeout(value: number) {
+		if (!this.#async) {
+			throw new this[PropertySymbol.window].DOMException(
+				`Failed to set the 'timeout' property on 'XMLHttpRequest': Timeouts cannot be set for synchronous requests made from a document.`,
+				DOMExceptionNameEnum.invalidAccessError
+			);
+		}
+		// Converts the value according to Web IDL "unsigned long" conversion rules (e.g. NaN becomes 0).
+		this.#timeout = Number(value) >>> 0;
+	}
+
+	/**
 	 * Opens the connection.
 	 *
 	 * @param method Connection method (eg GET, POST).
@@ -221,6 +250,13 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			);
 		}
 
+		if (!async && this.#timeout !== 0) {
+			throw new window.DOMException(
+				`Failed to execute 'open' on 'XMLHttpRequest': Synchronous requests from a document must not set a timeout.`,
+				DOMExceptionNameEnum.invalidAccessError
+			);
+		}
+
 		const headers = new this[PropertySymbol.window].Headers();
 		if (user) {
 			const authBuffer = Buffer.from(`${user}:${password || ''}`);
@@ -229,6 +265,8 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 
 		this.#async = async;
 		this.#aborted = false;
+		this.#timedOut = false;
+		this.#clearTimeoutTimer();
 		this.#response = null;
 		this.#responseBody = null;
 		this.#accumulatedData = Buffer.from([]);
@@ -396,7 +434,25 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 			});
 		}
 
+		if (this.#timeout !== 0) {
+			this.#timeoutTimer = window.setTimeout(() => {
+				this.#timedOut = true;
+				this.#abortController!.abort();
+			}, this.#timeout);
+		}
+
 		this.#abortController!.signal.addEventListener('abort', () => {
+			this.#clearTimeoutTimer();
+
+			if (this.#timedOut) {
+				this.#readyState = XMLHttpRequestReadyStateEnum.done;
+				this.#dispatchEvent(new Event('readystatechange'));
+				this.#dispatchEvent(new ProgressEvent('timeout'));
+				this.#dispatchEvent(new Event('loadend'));
+				asyncTaskManager.endTask(taskID);
+				return;
+			}
+
 			this.#aborted = true;
 			this.#readyState = XMLHttpRequestReadyStateEnum.unsent;
 			this.#dispatchEvent(new Event('abort'));
@@ -406,6 +462,11 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		});
 
 		const onError = (error: Error): void => {
+			this.#clearTimeoutTimer();
+			// The "timeout" event has already been dispatched by the abort signal listener when the request has timed out.
+			if (this.#timedOut) {
+				return;
+			}
 			if (error instanceof DOMException && error.name === DOMExceptionNameEnum.abortError) {
 				if (this.#aborted) {
 					return;
@@ -486,6 +547,8 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#readyState = XMLHttpRequestReadyStateEnum.done;
 		this.#accumulatedData = Buffer.from([]);
 
+		this.#clearTimeoutTimer();
+
 		asyncTaskManager.endTask(taskID);
 
 		this.#dispatchEvent(new Event('readystatechange'));
@@ -554,6 +617,16 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget {
 		this.#dispatchEvent(new Event('readystatechange'));
 		this.#dispatchEvent(new Event('load'));
 		this.#dispatchEvent(new Event('loadend'));
+	}
+
+	/**
+	 * Clears the timer used for detecting when the request has timed out.
+	 */
+	#clearTimeoutTimer(): void {
+		if (this.#timeoutTimer !== null) {
+			this[PropertySymbol.window].clearTimeout(this.#timeoutTimer);
+			this.#timeoutTimer = null;
+		}
 	}
 
 	/**

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -495,6 +495,26 @@ describe('XMLHttpRequest', () => {
 		});
 	});
 
+	describe('get timeout()', () => {
+		it('Returns "0" by default.', () => {
+			expect(request.timeout).toBe(0);
+		});
+	});
+
+	describe('set timeout()', () => {
+		it('Sets the timeout.', () => {
+			request.timeout = 100;
+			expect(request.timeout).toBe(100);
+		});
+
+		it(`Throws an exception if the request is synchronous.`, () => {
+			request.open('GET', REQUEST_URL, false);
+			expect(() => (request.timeout = 100)).toThrow(
+				`Failed to set the 'timeout' property on 'XMLHttpRequest': Timeouts cannot be set for synchronous requests made from a document.`
+			);
+		});
+	});
+
 	describe('open()', () => {
 		it('Opens a request.', () => {
 			request.open('GET', REQUEST_URL, true);
@@ -513,6 +533,13 @@ describe('XMLHttpRequest', () => {
 			request.responseType = XMLHttpResponseTypeEnum.json;
 			expect(() => request.open('GET', REQUEST_URL, false)).toThrow(
 				`Failed to execute 'open' on 'XMLHttpRequest': Synchronous requests from a document must not set a response type.`
+			);
+		});
+
+		it(`Throws an exception if the request is set to be synchronous and timeout is set.`, () => {
+			request.timeout = 100;
+			expect(() => request.open('GET', REQUEST_URL, false)).toThrow(
+				`Failed to execute 'open' on 'XMLHttpRequest': Synchronous requests from a document must not set a timeout.`
 			);
 		});
 	});
@@ -1314,6 +1341,92 @@ describe('XMLHttpRequest', () => {
 			await new Promise((resolve) => setTimeout(resolve, 50));
 
 			expect(triggeredEvents).toBe(8);
+		});
+
+		it('Terminates the request and dispatches a "timeout" event when the request takes longer than the "timeout" property.', async () => {
+			await new Promise((resolve) => {
+				let isAborted = false;
+
+				vi.spyOn(Fetch.prototype, 'send').mockImplementation(function (): Promise<Response> {
+					return new Promise((resolveResponse, reject) => {
+						const timer = setTimeout(() => {
+							resolveResponse(<Response>{ headers: <Headers>new Headers() });
+						}, 1000);
+						this.request.signal.addEventListener('abort', () => {
+							isAborted = true;
+							clearTimeout(timer);
+							reject(
+								new DOMException('The operation was aborted.', DOMExceptionNameEnum.abortError)
+							);
+						});
+					});
+				});
+
+				let timeoutEvent: ProgressEvent | null = null;
+				let isAbortTriggered = false;
+				let isErrorTriggered = false;
+				let isLoadEndTriggered = false;
+
+				request.open('GET', REQUEST_URL, true);
+				request.timeout = 10;
+				request.ontimeout = (event) => {
+					timeoutEvent = <ProgressEvent>event;
+				};
+				request.addEventListener('abort', () => {
+					isAbortTriggered = true;
+				});
+				request.addEventListener('error', () => {
+					isErrorTriggered = true;
+				});
+				request.addEventListener('loadend', () => {
+					isLoadEndTriggered = true;
+				});
+				request.send();
+
+				setTimeout(() => {
+					expect(isAborted).toBe(true);
+					expect(timeoutEvent!.type).toBe('timeout');
+					expect(isAbortTriggered).toBe(false);
+					expect(isErrorTriggered).toBe(false);
+					expect(isLoadEndTriggered).toBe(true);
+					expect(request.readyState).toBe(XMLHttpRequestReadyStateEnum.done);
+					expect(request.status).toBe(0);
+					expect(request.responseText).toBe('');
+
+					resolve(null);
+				}, 100);
+			});
+		});
+
+		it('Does not dispatch a "timeout" event when the request completes within the "timeout" property.', async () => {
+			const responseText = 'responseText';
+
+			vi.spyOn(Fetch.prototype, 'send').mockImplementation(async function () {
+				return <Response>{
+					headers: <Headers>new Headers(),
+					body: new ReadableStream({
+						start(controller) {
+							controller.enqueue(responseText);
+							controller.close();
+						}
+					})
+				};
+			});
+
+			let isTimeoutTriggered = false;
+
+			request.open('GET', REQUEST_URL, true);
+			request.timeout = 500;
+			request.addEventListener('timeout', () => {
+				isTimeoutTriggered = true;
+			});
+			request.send();
+
+			await window.happyDOM?.waitUntilComplete();
+
+			expect(isTimeoutTriggered).toBe(false);
+			expect(request.readyState).toBe(XMLHttpRequestReadyStateEnum.done);
+			expect(request.responseText).toBe(responseText);
 		});
 	});
 


### PR DESCRIPTION
Fixes #2293

**What it does**

- Adds the `timeout` property to `XMLHttpRequest` (defaults to `0`, which means no timeout).
- When a request takes longer than `timeout` milliseconds, it is terminated and a `timeout` event is dispatched (`readystatechange`, then `timeout`, then `loadend`), with `readyState` set to `DONE` and `status` at `0`. The `ontimeout` property already existed and now works.
- Setting `timeout` on a synchronous request throws an `InvalidAccessError`, and `open()` with `async` set to `false` throws when a timeout is set, as defined in the specification.
- The timer is cleared when the request completes, fails, or is aborted, so a completed request never fires a late `timeout` event.

**What it doesn't do**

The specification also dispatches a `timeout` event on `xhr.upload` when the request body hasn't finished uploading. Happy DOM currently doesn't dispatch any upload events (`XMLHttpRequestUpload` is an empty stub) and doesn't track upload progress, so that part is left out rather than approximated.

**Tests**

New tests cover the default value, the two synchronous-request guards, a request that times out (event order, readyState, status, and that no `abort`/`error` events fire), and a request that completes in time (no `timeout` event fires). Behavior was verified against Chrome.

Claude Code assisted with this pull request. All code has been reviewed and tested by me.
