### PR TITLE
fix: [#2185] Queues the "selectionchange" event as a task instead of dispatching it synchronously

### DIFF
--- a/packages/happy-dom/src/selection/Selection.ts
+++ b/packages/happy-dom/src/selection/Selection.ts
@@ -22,6 +22,7 @@ export default class Selection {
 	readonly #ownerDocument: Document;
 	#range: Range | null = null;
 	#direction: SelectionDirectionEnum = SelectionDirectionEnum.directionless;
+	#hasScheduledSelectionChangeEvent = false;
 
 	/**
 	 * Constructor.
@@ -549,8 +550,28 @@ export default class Selection {
 			range === null ? SelectionDirectionEnum.directionless : SelectionDirectionEnum.forwards;
 
 		if (oldRange !== this.#range) {
-			// https://w3c.github.io/selection-api/#selectionchange-event
-			this.#ownerDocument.dispatchEvent(new Event('selectionchange'));
+			this.#scheduleSelectionChangeEvent();
 		}
+	}
+
+	/**
+	 * Queues a task that dispatches a "selectionchange" event on the owner document.
+	 *
+	 * The task is only queued when there is no task queued already, so that multiple selection changes made within the same task are coalesced into a single event.
+	 *
+	 * @see https://w3c.github.io/selection-api/#scheduling-selectionchange-event
+	 */
+	#scheduleSelectionChangeEvent(): void {
+		if (this.#hasScheduledSelectionChangeEvent) {
+			return;
+		}
+
+		this.#hasScheduledSelectionChangeEvent = true;
+
+		this.#ownerDocument[PropertySymbol.window].setTimeout(() => {
+			// https://w3c.github.io/selection-api/#firing-selectionchange-event
+			this.#hasScheduledSelectionChangeEvent = false;
+			this.#ownerDocument.dispatchEvent(new Event('selectionchange'));
+		});
 	}
 }

