### PR TITLE
fix: [#2222] Calculates the size in getBoundingClientRect() based on the computed style

### DIFF
--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -959,11 +959,36 @@ export default class Element
 	/**
 	 * Returns the size of an element and its position relative to the viewport.
 	 *
+	 * Happy DOM doesn't have a layout engine, so the position is always 0 and the size is based on the computed style of the element. Sizes that depend on the layout of other elements (such as percentages, "auto" or "fit-content") can't be calculated and are treated as 0.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
 	 * @returns DOM rect.
 	 */
 	public getBoundingClientRect(): DOMRect {
-		// TODO: Not full implementation
-		return new DOMRect();
+		const computedStyle = this[PropertySymbol.window].getComputedStyle(this);
+
+		if (!this[PropertySymbol.isConnected] || computedStyle.display === 'none') {
+			return new DOMRect();
+		}
+
+		let width = this.#getComputedPixelValue(computedStyle.width);
+		let height = this.#getComputedPixelValue(computedStyle.height);
+
+		// The bounding client rect is the size of the border box. When box-sizing is "content-box" (the default), padding and border are not part of "width" and "height" and need to be added.
+		if (computedStyle.boxSizing !== 'border-box') {
+			width +=
+				this.#getComputedPixelValue(computedStyle.paddingLeft) +
+				this.#getComputedPixelValue(computedStyle.paddingRight) +
+				this.#getComputedPixelValue(computedStyle.borderLeftWidth) +
+				this.#getComputedPixelValue(computedStyle.borderRightWidth);
+			height +=
+				this.#getComputedPixelValue(computedStyle.paddingTop) +
+				this.#getComputedPixelValue(computedStyle.paddingBottom) +
+				this.#getComputedPixelValue(computedStyle.borderTopWidth) +
+				this.#getComputedPixelValue(computedStyle.borderBottomWidth);
+		}
+
+		return new DOMRect(0, 0, width, height);
 	}
 
 	/**
@@ -1644,6 +1669,16 @@ export default class Element
 		this[PropertySymbol.attributes][PropertySymbol.itemsByNamespaceURI].clear();
 		this[PropertySymbol.attributes][PropertySymbol.itemsByName].clear();
 		this[PropertySymbol.attributes][PropertySymbol.items].clear();
+	}
+
+	/**
+	 * Returns a computed style value in pixels. Values that haven't been resolved to pixels (such as percentages) can't be calculated without a layout engine and are treated as 0.
+	 *
+	 * @param value Computed style value.
+	 * @returns Value in pixels.
+	 */
+	#getComputedPixelValue(value: string): number {
+		return value.endsWith('px') ? parseFloat(value) || 0 : 0;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/element/Element.test.ts
+++ b/packages/happy-dom/test/nodes/element/Element.test.ts
@@ -2174,6 +2174,81 @@ describe('Element', () => {
 			const domRect = element.getBoundingClientRect();
 			expect(domRect instanceof DOMRect).toBe(true);
 		});
+
+		it('Returns the width and height defined in a stylesheet.', () => {
+			document.body.innerHTML =
+				'<style>.test-div { width: 100px; height: 80px; }</style><div class="test-div">test</div>';
+			const domRect = document.body.querySelector('.test-div')!.getBoundingClientRect();
+			expect(domRect.x).toBe(0);
+			expect(domRect.y).toBe(0);
+			expect(domRect.width).toBe(100);
+			expect(domRect.height).toBe(80);
+		});
+
+		it('Returns the width and height defined in the style attribute.', () => {
+			document.body.innerHTML = '<div style="width: 100px; height: 80px;">test</div>';
+			const domRect = document.body.querySelector('div')!.getBoundingClientRect();
+			expect(domRect.width).toBe(100);
+			expect(domRect.height).toBe(80);
+		});
+
+		it('Converts font relative units to pixels.', () => {
+			document.body.innerHTML = '<div style="width: 10rem; height: 5em;">test</div>';
+			const domRect = document.body.querySelector('div')!.getBoundingClientRect();
+			expect(domRect.width).toBe(160);
+			expect(domRect.height).toBe(80);
+		});
+
+		it('Adds padding and border to the size when box-sizing is "content-box".', () => {
+			document.body.innerHTML =
+				'<div style="width: 70px; height: 60px; padding: 5px 10px; border: 2px solid green;">test</div>';
+			const domRect = document.body.querySelector('div')!.getBoundingClientRect();
+			expect(domRect.width).toBe(94);
+			expect(domRect.height).toBe(74);
+		});
+
+		it('Does not add padding and border to the size when box-sizing is "border-box".', () => {
+			document.body.innerHTML =
+				'<div style="box-sizing: border-box; width: 70px; height: 60px; padding: 5px 10px; border: 2px solid green;">test</div>';
+			const domRect = document.body.querySelector('div')!.getBoundingClientRect();
+			expect(domRect.width).toBe(70);
+			expect(domRect.height).toBe(60);
+		});
+
+		it('Returns a zero rect when the element is not connected to the document.', () => {
+			const div = document.createElement('div');
+			div.style.width = '100px';
+			div.style.height = '80px';
+			const domRect = div.getBoundingClientRect();
+			expect(domRect.width).toBe(0);
+			expect(domRect.height).toBe(0);
+		});
+
+		it('Returns a zero rect when the display is "none".', () => {
+			document.body.innerHTML =
+				'<div style="display: none; width: 100px; height: 80px;">test</div>';
+			const domRect = document.body.querySelector('div')!.getBoundingClientRect();
+			expect(domRect.width).toBe(0);
+			expect(domRect.height).toBe(0);
+		});
+
+		it('Returns 0 for sizes that can\'t be calculated without a layout engine (e.g. percentages or "fit-content").', () => {
+			document.body.innerHTML = '<div style="width: 50%; height: fit-content;">test</div>';
+			const domRect = document.body.querySelector('div')!.getBoundingClientRect();
+			expect(domRect.width).toBe(0);
+			expect(domRect.height).toBe(0);
+		});
+	});
+
+	describe('getClientRects()', () => {
+		it('Returns a DOMRectList containing the bounding client rect.', () => {
+			document.body.innerHTML =
+				'<style>.test-div { width: 100px; height: 80px; }</style><div class="test-div">test</div>';
+			const clientRects = document.body.querySelector('.test-div')!.getClientRects();
+			expect(clientRects.length).toBe(1);
+			expect(clientRects[0].width).toBe(100);
+			expect(clientRects.item(0)!.height).toBe(80);
+		});
 	});
 
 	describe('setPointerCapture()', () => {


### PR DESCRIPTION
Fixes #2222

**What it does**

Implements the size calculation that @capricorn86 suggested in #1416: `getBoundingClientRect()` now returns the width and height from the computed style of the element instead of always returning zeros. `getClientRects()` returns the same rect, as before.

- Works for sizes set through stylesheets, the `style` attribute, and font relative units (`rem`, `em`), since the computed style resolves those to pixels.
- Returns the border box: when `box-sizing` is `content-box`, padding and border widths are added to the size.
- Returns a zero rect for disconnected elements and for `display: none`.

**Limitations (documented in the JSDoc)**

Happy DOM has no layout engine, so values that depend on the layout of other elements (percentages, `auto`, `fit-content`, transforms, grid tracks) can't be calculated and are treated as 0. The position (`x`/`y`) also stays 0.

**Tests**

New tests cover the stylesheet case from the issue, the `style` attribute, unit conversion, both `box-sizing` modes, disconnected elements, `display: none`, and non-resolvable values. Expected values were verified in a real browser.

Claude Code assisted with this pull request. All code has been reviewed and tested by me.
