### PR TITLE
fix: [#2184] Excludes all disabled form controls from FormData

### DIFF
--- a/packages/happy-dom/src/form-data/FormData.ts
+++ b/packages/happy-dom/src/form-data/FormData.ts
@@ -58,13 +58,11 @@ export default class FormData implements Iterable<[string, string | File]> {
 		for (const item of items) {
 			const name = item.name;
 
-			if (name) {
+			// Disabled form controls are never part of the entry list, no matter their type.
+			// @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+			if (name && !(<HTMLInputElement>item).disabled) {
 				switch (item[PropertySymbol.tagName]) {
 					case 'INPUT':
-						if ((<HTMLInputElement>item).disabled) {
-							break;
-						}
-
 						switch ((<HTMLInputElement>item).type) {
 							case 'file':
 								if ((<HTMLInputElement>item)[PropertySymbol.files].length === 0) {

--- a/packages/happy-dom/test/form-data/FormData.test.ts
+++ b/packages/happy-dom/test/form-data/FormData.test.ts
@@ -307,6 +307,78 @@ describe('FormData', () => {
 			expect(formData.getAll('radioInput')).toEqual([]);
 			expect(formData.getAll('checkboxInput')).toEqual([]);
 		});
+
+		it('Supports disabled select and textarea elements.', () => {
+			const form = document.createElement('form');
+
+			const disabledSelect = document.createElement('select');
+			const disabledSelectOption = document.createElement('option');
+			const disabledTextarea = document.createElement('textarea');
+			const select = document.createElement('select');
+			const selectOption = document.createElement('option');
+			const textarea = document.createElement('textarea');
+
+			disabledSelect.name = 'disabledSelect';
+			disabledSelect.disabled = true;
+			disabledSelectOption.value = 'disabled select value';
+			disabledSelect.appendChild(disabledSelectOption);
+
+			disabledTextarea.name = 'disabledTextarea';
+			disabledTextarea.value = 'disabled textarea value';
+			disabledTextarea.disabled = true;
+
+			select.name = 'select';
+			selectOption.value = 'select value';
+			select.appendChild(selectOption);
+
+			textarea.name = 'textarea';
+			textarea.value = 'textarea value';
+
+			form.appendChild(disabledSelect);
+			form.appendChild(disabledTextarea);
+			form.appendChild(select);
+			form.appendChild(textarea);
+
+			const formData = new window.FormData(form);
+
+			expect(formData.get('disabledSelect')).toBe(null);
+			expect(formData.get('disabledTextarea')).toBe(null);
+			expect(formData.get('select')).toBe('select value');
+			expect(formData.get('textarea')).toBe('textarea value');
+			expect([...formData.keys()]).toEqual(['select', 'textarea']);
+		});
+
+		it('Supports disabled submitters.', () => {
+			const form = document.createElement('form');
+			const textInput = document.createElement('input');
+			const button = document.createElement('button');
+			const inputButton = document.createElement('input');
+
+			textInput.type = 'text';
+			textInput.name = 'textInput';
+			textInput.value = 'text value';
+
+			button.type = 'submit';
+			button.name = 'button';
+			button.value = 'button value';
+			button.disabled = true;
+
+			inputButton.type = 'submit';
+			inputButton.name = 'inputButton';
+			inputButton.value = 'input button value';
+			inputButton.disabled = true;
+
+			form.appendChild(textInput);
+			form.appendChild(button);
+			form.appendChild(inputButton);
+
+			expect([...new window.FormData(form, button).entries()]).toEqual([
+				['textInput', 'text value']
+			]);
+			expect([...new window.FormData(form, inputButton).entries()]).toEqual([
+				['textInput', 'text value']
+			]);
+		});
 	});
 
 	describe('forEach()', () => {


### PR DESCRIPTION
### Description

Resolves #2184

The `FormData` constructor only skipped disabled `<input>` elements. Disabled `<select>` and `<textarea>` controls were still added to the entry list, so the behavior was inconsistent between control types.

[Constructing the entry list](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set) step 5.1 skips *every* disabled submittable element, not only inputs. This PR moves the `disabled` check above the tag name `switch`, so it applies to `<select>`, `<textarea>` and `<button>` too:

```diff
-			if (name) {
+			// Disabled form controls are never part of the entry list, no matter their type.
+			// @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set
+			if (name && !(<HTMLInputElement>item).disabled) {
 				switch (item[PropertySymbol.tagName]) {
 					case 'INPUT':
-						if ((<HTMLInputElement>item).disabled) {
-							break;
-						}
-
 						switch ((<HTMLInputElement>item).type) {
```

The example from the issue now matches Chrome, Firefox, Safari and jsdom:

```js
const form = document.createElement('form');
form.innerHTML = `
  <select name="sel" disabled><option value="x" selected>x</option></select>
  <textarea name="ta" disabled>hello</textarea>
  <input name="in" type="text" value="i" disabled>
`;
document.body.appendChild(form);

[...new window.FormData(form).keys()];
// Before: [ 'sel', 'ta' ]
// After:  [ ]
```

Hoisting the check also covers a disabled submitter, which browsers exclude as well:

```js
// <input name="t" value="v">
// <button type="submit" name="btn" value="bval" disabled>go</button>
[...new FormData(form, button).entries()];
// Chrome and happy-dom after this PR: [ [ 't', 'v' ] ]
```

Out of scope: `item.disabled` reads only the element's own attribute, so a control inside a `<fieldset disabled>` is still included. That needs the inherited ["actually disabled"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled) state and is a separate change.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

Two tests were added to `test/form-data/FormData.test.ts`, next to the existing *"Supports disabled input elements."* test. Both fail before the fix and pass after it:

- *"Supports disabled select and textarea elements."* — a disabled `<select>` and `<textarea>` are excluded, while the enabled ones are kept.
- *"Supports disabled submitters."* — a disabled `<button type="submit">` and `<input type="submit">` contribute no entry when passed as the submitter.

Both expectations were verified in the Chrome console before writing them. `packages/happy-dom` passes in full (7630 tests). Two pre-existing failures on `master` are unrelated to this change and reproduce without it: `@happy-dom/server-renderer` *"Handles result with page errors"*, and the `@happy-dom/node-canvas-adapter` image snapshots.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

Claude Code was used to write the fix and the tests. I reviewed the change, confirmed the expected behavior in Chrome, and ran the test suite locally.