--- a/packages/happy-dom/test/selection/Selection.test.ts
+++ b/packages/happy-dom/test/selection/Selection.test.ts
@@ -270,11 +270,17 @@ describe('Selection', () => {
 			expect(selection.rangeCount).toBe(0);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			let triggeredEvent: Event | null = null;
 			document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 			const range = document.createRange();
 			selection.addRange(range);
+
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -328,12 +334,21 @@ describe('Selection', () => {
 			);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			let triggeredEvent: Event | null = null;
 			const range = document.createRange();
 			selection.addRange(range);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
 			document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 			selection.removeRange(range);
+
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -348,12 +363,21 @@ describe('Selection', () => {
 				expect(selection.rangeCount).toBe(0);
 			});
 
-			it('Triggers a "selectionchange" event.', () => {
+			it('Triggers a "selectionchange" event.', async () => {
 				let triggeredEvent: Event | null = null;
 				const range = document.createRange();
 				selection.addRange(range);
+
+				await new Promise((resolve) => setTimeout(resolve, 1));
+
 				document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 				selection[method]();
+
+				expect(triggeredEvent).toBe(null);
+
+				await new Promise((resolve) => setTimeout(resolve, 1));
+
+				expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 				expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 				expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 			});
@@ -405,17 +429,24 @@ describe('Selection', () => {
 				expect(newRange.endOffset).toBe(2);
 			});
 
-			it('Triggers a "selectionchange" event.', () => {
+			it('Triggers a "selectionchange" event.', async () => {
 				const range = document.createRange();
 				const text = document.createTextNode('Text');
 				let triggeredEvent: Event | null = null;
 
 				selection.addRange(range);
 
+				await new Promise((resolve) => setTimeout(resolve, 1));
+
 				document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 
 				selection[method](text, 2);
 
+				expect(triggeredEvent).toBe(null);
+
+				await new Promise((resolve) => setTimeout(resolve, 1));
+
+				expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 				expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 				expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 			});
@@ -468,16 +499,23 @@ describe('Selection', () => {
 			);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			const range = document.createRange();
 			let triggeredEvent: Event | null = null;
 
 			selection.addRange(range);
 
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
 			document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 
 			selection.collapseToEnd();
 
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -516,16 +554,23 @@ describe('Selection', () => {
 			);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			const range = document.createRange();
 			let triggeredEvent: Event | null = null;
 
 			selection.addRange(range);
 
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
 			document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 
 			selection.collapseToStart();
 
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -649,7 +694,7 @@ describe('Selection', () => {
 			);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			const range = document.createRange();
 			const start = document.createTextNode('start');
 			const end = document.createTextNode('end');
@@ -665,10 +710,17 @@ describe('Selection', () => {
 
 			selection.addRange(range);
 
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
 			document.addEventListener('selectionchange', (event) => (triggeredEvent = event));
 
 			selection.extend(after, 3);
 
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -732,7 +784,7 @@ describe('Selection', () => {
 			);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			const container = document.createElement('div');
 			const child = document.createTextNode('child');
 			let triggeredEvent: Event | null = null;
@@ -743,6 +795,11 @@ describe('Selection', () => {
 
 			selection.selectAllChildren(container);
 
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -824,7 +881,7 @@ describe('Selection', () => {
 			);
 		});
 
-		it('Triggers a "selectionchange" event.', () => {
+		it('Triggers a "selectionchange" event.', async () => {
 			const start = document.createTextNode('start');
 			const end = document.createTextNode('end');
 			let triggeredEvent: Event | null = null;
@@ -836,6 +893,11 @@ describe('Selection', () => {
 
 			selection.setBaseAndExtent(start, 1, end, 2);
 
+			expect(triggeredEvent).toBe(null);
+
+			await new Promise((resolve) => setTimeout(resolve, 1));
+
+			expect((<Event>(<unknown>triggeredEvent)).type).toBe('selectionchange');
 			expect((<Event>(<unknown>triggeredEvent)).bubbles).toBe(false);
 			expect((<Event>(<unknown>triggeredEvent)).cancelable).toBe(false);
 		});
@@ -864,6 +926,133 @@ describe('Selection', () => {
 			selection.addRange(range);
 
 			expect(selection.toString()).toBe('tarten');
+		});
+	});
+
+	describe('selectionchange event', () => {
+		it('Queues the event as a task instead of dispatching it synchronously.', async () => {
+			const isDispatchedAfterCurrentTask: boolean[] = [];
+			let isCurrentTaskDone = false;
+
+			document.addEventListener('selectionchange', () =>
+				isDispatchedAfterCurrentTask.push(isCurrentTaskDone)
+			);
+
+			selection.addRange(document.createRange());
+
+			isCurrentTaskDone = true;
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(isDispatchedAfterCurrentTask).toEqual([true]);
+		});
+
+		it('Dispatches the event at the document.', async () => {
+			let target: unknown = null;
+
+			document.addEventListener('selectionchange', (event) => (target = event.target));
+
+			selection.addRange(document.createRange());
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(target).toBe(document);
+		});
+
+		it('Coalesces multiple selection changes made within the same task into a single event.', async () => {
+			const range = document.createRange();
+			let eventCount = 0;
+
+			document.addEventListener('selectionchange', () => eventCount++);
+
+			selection.addRange(range);
+			selection.removeAllRanges();
+			selection.addRange(range);
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(1);
+		});
+
+		it('Dispatches one event for each task that changes the selection.', async () => {
+			const range = document.createRange();
+			let eventCount = 0;
+
+			document.addEventListener('selectionchange', () => eventCount++);
+
+			selection.addRange(range);
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(1);
+
+			selection.removeAllRanges();
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(2);
+		});
+
+		it('Does not dispatch the event when the selection is unchanged.', async () => {
+			const range = document.createRange();
+			let eventCount = 0;
+
+			document.addEventListener('selectionchange', () => eventCount++);
+
+			// There is no range to remove.
+			selection.removeAllRanges();
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(0);
+
+			selection.addRange(range);
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(1);
+
+			// The range is already added.
+			selection.addRange(range);
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(1);
+		});
+
+		it('Queues a new event when a listener changes the selection.', async () => {
+			const range = document.createRange();
+			let eventCount = 0;
+
+			document.addEventListener('selectionchange', () => {
+				eventCount++;
+				if (eventCount < 3) {
+					if (selection.rangeCount) {
+						selection.removeAllRanges();
+					} else {
+						selection.addRange(range);
+					}
+				}
+			});
+
+			selection.addRange(range);
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(3);
+		});
+
+		it('Does not dispatch the event after the window has been closed.', async () => {
+			let eventCount = 0;
+
+			document.addEventListener('selectionchange', () => eventCount++);
+
+			selection.addRange(document.createRange());
+
+			await window.happyDOM.close();
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(eventCount).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
### Description

Resolves #2185

`Selection` dispatched `selectionchange` **synchronously**, in the same call stack as the method that changed the selection (`addRange()`, `removeRange()`, `removeAllRanges()`, `collapse()`, `extend()`, …), and once per change.

The Selection API requires the event to be **queued as a task** and **coalesced**, so that several selection changes made within the same task result in a single event:

- [§Scheduling selectionchange event](https://w3c.github.io/selection-api/#scheduling-selectionchange-event) — if the target already has a scheduled event, abort; otherwise set the flag and queue a task.
- [§Firing selectionchange event](https://w3c.github.io/selection-api/#firing-selectionchange-event) — reset the flag, then fire the event.

`Selection.#associateRange()` now sets a "has scheduled selectionchange event" flag and queues the dispatch with `window.setTimeout()`, which is the deferral convention already used in the library (e.g. smooth scroll in `Element.ts`) and keeps the task tracked by the async task manager. The flag is reset when the task runs, so a listener that changes the selection during dispatch schedules a new event, as it does in browsers.

Before this change, the reproduction from #2185 printed `synchronously: true, after task: false`. It now prints `synchronously: false, after task: true`, matching Chrome, Firefox, Safari and jsdom.

One behavior note: the queued task is a normal window timer, so it is subject to the opt-in `settings.timer.preventTimerLoops` option. With that option enabled, a selection change made repeatedly from the same call site can have its event dropped, the same way the option already drops other deferred work such as smooth scroll. It defaults to `false`.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

The expected behavior was verified in the Chrome console before writing the tests:

| Behavior | Chrome | happy-dom (before) | happy-dom (after) |
| --- | --- | --- | --- |
| Dispatched synchronously | no | **yes** | no |
| Dispatched after the current task | yes | **no** | yes |
| Three changes in one task | 1 event | **3 events** | 1 event |
| One change in each of two tasks | 2 events | 2 events | 2 events |
| Change that does not change the selection | 0 events | 0 events | 0 events |
| Listener changes the selection | schedules a new event | dispatches synchronously, re-entrant | schedules a new event |
| `bubbles` / `cancelable` / `target` | `false` / `false` / `document` | same | same |

The nine existing `Triggers a "selectionchange" event.` tests now assert that the event is not dispatched synchronously and then await the task. A new `selectionchange event` block covers scheduling, the event target, coalescing, one event per task, no event when the selection is unchanged, re-entrancy from a listener, and that no event is dispatched after the window has been closed. Fourteen of these tests fail without the source change.

`npm test` passes. `@happy-dom/server-renderer` has one unrelated failure (`render() > Handles result with page errors`) that also fails on `master` without this change.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

Claude was used to write the fix and the tests. I reviewed the change, confirmed the expected behavior in Chrome, and ran the test suite locally.
