### PR TITLE
fix: [#2186] Batches requestAnimationFrame() callbacks into one task with a shared timestamp

### DIFF
--- a/packages/happy-dom/src/window/BrowserWindow.ts
+++ b/packages/happy-dom/src/window/BrowserWindow.ts
@@ -878,6 +878,9 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	#outerHeight: number | null = null;
 	#devicePixelRatio: number | null = null;
 	#zeroDelayTimeout: { timeouts: Array<Timeout> | null } = { timeouts: null };
+	#animationFrameCallbacks: Map<number, (timestamp: number) => void> = new Map();
+	#animationFrameHandle: number = 0;
+	#animationFrameImmediate: NodeJS.Immediate | null = null;
 	#timerLoopStacks: string[] = [];
 	#timerLoopLimits: ITimerLoopsLimit[] = [];
 
@@ -2619,12 +2622,13 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 	/**
 	 * Mock animation frames with timeouts.
 	 *
+	 * @see https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe
 	 * @param callback Callback.
-	 * @returns ID.
+	 * @returns Handle that can be sent to cancelAnimationFrame().
 	 */
-	public requestAnimationFrame(callback: (timestamp: number) => void): NodeJS.Immediate {
+	public requestAnimationFrame(callback: (timestamp: number) => void): number {
 		if (this.closed) {
-			return <NodeJS.Immediate>{};
+			return 0;
 		}
 		const settings = this.#browserFrame.page.context.browser.settings;
 
@@ -2641,7 +2645,7 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 						? 1
 						: (settings.timer.preventTimerLoops.requestAnimationFrame ?? 1))
 				) {
-					return <NodeJS.Immediate>{};
+					return 0;
 				}
 			} else {
 				timerLoopStacks.push(stack);
@@ -2652,44 +2656,71 @@ export default class BrowserWindow extends EventTarget implements INodeJSGlobal 
 			}
 		}
 
-		const useTryCatch =
-			!settings ||
-			(!settings.disableErrorCapturing &&
-				settings.errorCapture === BrowserErrorCaptureEnum.tryAndCatch);
-		const id = TIMER.setImmediate(() => {
-			// We need to call endImmediate() before the callback as the callback might throw an error.
-			this.#browserFrame[PropertySymbol.asyncTaskManager].endImmediate(id);
-			if (useTryCatch) {
-				let result: any;
-				try {
-					result = callback(this.performance.now());
-				} catch (error) {
-					this[PropertySymbol.dispatchError](<Error>error);
+		// All callbacks registered for the same frame are grouped into one immediate, as the specification
+		// requires "run the animation frame callbacks" to invoke every callback of a frame in one task.
+		// Grouping the callbacks also improves the performance of the async task manager.
+		// @see https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks
+		if (!this.#animationFrameImmediate) {
+			const animationFrameCallbacks = this.#animationFrameCallbacks;
+			const useTryCatch =
+				!settings ||
+				(!settings.disableErrorCapturing &&
+					settings.errorCapture === BrowserErrorCaptureEnum.tryAndCatch);
+
+			const id = TIMER.setImmediate(() => {
+				// We need to call endImmediate() before the callbacks as a callback might throw an error.
+				this.#browserFrame[PropertySymbol.asyncTaskManager].endImmediate(id);
+				this.#animationFrameImmediate = null;
+
+				// The specification requires all callbacks of a frame to be invoked with the same timestamp.
+				const timestamp = this.performance.now();
+
+				// The handles are read before the callbacks are invoked, so that a callback registered during
+				// the frame is invoked in the next frame instead of the current one.
+				for (const handle of [...animationFrameCallbacks.keys()]) {
+					const animationFrameCallback = animationFrameCallbacks.get(handle);
+
+					// The callback may have been canceled by an earlier callback in the same frame.
+					if (!animationFrameCallback) {
+						continue;
+					}
+
+					animationFrameCallbacks.delete(handle);
+
+					if (useTryCatch) {
+						let result: any;
+						try {
+							result = animationFrameCallback(timestamp);
+						} catch (error) {
+							this[PropertySymbol.dispatchError](<Error>error);
+						}
+						if (result instanceof Promise) {
+							result.catch((error: Error) => this[PropertySymbol.dispatchError](error));
+						}
+					} else {
+						animationFrameCallback(timestamp);
+					}
 				}
-				if (result instanceof Promise) {
-					result.catch((error: Error) => this[PropertySymbol.dispatchError](error));
-				}
-			} else {
-				callback(this.performance.now());
-			}
-		});
-		this.#browserFrame[PropertySymbol.asyncTaskManager].startImmediate(id);
-		return id;
+			});
+
+			this.#animationFrameImmediate = id;
+			this.#browserFrame[PropertySymbol.asyncTaskManager].startImmediate(id);
+		}
+
+		this.#animationFrameHandle++;
+		this.#animationFrameCallbacks.set(this.#animationFrameHandle, callback);
+
+		return this.#animationFrameHandle;
 	}
 
 	/**
 	 * Mock animation frames with timeouts.
 	 *
-	 * @param id ID.
+	 * @see https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-cancelanimationframe
+	 * @param handle Handle returned by requestAnimationFrame().
 	 */
