### PR TITLE
fix: [#2288] Implements the CORS preflight response cache according to the Fetch Standard

### DIFF
--- a/packages/happy-dom/src/fetch/Fetch.ts
+++ b/packages/happy-dom/src/fetch/Fetch.ts
@@ -31,6 +31,7 @@ import { Buffer } from 'buffer';
 import FetchBodyUtility from './utilities/FetchBodyUtility.js';
 import type IFetchInterceptor from './types/IFetchInterceptor.js';
 import VirtualServerUtility from './utilities/VirtualServerUtility.js';
+import type ICacheablePreflightRequest from './cache/preflight/ICacheablePreflightRequest.js';
 import PreloadUtility from './preload/PreloadUtility.js';
 import type IFetchRequestHeaders from './types/IFetchRequestHeaders.js';
 
@@ -448,25 +449,16 @@ export default class Fetch {
 			return true;
 		}
 
-		const cachedPreflightResponse = this.#browserFrame.page.context.preflightResponseCache.get(
-			this.request
-		);
+		const preflightResponseCache = this.#browserFrame.page.context.preflightResponseCache;
+		const cacheableRequest: ICacheablePreflightRequest = {
+			url: this.request.url,
+			method: this.request.method,
+			origin: this.#window.location.origin,
+			credentials: this.request.credentials,
+			headers: this.request.headers
+		};
 
-		if (cachedPreflightResponse) {
-			if (
-				cachedPreflightResponse.allowOrigin !== '*' &&
-				cachedPreflightResponse.allowOrigin !== this.#window.location.origin
-			) {
-				return false;
-			}
-
-			if (
-				cachedPreflightResponse.allowMethods.length !== 0 &&
-				!cachedPreflightResponse.allowMethods.includes(this.request.method)
-			) {
-				return false;
-			}
-
+		if (preflightResponseCache.matches(cacheableRequest)) {
 			return true;
 		}
 
@@ -530,6 +522,12 @@ export default class Fetch {
 		}
 
 		// TODO: Add support for more Access-Control-Allow-* headers.
+
+		preflightResponseCache.add(cacheableRequest, {
+			status: response.status,
+			url: response.url,
+			headers: response.headers
+		});
 
 		return true;
 	}

--- a/packages/happy-dom/src/fetch/SyncFetch.ts
+++ b/packages/happy-dom/src/fetch/SyncFetch.ts
@@ -24,6 +24,7 @@ import FetchCORSUtility from './utilities/FetchCORSUtility.js';
 import Fetch from './Fetch.js';
 import type IFetchInterceptor from './types/IFetchInterceptor.js';
 import VirtualServerUtility from './utilities/VirtualServerUtility.js';
+import type ICacheablePreflightRequest from './cache/preflight/ICacheablePreflightRequest.js';
 import type IFetchRequestHeaders from './types/IFetchRequestHeaders.js';
 
 interface ISyncHTTPResponse {
@@ -380,25 +381,16 @@ export default class SyncFetch {
 			return true;
 		}
 
-		const cachedPreflightResponse = this.#browserFrame.page.context.preflightResponseCache.get(
-			this.request
-		);
+		const preflightResponseCache = this.#browserFrame.page.context.preflightResponseCache;
+		const cacheableRequest: ICacheablePreflightRequest = {
+			url: this.request.url,
+			method: this.request.method,
+			origin: this.#window.location.origin,
+			credentials: this.request.credentials,
+			headers: this.request.headers
+		};
 
-		if (cachedPreflightResponse) {
-			if (
-				cachedPreflightResponse.allowOrigin !== '*' &&
-				cachedPreflightResponse.allowOrigin !== this.#window.location.origin
-			) {
-				return false;
-			}
-
-			if (
-				cachedPreflightResponse.allowMethods.length !== 0 &&
-				!cachedPreflightResponse.allowMethods.includes(this.request.method)
-			) {
-				return false;
-			}
-
+		if (preflightResponseCache.matches(cacheableRequest)) {
 			return true;
 		}
 
@@ -462,6 +454,12 @@ export default class SyncFetch {
 		}
 
 		// TODO: Add support for more Access-Control-Allow-* headers.
+
+		preflightResponseCache.add(cacheableRequest, {
+			status: response.status,
+			url: response.url,
+			headers: response.headers
+		});
 
 		return true;
 	}

