### PR TITLE
fix: [#2190] Makes a disabled button or input dispatch a click event sent using dispatchEvent()

### DIFF
--- a/packages/happy-dom/src/nodes/html-button-element/HTMLButtonElement.ts
+++ b/packages/happy-dom/src/nodes/html-button-element/HTMLButtonElement.ts
@@ -355,22 +355,16 @@ export default class HTMLButtonElement extends HTMLElement {
 	 * @override
 	 */
 	public override dispatchEvent(event: Event): boolean {
-		if (
-			event.type === 'click' &&
-			event instanceof MouseEvent &&
-			event.eventPhase === EventPhaseEnum.none &&
-			this.disabled
-		) {
-			return false;
-		}
-
 		const returnValue = super.dispatchEvent(event);
 
+		// A disabled button has no activation behavior, but its event listeners are still called.
+		// @see https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element
 		if (
 			!event[PropertySymbol.defaultPrevented] &&
 			event.type === 'click' &&
 			event.eventPhase === EventPhaseEnum.none &&
-			event instanceof MouseEvent
+			event instanceof MouseEvent &&
+			!this.disabled
 		) {
 			const type = this.type;
 			if (type === 'submit' || type === 'reset') {

--- a/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
+++ b/packages/happy-dom/src/nodes/html-element/HTMLElement.ts
@@ -10,6 +10,20 @@ import type Attr from '../attr/Attr.js';
 import ElementEventAttributeUtility from '../element/ElementEventAttributeUtility.js';
 
 /**
+ * Tag names of form controls that don't dispatch a click event when the click() method is called on a disabled element.
+ *
+ * Note that "fieldset" is not part of the list, as browsers dispatch the event for a disabled fieldset element.
+ */
+const DISABLEABLE_FORM_CONTROLS = new Set([
+	'BUTTON',
+	'INPUT',
+	'OPTGROUP',
+	'OPTION',
+	'SELECT',
+	'TEXTAREA'
+]);
+
+/**
  * HTML Element.
  *
  * Reference:
@@ -945,8 +959,20 @@ export default class HTMLElement extends Element {
 
 	/**
 	 * Triggers a click event.
+	 *
+	 * A disabled form control doesn't dispatch a click event when this method is called.
+	 * Note that a click event dispatched using dispatchEvent() is not affected by this, as it is only the synthetic click that is suppressed.
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/interaction.html#dom-click
 	 */
 	public click(): void {
+		if (
+			DISABLEABLE_FORM_CONTROLS.has(<string>this[PropertySymbol.tagName]) &&
+			(<HTMLElement & { disabled?: boolean }>this).disabled
+		) {
+			return;
+		}
+
 		this.dispatchEvent(
 			new PointerEvent('click', {
 				bubbles: true,

--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
@@ -1438,11 +1438,6 @@ export default class HTMLInputElement extends HTMLElement {
 			return super.dispatchEvent(event);
 		}
 
-		// Do nothing if the input element is disabled and the event is a click event.
-		if (this.disabled) {
-			return false;
-		}
-
 		let previousCheckedValue: boolean | null = null;
 		let previousIndeterminateValue: boolean = this[PropertySymbol.indeterminate];
 
@@ -1485,7 +1480,9 @@ export default class HTMLInputElement extends HTMLElement {
 			} else if (type === 'radio' && !previousCheckedValue && this[PropertySymbol.isConnected]) {
 				this.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
 				this.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
-			} else if (type === 'submit' || type === 'reset') {
+			} else if ((type === 'submit' || type === 'reset') && !this.disabled) {
+				// A disabled submit or reset button has no activation behavior, but its event listeners are still called.
+				// @see https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit)
 				const form = this.form;
 				if (form) {
 					if (type === 'submit' && this[PropertySymbol.isConnected]) {

--- a/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElement.ts
+++ b/packages/happy-dom/src/nodes/html-label-element/HTMLLabelElement.ts
@@ -117,8 +117,10 @@ export default class HTMLLabelElement extends HTMLElement {
 				event.eventPhase === EventPhaseEnum.bubbling) &&
 			event instanceof MouseEvent
 		) {
-			const control = this.control;
-			if (control && event.target !== control) {
+			// A disabled form control is not activated when its label is clicked.
+			// @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
+			const control = <HTMLInputElement | null>this.control;
+			if (control && event.target !== control && !control.disabled) {
 				control.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 			}
 		}

--- a/packages/happy-dom/test/nodes/html-button-element/HTMLButtonElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-button-element/HTMLButtonElement.test.ts
@@ -449,6 +449,66 @@ describe('HTMLButtonElement', () => {
 	}
 
 	describe('dispatchEvent()', () => {
+		it('Dispatches a "click" event to its listeners even if the button is disabled.', () => {
+			const button = <HTMLButtonElement>document.createElement('button');
+
+			let clickCount = 0;
+
+			button.disabled = true;
+			button.addEventListener('click', () => clickCount++);
+
+			document.body.appendChild(button);
+
+			const returnValue = button.dispatchEvent(
+				new MouseEvent('click', { bubbles: true, cancelable: true })
+			);
+
+			expect(clickCount).toBe(1);
+			expect(returnValue).toBe(true);
+		});
+
+		it('Doesn\'t submit form if type is "submit" and the button is disabled.', () => {
+			const form = <HTMLFormElement>document.createElement('form');
+			const button = <HTMLButtonElement>document.createElement('button');
+
+			let submitTriggeredCount = 0;
+			let clickCount = 0;
+
+			button.disabled = true;
+			button.addEventListener('click', () => clickCount++);
+
+			form.appendChild(button);
+
+			document.body.appendChild(form);
+
+			form.addEventListener('submit', () => submitTriggeredCount++);
+
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			expect(clickCount).toBe(1);
+			expect(submitTriggeredCount).toBe(0);
+		});
+
+		it('Doesn\'t reset form if type is "reset" and the button is disabled.', () => {
+			const form = <HTMLFormElement>document.createElement('form');
+			const button = <HTMLButtonElement>document.createElement('button');
+
+			let resetTriggeredCount = 0;
+
+			button.type = 'reset';
+			button.disabled = true;
+
+			form.appendChild(button);
+
+			document.body.appendChild(form);
+
+			form.addEventListener('reset', () => resetTriggeredCount++);
+
+			button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			expect(resetTriggeredCount).toBe(0);
+		});
+
 		it('Submits form if type is "submit" and is a "click" event.', () => {
 			const form = <HTMLFormElement>document.createElement('form');
 			const button = <HTMLButtonElement>document.createElement('button');
@@ -535,6 +595,30 @@ describe('HTMLButtonElement', () => {
 			button.click();
 
 			expect(resetTriggeredCount).toBe(1);
+		});
+	});
+
+	describe('click()', () => {
+		it('Doesn\'t dispatch a "click" event if the button is disabled.', () => {
+			const form = <HTMLFormElement>document.createElement('form');
+			const button = <HTMLButtonElement>document.createElement('button');
+
+			let submitTriggeredCount = 0;
+			let clickCount = 0;
+
+			button.disabled = true;
+			button.addEventListener('click', () => clickCount++);
+
+			form.appendChild(button);
+
+			document.body.appendChild(form);
+
+			form.addEventListener('submit', () => submitTriggeredCount++);
+
+			button.click();
+
+			expect(clickCount).toBe(0);
+			expect(submitTriggeredCount).toBe(0);
 		});
 	});
 });

--- a/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-element/HTMLElement.test.ts
@@ -659,6 +659,49 @@ describe('HTMLElement', () => {
 			expect(target).toBe(element);
 			expect(currentTarget).toBe(element);
 		});
+
+		it('Doesn\'t dispatch a "click" event on a disabled form control.', () => {
+			for (const tagName of ['button', 'input', 'optgroup', 'option', 'select', 'textarea']) {
+				const control = <HTMLElement & { disabled: boolean }>document.createElement(tagName);
+
+				let clickCount = 0;
+
+				control.disabled = true;
+				control.addEventListener('click', () => clickCount++);
+
+				document.body.appendChild(control);
+
+				control.click();
+
+				expect(clickCount).toBe(0);
+
+				control.disabled = false;
+
+				control.click();
+
+				expect(clickCount).toBe(1);
+			}
+		});
+
+		it('Dispatches a "click" event on a disabled element that is not a form control.', () => {
+			// Browsers dispatch the event for a disabled "fieldset" and "style" element.
+			for (const tagName of ['fieldset', 'style']) {
+				const disabledElement = <HTMLElement & { disabled: boolean }>(
+					document.createElement(tagName)
+				);
+
+				let clickCount = 0;
+
+				disabledElement.disabled = true;
+				disabledElement.addEventListener('click', () => clickCount++);
+
+				document.body.appendChild(disabledElement);
+
+				disabledElement.click();
+
+				expect(clickCount).toBe(1);
+			}
+		});
 	});
 
 	describe('blur()', () => {

--- a/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
@@ -1602,6 +1602,107 @@ describe('HTMLInputElement', () => {
 	});
 
 	describe('dispatchEvent()', () => {
+		it('Dispatches a "click" event to its listeners and runs the activation behavior even if the input is disabled.', () => {
+			const input = <HTMLInputElement>document.createElement('input');
+
+			let clickCount = 0;
+			let inputCount = 0;
+			let changeCount = 0;
+
+			input.type = 'checkbox';
+			input.disabled = true;
+
+			input.addEventListener('click', () => clickCount++);
+			input.addEventListener('input', () => inputCount++);
+			input.addEventListener('change', () => changeCount++);
+
+			document.body.appendChild(input);
+
+			const returnValue = input.dispatchEvent(
+				new MouseEvent('click', { bubbles: true, cancelable: true })
+			);
+
+			expect(clickCount).toBe(1);
+			expect(inputCount).toBe(1);
+			expect(changeCount).toBe(1);
+			expect(returnValue).toBe(true);
+			expect(input.checked).toBe(true);
+		});
+
+		it('Restores "checked" if preventDefault() is called in a "click" listener of a disabled input.', () => {
+			const input = <HTMLInputElement>document.createElement('input');
+
+			input.type = 'checkbox';
+			input.disabled = true;
+
+			input.addEventListener('click', (event) => event.preventDefault());
+
+			document.body.appendChild(input);
+
+			const returnValue = input.dispatchEvent(
+				new MouseEvent('click', { bubbles: true, cancelable: true })
+			);
+
+			expect(returnValue).toBe(false);
+			expect(input.checked).toBe(false);
+		});
+
+		it('Sets "checked" to "true" if type is "radio" and the input is disabled.', () => {
+			const input = <HTMLInputElement>document.createElement('input');
+
+			input.type = 'radio';
+			input.disabled = true;
+
+			document.body.appendChild(input);
+
+			input.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			expect(input.checked).toBe(true);
+		});
+
+		it('Doesn\'t submit form if type is "submit" and the input is disabled.', () => {
+			const form = <HTMLFormElement>document.createElement('form');
+			const input = <HTMLInputElement>document.createElement('input');
+
+			let submitTriggeredCount = 0;
+			let clickCount = 0;
+
+			input.type = 'submit';
+			input.disabled = true;
+			input.addEventListener('click', () => clickCount++);
+
+			form.appendChild(input);
+
+			document.body.appendChild(form);
+
+			form.addEventListener('submit', () => submitTriggeredCount++);
+
+			input.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			expect(clickCount).toBe(1);
+			expect(submitTriggeredCount).toBe(0);
+		});
+
+		it('Doesn\'t reset form if type is "reset" and the input is disabled.', () => {
+			const form = <HTMLFormElement>document.createElement('form');
+			const input = <HTMLInputElement>document.createElement('input');
+
+			let resetTriggeredCount = 0;
+
+			input.type = 'reset';
+			input.disabled = true;
+
+			form.appendChild(input);
+
+			document.body.appendChild(form);
+
+			form.addEventListener('reset', () => resetTriggeredCount++);
+
+			input.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			expect(resetTriggeredCount).toBe(0);
+		});
+
 		it('Sets "checked" to "true" if type is "checkbox" and is a "click" event.', () => {
 			let isInputTriggered = false;
 			let isChangeTriggered = false;
@@ -1878,6 +1979,25 @@ describe('HTMLInputElement', () => {
 			button.click();
 
 			expect(resetTriggeredCount).toBe(1);
+		});
+	});
+
+	describe('click()', () => {
+		it('Doesn\'t dispatch a "click" event or run the activation behavior if the input is disabled.', () => {
+			const input = <HTMLInputElement>document.createElement('input');
+
+			let clickCount = 0;
+
+			input.type = 'checkbox';
+			input.disabled = true;
+			input.addEventListener('click', () => clickCount++);
+
+			document.body.appendChild(input);
+
+			input.click();
+
+			expect(clickCount).toBe(0);
+			expect(input.checked).toBe(false);
 		});
 	});
 });

--- a/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-label-element/HTMLLabelElement.test.ts
@@ -123,6 +123,26 @@ describe('HTMLLabelElement', () => {
 			expect(inputClickCount).toBe(1);
 		});
 
+		it("Doesn't dispatch a click event on the control element if it is disabled.", () => {
+			const input = <HTMLInputElement>document.createElement('input');
+			const span = document.createElement('span');
+
+			input.type = 'checkbox';
+			input.disabled = true;
+
+			span.appendChild(input);
+			element.appendChild(span);
+
+			let inputClickCount = 0;
+
+			input.addEventListener('click', () => inputClickCount++);
+
+			element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+			expect(inputClickCount).toBe(0);
+			expect(input.checked).toBe(false);
+		});
+
 		it('Supports MouseEvent.', () => {
 			const input = <HTMLInputElement>document.createElement('input');
 			const span = document.createElement('span');


### PR DESCRIPTION
### Description

Resolves #2190

A `click` dispatched with `dispatchEvent()` on a disabled `<button>` or `<input>` was dropped: `dispatchEvent()` returned `false` and no `click` listener ran.

`HTMLButtonElement.dispatchEvent()` and `HTMLInputElement.dispatchEvent()` returned early when the element was disabled, before `super.dispatchEvent()` had a chance to call the listeners.

The DOM standard has no disabled provision for [`dispatchEvent()`](https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent). The HTML standard only suppresses clicks that are ["queued on the user interaction task source"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled), and it is the [`click()`](https://html.spec.whatwg.org/multipage/interaction.html#dom-click) method that returns early for a disabled form control. This PR moves the disabled check from `dispatchEvent()` to `click()`.

```js
const button = document.createElement('button');
button.disabled = true;
button.addEventListener('click', () => console.log('clicked'));
document.body.appendChild(button);

button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
// Before: nothing logged, returns false
// After:  "clicked", returns true
```

**Changes**

- `HTMLElement.click()` doesn't dispatch a click event when the element is a disabled `button`, `input`, `optgroup`, `option`, `select` or `textarea`. Browsers dispatch the event for a disabled `fieldset`, so `fieldset` is not part of that list.
- `HTMLButtonElement.dispatchEvent()` and `HTMLInputElement.dispatchEvent()` call their listeners when the element is disabled. The checkbox and radio activation behavior still runs, because browsers toggle a disabled checkbox on a scripted click, but a disabled button or input doesn't submit or reset its form.
- `HTMLLabelElement.dispatchEvent()` doesn't forward the click to its control when the control is disabled. It relied on the suppression that this PR removes, so without this guard a label click would activate a disabled control.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

Every behavior in this PR was first run in the Chrome console, and the tests assert what Chrome does:

| Case | Listener | Returns | Activation |
| --- | --- | --- | --- |
| `dispatchEvent('click')` on a disabled `<button>` | ✅ | `true` | — |
| `dispatchEvent('click')` on a disabled `<input type="checkbox">` | ✅ | `true` | toggles, plus `input` and `change` |
| `dispatchEvent('click')` on a disabled submit button in a `<form>` | ✅ | `true` | no submission |
| `click()` on a disabled `<button>`, `<input>`, `<select>`, `<textarea>`, `<option>`, `<optgroup>` | ❌ | — | none |
| `click()` on a disabled `<fieldset>` | ✅ | — | — |
| Click on a `<label>` whose control is disabled | ❌ | — | none |

Tests were added to `HTMLElement.test.ts`, `HTMLButtonElement.test.ts`, `HTMLInputElement.test.ts` and `HTMLLabelElement.test.ts`. Six of them fail on `master` and pass with this change.

All 7641 tests in the `happy-dom` package pass. Two unrelated suites also fail on a clean `master` in my environment: one `@happy-dom/server-renderer` log assertion and the `@happy-dom/node-canvas-adapter` image snapshots.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

I used Claude to investigate the issue, write the code and write the tests. I reviewed the change and verified each behavior in Chrome myself.