-	public cancelAnimationFrame(id: NodeJS.Immediate): void {
-		// We need to make sure that the ID is an Immediate object, otherwise Node.js might throw an error.
-		// This is only necessary if we are in a Node.js environment.
-		if (IS_NODE_JS_TIMEOUT_ENVIRONMENT && (!id || id.constructor.name !== 'Immediate')) {
-			return;
-		}
-		TIMER.clearImmediate(id);
-		this.#browserFrame[PropertySymbol.asyncTaskManager].endImmediate(id);
+	public cancelAnimationFrame(handle: number): void {
+		this.#animationFrameCallbacks.delete(handle);
 	}
 
 	/**

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -1832,9 +1832,20 @@ describe('BrowserWindow', () => {
 	describe('requestAnimationFrame()', () => {
 		it('Requests an animation frame.', async () => {
 			await new Promise((resolve) => {
-				const timeoutId = window.requestAnimationFrame(resolve);
-				expect(timeoutId.constructor.name).toBe('Immediate');
+				const handle = window.requestAnimationFrame(resolve);
+				expect(typeof handle).toBe('number');
+				expect(handle).toBeGreaterThan(0);
 			});
+		});
+
+		it('Returns a new handle for each request.', () => {
+			const first = window.requestAnimationFrame(() => {});
+			const second = window.requestAnimationFrame(() => {});
+
+			expect(second).not.toBe(first);
+
+			window.cancelAnimationFrame(first);
+			window.cancelAnimationFrame(second);
 		});
 
 		it('Calls passed callback with current time', async () => {
@@ -1844,6 +1855,84 @@ describe('BrowserWindow', () => {
 					resolve(null);
 				});
 			});
+		});
+
+		it('Calls all callbacks registered for the same frame with the same timestamp.', async () => {
+			const timestamps: number[] = [];
+
+			await new Promise((resolve) => {
+				window.requestAnimationFrame((timestamp) => timestamps.push(timestamp));
+				window.requestAnimationFrame((timestamp) => {
+					timestamps.push(timestamp);
+					resolve(null);
+				});
+			});
+
+			expect(timestamps.length).toBe(2);
+			expect(timestamps[0]).toBe(timestamps[1]);
+		});
+
+		it('Calls all callbacks registered for the same frame in the same task.', async () => {
+			const order: string[] = [];
+
+			await new Promise((resolve) => {
+				window.requestAnimationFrame(() => {
+					order.push('first');
+					// A task queued during the frame can't be executed until the frame is complete.
+					window.setTimeout(() => order.push('timeout'), 0);
+				});
+				window.requestAnimationFrame(() => {
+					order.push('second');
+					window.setTimeout(() => resolve(null), 10);
+				});
+			});
+
+			expect(order).toEqual(['first', 'second', 'timeout']);
+		});
+
+		it('Calls a callback registered during a frame in the next frame.', async () => {
+			const order: string[] = [];
+			const timestamps: number[] = [];
+
+			await new Promise((resolve) => {
+				window.requestAnimationFrame((timestamp) => {
+					order.push('first');
+					timestamps.push(timestamp);
+					window.requestAnimationFrame((nextTimestamp) => {
+						order.push('third');
+						timestamps.push(nextTimestamp);
+						resolve(null);
+					});
+				});
+				window.requestAnimationFrame((timestamp) => {
+					order.push('second');
+					timestamps.push(timestamp);
+				});
+			});
+
+			expect(order).toEqual(['first', 'second', 'third']);
+			expect(timestamps[1]).toBe(timestamps[0]);
+			expect(timestamps[2]).toBeGreaterThan(timestamps[1]);
+		});
+
+		it('Calls the remaining callbacks of a frame when a callback throws an error.', async () => {
+			const order: string[] = [];
+			let errorEvent: ErrorEvent | null = null;
+
+			window.addEventListener('error', (event) => (errorEvent = <ErrorEvent>event));
+
+			await new Promise((resolve) => {
+				window.requestAnimationFrame(() => {
+					throw new window.Error('Test error');
+				});
+				window.requestAnimationFrame(() => {
+					order.push('second');
+					resolve(null);
+				});
+			});
+
+			expect(order).toEqual(['second']);
+			expect((<ErrorEvent>(<unknown>errorEvent)).error?.message).toBe('Test error');
 		});
 
 		it('Catches errors thrown in the callback.', async () => {
@@ -1941,14 +2030,50 @@ describe('BrowserWindow', () => {
 
 	describe('cancelAnimationFrame()', () => {
 		it('Cancels an animation frame.', () => {
-			const timeoutId = window.requestAnimationFrame(() => {
-				throw new Error('This timeout should have been canceled.');
+			const handle = window.requestAnimationFrame(() => {
+				throw new Error('This animation frame should have been canceled.');
 			});
-			window.cancelAnimationFrame(timeoutId);
+			window.cancelAnimationFrame(handle);
 		});
 
-		it('Supports number values.', () => {
-			window.cancelAnimationFrame(<NodeJS.Immediate>(<unknown>-1));
+		it('Cancels an animation frame without canceling the other callbacks of the frame.', async () => {
+			const order: string[] = [];
+
+			await new Promise((resolve) => {
+				const handle = window.requestAnimationFrame(() => {
+					throw new Error('This animation frame should have been canceled.');
+				});
+				window.requestAnimationFrame(() => {
+					order.push('second');
+					resolve(null);
+				});
+				window.cancelAnimationFrame(handle);
+			});
+
+			expect(order).toEqual(['second']);
+		});
+
+		it('Cancels an animation frame from a callback in the same frame.', async () => {
+			const order: string[] = [];
+
+			let handle = 0;
+
+			await new Promise((resolve) => {
+				window.requestAnimationFrame(() => {
+					order.push('first');
+					window.cancelAnimationFrame(handle);
+					window.requestAnimationFrame(() => resolve(null));
+				});
+				handle = window.requestAnimationFrame(() => {
+					throw new Error('This animation frame should have been canceled.');
+				});
+			});
+
+			expect(order).toEqual(['first']);
+		});
+
+		it('Ignores unknown handles.', () => {
+			window.cancelAnimationFrame(-1);
 		});
 	});
 


### PR DESCRIPTION
### Description

Resolves #2186

Each `requestAnimationFrame()` call scheduled its **own** `setImmediate()` and read `performance.now()` separately when it fired. Callbacks registered for the *same* frame therefore received **different timestamps** and were executed in **separate tasks**.

Browsers and jsdom (`pretendToBeVisual`) execute all callbacks of a frame in one "run the animation frame callbacks" pass with one shared timestamp.

```js
const window = new Window();

window.requestAnimationFrame((t) => timestamps.push(t));
window.requestAnimationFrame((t) => timestamps.push(t));

// Before → [111.000667, 111.013792]   two timestamps
// After  → [111.0,      111.0     ]   one timestamp (Chrome/Firefox/Safari and jsdom)
```

The callbacks of a frame are now collected in a map keyed by an integer handle and executed in **one** immediate with a **single** timestamp. The handles are read *before* the callbacks are invoked, so a callback registered *during* a frame is executed in the next frame. The existing `preventTimerLoops` and error capturing behavior is unchanged, and grouping the callbacks reduces the number of tasks the async task manager has to track.

#### ⚠️ Behavior change

`requestAnimationFrame()` now returns an **integer handle** instead of a `NodeJS.Immediate` object. A handle can no longer refer to a single immediate, because one immediate is shared by all callbacks of a frame. The integer is what the specification, browsers and jsdom return, and `cancelAnimationFrame(handle)` keeps working as before.

The only code that breaks is code that treats the return value as a Node.js `Immediate` object (for example `id.constructor.name` or `clearImmediate(id)`), which is not something a browser supports either. I titled this `fix:` because it makes the API behave like a browser, but please rename the title to `BREAKING CHANGE:` if you prefer it released as one.

#### Known difference from browsers

Browsers perform a microtask checkpoint *between* the callbacks of a frame, because each callback is invoked with an empty JavaScript stack. This implementation invokes them in a synchronous loop, so a microtask queued by the first callback runs after the last callback of the frame instead of before the second one. jsdom has the same behavior. Tasks (such as `setTimeout()`) correctly cannot interleave, which is the part that was broken before.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

Every added test was run in the Chrome console first, and the assertions match what Chrome does:

| Test | Chrome |
| --- | --- |
| Calls all callbacks registered for the same frame with the same timestamp. | `sameFrameSameTimestamp: true` |
| Calls all callbacks registered for the same frame in the same task. | `["raf1", "raf2", "timeout-from-raf1"]` |
| Calls a callback registered during a frame in the next frame. | `["a", "b", "c (next frame)"]`, later timestamp |
| Calls the remaining callbacks of a frame when a callback throws an error. | `["before-error", "after-error"]` |
| Cancels an animation frame from a callback in the same frame. | `["first"]` |

The three timestamp and task related tests fail on `master` and pass with this change.

`npm test` passes for `packages/happy-dom` (7635 tests), `@happy-dom/jest-environment` and `@happy-dom/global-registrator`. Two suites fail on my machine **both with and without this change**, so they look unrelated to it: `@happy-dom/node-canvas-adapter` (9 image snapshot mismatches) and `@happy-dom/server-renderer` (a Chalk color code mismatch in "Handles result with page errors").

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

Claude Code wrote the implementation and the tests from the analysis in #2186, and verified each test against Chrome. I reviewed the result.