--- a/packages/happy-dom/src/fetch/cache/preflight/ICacheablePreflightRequest.ts
+++ b/packages/happy-dom/src/fetch/cache/preflight/ICacheablePreflightRequest.ts
@@ -1,7 +1,10 @@
 import type Headers from '../../Headers.js';
+import type { TRequestCredentials } from '../../types/TRequestCredentials.js';
 
 export default interface ICacheablePreflightRequest {
 	url: string;
 	method: string;
+	origin: string;
+	credentials: TRequestCredentials;
 	headers: Headers;
 }

--- a/packages/happy-dom/src/fetch/cache/preflight/ICachedPreflightEntry.ts
+++ b/packages/happy-dom/src/fetch/cache/preflight/ICachedPreflightEntry.ts
@@ -1,0 +1,13 @@
+/**
+ * A cache entry created from a successful preflight response.
+ *
+ * Each entry holds either an allowed method or an allowed header name. The origin and URL of the entry are used as the key in the cache.
+ *
+ * @see https://fetch.spec.whatwg.org/#concept-cache
+ */
+export default interface ICachedPreflightEntry {
+	expires: number;
+	credentials: boolean;
+	method: string | null;
+	headerName: string | null;
+}

--- a/packages/happy-dom/src/fetch/cache/preflight/ICachedPreflightResponse.ts
+++ b/packages/happy-dom/src/fetch/cache/preflight/ICachedPreflightResponse.ts
@@ -1,5 +1,0 @@
-export default interface ICachedPreflightResponse {
-	allowOrigin: string;
-	allowMethods: string[];
-	expires: number;
-}

--- a/packages/happy-dom/src/fetch/cache/preflight/IPreflightResponseCache.ts
+++ b/packages/happy-dom/src/fetch/cache/preflight/IPreflightResponseCache.ts
@@ -1,30 +1,25 @@
-import type ICachedPreflightResponse from './ICachedPreflightResponse.js';
 import type ICacheablePreflightRequest from './ICacheablePreflightRequest.js';
 import type ICacheablePreflightResponse from './ICacheablePreflightResponse.js';
 
 /**
- * Fetch response cache.
+ * CORS-preflight response cache.
  */
 export default interface IPreflightResponseCache {
 	/**
-	 * Returns cached response.
+	 * Returns whether the cache contains entries that allow the preflight request to be skipped.
 	 *
 	 * @param request Request.
-	 * @returns Cached response.
+	 * @returns "true" if the preflight request can be skipped.
 	 */
-	get(request: ICacheablePreflightRequest): ICachedPreflightResponse | null;
+	matches(request: ICacheablePreflightRequest): boolean;
 
 	/**
-	 * Adds a cached response.
+	 * Adds cache entries based on a successful preflight response.
 	 *
 	 * @param request Request.
-	 * @param response Response.
-	 * @returns Cached response.
+	 * @param response Preflight response.
 	 */
-	add(
-		request: ICacheablePreflightRequest,
-		response: ICacheablePreflightResponse
-	): ICachedPreflightResponse | null;
+	add(request: ICacheablePreflightRequest, response: ICacheablePreflightResponse): void;
 
 	/**
 	 * Clears the cache.

--- a/packages/happy-dom/src/fetch/cache/preflight/PreflightResponseCache.ts
+++ b/packages/happy-dom/src/fetch/cache/preflight/PreflightResponseCache.ts
@@ -1,88 +1,112 @@
 import type IPreflightResponseCache from './IPreflightResponseCache.js';
 import type ICacheablePreflightRequest from './ICacheablePreflightRequest.js';
-import type ICachedPreflightResponse from './ICachedPreflightResponse.js';
 import type ICacheablePreflightResponse from './ICacheablePreflightResponse.js';
+import type ICachedPreflightEntry from './ICachedPreflightEntry.js';
+
+// According to the specification, a max age of 5 seconds should be used when the "Access-Control-Max-Age" header is missing or invalid.
+const DEFAULT_MAX_AGE_IN_SECONDS = 5;
 
 /**
- * Fetch preflight response cache.
+ * CORS-preflight response cache.
  *
- * @see https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+ * @see https://fetch.spec.whatwg.org/#cors-preflight-cache
  */
 export default class PreflightResponseCache implements IPreflightResponseCache {
-	#entries: Map<string, ICachedPreflightResponse> = new Map();
+	#entries: Map<string, ICachedPreflightEntry[]> = new Map();
 
 	/**
-	 * Returns cached response.
+	 * Returns whether the cache contains entries that allow the preflight request to be skipped. This is the case when there is an entry matching the request method and an entry matching each of the request headers.
 	 *
+	 * @see https://fetch.spec.whatwg.org/#cors-preflight-fetch
 	 * @param request Request.
-	 * @returns Cached response.
+	 * @returns "true" if the preflight request can be skipped.
 	 */
-	public get(request: ICacheablePreflightRequest): ICachedPreflightResponse | null {
-		const cachedResponse = this.#entries.get(request.url);
+	public matches(request: ICacheablePreflightRequest): boolean {
+		const entries = this.#getMatchingEntries(request);
 
-		if (cachedResponse) {
-			if (cachedResponse.expires < Date.now()) {
-				this.#entries.delete(request.url);
-				return null;
-			}
-			return cachedResponse;
+		if (!entries.some((entry) => entry.method === request.method || entry.method === '*')) {
+			return false;
 		}
 
-		return null;
+		for (const [name] of request.headers) {
+			const headerName = name.toLowerCase();
+			const hasMatchingEntry = entries.some(
+				(entry) =>
+					entry.headerName === headerName ||
+					// The wildcard doesn't cover the "Authorization" header, which needs to be allowed explicitly.
+					(entry.headerName === '*' && headerName !== 'authorization')
+			);
+			if (!hasMatchingEntry) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
-	 * Adds a cache entity.
+	 * Adds cache entries based on a successful preflight response.
 	 *
 	 * @param request Request.
-	 * @param response Response.
-	 * @returns Cached response.
+	 * @param response Preflight response.
 	 */
-	public add(
-		request: ICacheablePreflightRequest,
-		response: ICacheablePreflightResponse
-	): ICachedPreflightResponse | null {
-		this.#entries.delete(request.url);
-
-		if (request.headers.get('Cache-Control')?.includes('no-cache')) {
-			return null;
-		}
-
+	public add(request: ICacheablePreflightRequest, response: ICacheablePreflightResponse): void {
 		if (response.status < 200 || response.status >= 300) {
-			return null;
+			return;
 		}
 
-		const maxAge = response.headers.get('Access-Control-Max-Age');
-		const allowOrigin = response.headers.get('Access-Control-Allow-Origin');
+		const maxAgeHeader = response.headers.get('Access-Control-Max-Age');
+		const maxAge =
+			maxAgeHeader !== null && !isNaN(parseInt(maxAgeHeader))
+				? parseInt(maxAgeHeader)
+				: DEFAULT_MAX_AGE_IN_SECONDS;
 
-		if (!maxAge || !allowOrigin) {
-			return null;
+		if (maxAge <= 0) {
+			return;
 		}
 
-		const allowMethods: string[] = [];
+		const expires = Date.now() + maxAge * 1000;
+		const credentials = request.credentials === 'include';
 
-		if (response.headers.has('Access-Control-Allow-Methods')) {
-			const allowMethodsHeader = response.headers.get('Access-Control-Allow-Methods');
-			if (allowMethodsHeader !== '*') {
-				for (const method of response.headers.get('Access-Control-Allow-Methods')!.split(',')) {
-					allowMethods.push(method.trim().toUpperCase());
-				}
+		// When the response doesn't specify which methods are allowed, only the method of the request that triggered the preflight is cached.
+		const methods = this.#getHeaderValues(response.headers, 'Access-Control-Allow-Methods')?.map(
+			(method) => (method === '*' ? method : method.toUpperCase())
+		) ?? [request.method];
+		const headerNames =
+			this.#getHeaderValues(response.headers, 'Access-Control-Allow-Headers')?.map((headerName) =>
+				headerName.toLowerCase()
+			) ?? [];
+
+		const matchingEntries = this.#getMatchingEntries(request);
+		const key = this.#getKey(request);
+		let entries = this.#entries.get(key);
+
+		if (!entries) {
+			entries = [];
+			this.#entries.set(key, entries);
+		}
+
+		for (const method of methods) {
+			const matchingEntry = matchingEntries.find(
+				(entry) => entry.method === method || entry.method === '*'
+			);
+			if (matchingEntry) {
+				matchingEntry.expires = expires;
+			} else {
+				entries.push({ expires, credentials, method, headerName: null });
 			}
 		}
 
-		const cachedResponse: ICachedPreflightResponse = {
-			allowOrigin,
-			allowMethods,
-			expires: Date.now() + parseInt(maxAge) * 1000
-		};
-
-		if (isNaN(cachedResponse.expires) || cachedResponse.expires < Date.now()) {
-			return null;
+		for (const headerName of headerNames) {
+			const matchingEntry = matchingEntries.find(
+				(entry) => entry.headerName === headerName || entry.headerName === '*'
+			);
+			if (matchingEntry) {
+				matchingEntry.expires = expires;
+			} else {
+				entries.push({ expires, credentials, method: null, headerName });
+			}
 		}
-
-		this.#entries.set(request.url, cachedResponse);
-
-		return cachedResponse;
 	}
 
 	/**
@@ -90,5 +114,62 @@ export default class PreflightResponseCache implements IPreflightResponseCache {
 	 */
 	public clear(): void {
 		this.#entries.clear();
+	}
+
+	/**
+	 * Returns the entries matching the origin, URL and credentials mode of the request. Expired entries are removed.
+	 *
+	 * @param request Request.
+	 * @returns Entries.
+	 */
+	#getMatchingEntries(request: ICacheablePreflightRequest): ICachedPreflightEntry[] {
+		const key = this.#getKey(request);
+		const entries = this.#entries.get(key);
+
+		if (!entries) {
+			return [];
+		}
+
+		const now = Date.now();
+		const validEntries = entries.filter((entry) => entry.expires > now);
+
+		if (!validEntries.length) {
+			this.#entries.delete(key);
+		} else if (validEntries.length !== entries.length) {
+			this.#entries.set(key, validEntries);
+		}
+
+		// Entries created from a request without credentials don't apply to requests with credentials.
+		return validEntries.filter((entry) => entry.credentials || request.credentials !== 'include');
+	}
+
+	/**
+	 * Returns the cache key for a request.
+	 *
+	 * @param request Request.
+	 * @returns Key.
+	 */
+	#getKey(request: ICacheablePreflightRequest): string {
+		return `${request.origin}\n${request.url}`;
+	}
+
+	/**
+	 * Returns the values of a comma separated header, or null when the header isn't set.
+	 *
+	 * @param headers Headers.
+	 * @param name Header name.
+	 * @returns Header values.
+	 */
+	#getHeaderValues(headers: ICacheablePreflightResponse['headers'], name: string): string[] | null {
+		const value = headers.get(name);
+
+		if (value === null) {
+			return null;
+		}
+
+		return value
+			.split(',')
+			.map((item) => item.trim())
+			.filter((item) => !!item);
 	}
 }

--- a/packages/happy-dom/test/fetch/Fetch.test.ts
+++ b/packages/happy-dom/test/fetch/Fetch.test.ts
@@ -546,6 +546,46 @@ describe('Fetch', () => {
 			]);
 		});
 
+		it('Caches the preflight response so that only one preflight request is sent for multiple cross-origin requests.', async () => {
+			const originURL = 'http://localhost:8080';
+			const window = new Window({ url: originURL });
+			const url = 'http://other.origin.com/some/path';
+
+			const network = mockNetwork('http', {
+				beforeResponse({ request, response }) {
+					response.rawHeaders =
+						request.options.method === 'OPTIONS'
+							? [
+									'Access-Control-Allow-Origin',
+									'*',
+									'Access-Control-Allow-Methods',
+									'POST',
+									'Access-Control-Allow-Headers',
+									'content-type',
+									'Access-Control-Max-Age',
+									'600'
+								]
+							: [];
+				}
+			});
+
+			for (let i = 0; i < 2; i++) {
+				await window.fetch(url, {
+					method: 'POST',
+					body: '{"foo": "bar"}',
+					headers: {
+						'Content-Type': 'application/json'
+					}
+				});
+			}
+
+			expect(network.requestHistory.map((entry) => entry.options.method)).toEqual([
+				'OPTIONS',
+				'POST',
+				'POST'
+			]);
+		});
+
 		it('Allows cross-origin request if "Browser.settings.fetch.disableSameOriginPolicy" is set to "true".', async () => {
 			const originURL = 'http://localhost:8080';
 			const window = new Window({ url: originURL });

--- a/packages/happy-dom/test/fetch/SyncFetch.test.ts
+++ b/packages/happy-dom/test/fetch/SyncFetch.test.ts
@@ -929,6 +929,57 @@ describe('SyncFetch', () => {
 			);
 		});
 
+		it('Caches the preflight response so that only one preflight request is sent for multiple cross-origin requests.', () => {
+			const originURL = 'http://localhost:8080';
+			browserFrame.url = originURL;
+			const url = 'http://other.origin.com/some/path';
+
+			const requestArgs: string[] = [];
+
+			mockModule('child_process', {
+				execFileSync: (_command: string, args: string[]) => {
+					requestArgs.push(args[1]);
+					return JSON.stringify({
+						error: null,
+						incomingMessage: {
+							statusCode: 200,
+							statusMessage: 'OK',
+							rawHeaders: args[1].includes('"method": "OPTIONS"')
+								? [
+										'Access-Control-Allow-Origin',
+										'*',
+										'Access-Control-Allow-Methods',
+										'POST',
+										'Access-Control-Allow-Headers',
+										'content-type',
+										'Access-Control-Max-Age',
+										'600'
+									]
+								: [],
+							data: ''
+						}
+					});
+				}
+			});
+
+			for (let i = 0; i < 2; i++) {
+				new SyncFetch({
+					browserFrame,
+					window,
+					url,
+					init: {
+						method: 'POST',
+						body: '{"foo": "bar"}',
+						headers: {
+							'Content-Type': 'application/json'
+						}
+					}
+				}).send();
+			}
+
+			expect(requestArgs.length, 'preflight + 2 post requests').toBe(3);
+		});
+
 		it('Allows cross-origin request if "Browser.settings.fetch.disableSameOriginPolicy" is set to "true".', async () => {
 			const originURL = 'http://localhost:8080';
 

--- a/packages/happy-dom/test/fetch/cache/preflight/PreflightResponseCache.test.ts
+++ b/packages/happy-dom/test/fetch/cache/preflight/PreflightResponseCache.test.ts
@@ -1,0 +1,260 @@
+import PreflightResponseCache from '../../../../src/fetch/cache/preflight/PreflightResponseCache';
+import type ICacheablePreflightRequest from '../../../../src/fetch/cache/preflight/ICacheablePreflightRequest';
+import type ICacheablePreflightResponse from '../../../../src/fetch/cache/preflight/ICacheablePreflightResponse';
+import Headers from '../../../../src/fetch/Headers';
+import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest';
+
+const ORIGIN = 'http://localhost:8080';
+const URL = 'http://other.origin.com/some/path';
+
+describe('PreflightResponseCache', () => {
+	let preflightResponseCache: PreflightResponseCache;
+	let dateNow: number;
+
+	beforeEach(() => {
+		preflightResponseCache = new PreflightResponseCache();
+		dateNow = Date.now();
+		vi.spyOn(Date, 'now').mockImplementation(() => dateNow);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function getRequest(
+		properties?: Partial<ICacheablePreflightRequest>
+	): ICacheablePreflightRequest {
+		return {
+			url: URL,
+			method: 'POST',
+			origin: ORIGIN,
+			credentials: 'same-origin',
+			headers: new Headers({ 'Content-Type': 'application/json' }),
+			...properties
+		};
+	}
+
+	function getResponse(
+		properties?: Partial<ICacheablePreflightResponse>
+	): ICacheablePreflightResponse {
+		return {
+			status: 200,
+			url: URL,
+			headers: new Headers({
+				'Access-Control-Allow-Origin': '*',
+				'Access-Control-Allow-Methods': 'POST',
+				'Access-Control-Allow-Headers': 'Content-Type',
+				'Access-Control-Max-Age': '600'
+			}),
+			...properties
+		};
+	}
+
+	describe('matches()', () => {
+		it('Returns false when the cache is empty.', () => {
+			expect(preflightResponseCache.matches(getRequest())).toBe(false);
+		});
+
+		it('Returns true for a request matching a cached preflight response.', () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			expect(preflightResponseCache.matches(getRequest())).toBe(true);
+		});
+
+		it('Returns false for a request with a different URL or origin.', () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			expect(
+				preflightResponseCache.matches(getRequest({ url: 'http://other.origin.com/other/path' }))
+			).toBe(false);
+			expect(preflightResponseCache.matches(getRequest({ origin: 'http://localhost:3000' }))).toBe(
+				false
+			);
+		});
+
+		it("Returns false for a request with a method that isn't allowed.", () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			expect(preflightResponseCache.matches(getRequest({ method: 'DELETE' }))).toBe(false);
+		});
+
+		it('Returns true for any method when the allowed methods contain the wildcard "*".', () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': '*',
+						'Access-Control-Allow-Headers': 'Content-Type'
+					})
+				})
+			);
+			expect(preflightResponseCache.matches(getRequest({ method: 'DELETE' }))).toBe(true);
+		});
+
+		it("Caches the request method when the response doesn't specify allowed methods.", () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Headers': 'Content-Type'
+					})
+				})
+			);
+			expect(preflightResponseCache.matches(getRequest())).toBe(true);
+			expect(preflightResponseCache.matches(getRequest({ method: 'DELETE' }))).toBe(false);
+		});
+
+		it("Returns false for a request with a header that isn't allowed.", () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			expect(
+				preflightResponseCache.matches(
+					getRequest({
+						headers: new Headers({ 'Content-Type': 'application/json', 'X-Custom-Header': 'yes' })
+					})
+				)
+			).toBe(false);
+		});
+
+		it('Matches header names case-insensitively.', () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'POST',
+						'Access-Control-Allow-Headers': 'CONTENT-TYPE'
+					})
+				})
+			);
+			expect(preflightResponseCache.matches(getRequest())).toBe(true);
+		});
+
+		it('Matches any header except "Authorization" when the allowed headers contain the wildcard "*".', () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'POST',
+						'Access-Control-Allow-Headers': '*'
+					})
+				})
+			);
+			expect(
+				preflightResponseCache.matches(
+					getRequest({ headers: new Headers({ 'X-Custom-Header': 'yes' }) })
+				)
+			).toBe(true);
+			expect(
+				preflightResponseCache.matches(
+					getRequest({ headers: new Headers({ Authorization: 'Bearer token' }) })
+				)
+			).toBe(false);
+		});
+
+		it('Matches the "Authorization" header when it is explicitly allowed.', () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'POST',
+						'Access-Control-Allow-Headers': 'Authorization'
+					})
+				})
+			);
+			expect(
+				preflightResponseCache.matches(
+					getRequest({ headers: new Headers({ Authorization: 'Bearer token' }) })
+				)
+			).toBe(true);
+		});
+
+		it('Returns false for a request with credentials when the preflight request was sent without credentials.', () => {
+			preflightResponseCache.add(getRequest({ credentials: 'same-origin' }), getResponse());
+			expect(preflightResponseCache.matches(getRequest({ credentials: 'include' }))).toBe(false);
+		});
+
+		it('Returns true for a request without credentials when the preflight request was sent with credentials.', () => {
+			preflightResponseCache.add(getRequest({ credentials: 'include' }), getResponse());
+			expect(preflightResponseCache.matches(getRequest({ credentials: 'same-origin' }))).toBe(true);
+		});
+
+		it('Removes entries when the max age defined in the "Access-Control-Max-Age" header has passed.', () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			dateNow += 599000;
+			expect(preflightResponseCache.matches(getRequest())).toBe(true);
+			dateNow += 2000;
+			expect(preflightResponseCache.matches(getRequest())).toBe(false);
+		});
+
+		it("Uses a default max age of 5 seconds when the response doesn't specify one.", () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'POST',
+						'Access-Control-Allow-Headers': 'Content-Type'
+					})
+				})
+			);
+			dateNow += 4000;
+			expect(preflightResponseCache.matches(getRequest())).toBe(true);
+			dateNow += 2000;
+			expect(preflightResponseCache.matches(getRequest())).toBe(false);
+		});
+	});
+
+	describe('add()', () => {
+		it("Doesn't cache non-successful preflight responses.", () => {
+			preflightResponseCache.add(getRequest(), getResponse({ status: 500 }));
+			expect(preflightResponseCache.matches(getRequest())).toBe(false);
+		});
+
+		it("Doesn't cache the response when the max age is zero or negative.", () => {
+			preflightResponseCache.add(
+				getRequest(),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'POST',
+						'Access-Control-Allow-Headers': 'Content-Type',
+						'Access-Control-Max-Age': '-1'
+					})
+				})
+			);
+			expect(preflightResponseCache.matches(getRequest())).toBe(false);
+		});
+
+		it('Combines entries from multiple preflight responses.', () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			preflightResponseCache.add(
+				getRequest({ method: 'DELETE', headers: new Headers({ 'X-Custom-Header': 'yes' }) }),
+				getResponse({
+					headers: new Headers({
+						'Access-Control-Allow-Origin': '*',
+						'Access-Control-Allow-Methods': 'DELETE',
+						'Access-Control-Allow-Headers': 'X-Custom-Header',
+						'Access-Control-Max-Age': '600'
+					})
+				})
+			);
+			expect(
+				preflightResponseCache.matches(
+					getRequest({
+						method: 'DELETE',
+						headers: new Headers({ 'Content-Type': 'application/json', 'X-Custom-Header': 'yes' })
+					})
+				)
+			).toBe(true);
+		});
+	});
+
+	describe('clear()', () => {
+		it('Clears the cache.', () => {
+			preflightResponseCache.add(getRequest(), getResponse());
+			preflightResponseCache.clear();
+			expect(preflightResponseCache.matches(getRequest())).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #2288

**The problem**

`Fetch` and `SyncFetch` read from `PreflightResponseCache`, but nothing ever wrote to it, so every cross-origin request that needs a preflight sent a new `OPTIONS` request. The cache structure also couldn't represent the entries that the Fetch Standard defines.

**What it does**

Rewrites `PreflightResponseCache` to follow the CORS-preflight cache section of the Fetch Standard (https://fetch.spec.whatwg.org/#cors-preflight-cache) and populates it after each successful preflight:

- Entries are stored per origin and URL, with a credentials flag. Entries created from a request without credentials don't apply to requests with credentials.
- Allowed methods and allowed header names are stored as separate entries, each with their own expiry, so entries from multiple preflight responses combine like in the specification.
- A preflight is skipped only when the cache has a matching entry for the request method and for every request header.
- Wildcard handling: `*` matches any method, and any header name except `Authorization`, which has to be allowed explicitly.
- `Access-Control-Max-Age` controls the expiry, with the specification's default of 5 seconds when the header is missing. Expired entries are removed, and `clear()` still allows early eviction.
- When the response has no `Access-Control-Allow-Methods` header, the request's own method is cached, as in the specification.

The cache instance already lives on the browser context, so each browser context acts as the network partition.

The existing validation of the fresh preflight response is unchanged (including the existing TODO about validating more `Access-Control-Allow-*` headers); this pull request only makes the cache work.

**Tests**

- New unit tests for the cache: matching by URL/origin/method/headers, wildcards, the `Authorization` exception, credentials modes, expiry, the 5 second default, non-successful responses, and `clear()`.
- New integration tests for both `Fetch` and `SyncFetch` asserting that two identical cross-origin `POST` requests result in exactly one `OPTIONS` request.

Claude Code assisted with this pull request. All code has been reviewed and tested by me.
