### PR TITLE
fix: Mirror named element properties to the global object when registered globally

### DIFF
--- a/packages/@happy-dom/global-registrator/test/node/GlobalRegistrator.test.ts
+++ b/packages/@happy-dom/global-registrator/test/node/GlobalRegistrator.test.ts
@@ -114,6 +114,22 @@ describe('GlobalRegistrator', () => {
 		});
 	});
 
+	it('Exposes named element properties on the global object', () => {
+		GlobalRegistrator.register();
+
+		document.body.innerHTML = `<button id="foo"></button><div id="baz"></div>`;
+
+		assert.strictEqual(typeof (<any>globalThis).foo, 'object');
+		assert.strictEqual((<any>globalThis).foo, document.getElementById('foo'));
+		assert.strictEqual((<any>globalThis).baz instanceof <any>globalThis.HTMLElement, true);
+
+		// Removing the element should drop the named property from the global object.
+		(<any>globalThis).baz.remove();
+		assert.strictEqual(typeof (<any>globalThis).baz, 'undefined');
+
+		GlobalRegistrator.unregister();
+	});
+
 	describe('unregister()', () => {
 		it('Restores properties and getters after unregistering', () => {
 			GlobalRegistrator.register();

--- a/packages/happy-dom/src/nodes/element/Element.ts
+++ b/packages/happy-dom/src/nodes/element/Element.ts
@@ -1743,6 +1743,13 @@ export default class Element
 		// To make sure we use the proxy we can check for the proxy property
 		const element = this[PropertySymbol.proxy] || this;
 
+		// When the window is registered globally (e.g. via @happy-dom/global-registrator), the
+		// global object itself should also expose named properties, like a browser does. We
+		// detect this by checking that the window's own `window` property points to the global
+		// object (which the GlobalRegistrator sets up).
+		const globalTarget =
+			<any>window !== globalThis && (<any>window).window === globalThis ? globalThis : null;
+
 		entry.elements.push(element);
 
 		if (entry.elements.length > 1) {
@@ -1761,6 +1768,12 @@ export default class Element
 			(entry.htmlCollection !== null && (<any>window)[id] === entry.htmlCollection)
 		) {
 			(<any>window)[id] = element;
+		}
+
+		// Mirror the named property onto the global object so that bare identifiers and
+		// `window.foo` resolve to the element, like in a browser.
+		if (globalTarget) {
+			(<any>globalTarget)[id] = (<any>window)[id];
 		}
 	}
 
@@ -1791,6 +1804,11 @@ export default class Element
 		// HTMLFormElement and HTMLSelectElement can be a proxy, but the scope can be the target and not the actual proxy
 		// To make sure we use the proxy we can check for the proxy property
 		const element = this[PropertySymbol.proxy] || this;
+
+		// Same global detection as in addIdentifierToWindow.
+		const globalTarget =
+			<any>window !== globalThis && (<any>window).window === globalThis ? globalThis : null;
+
 		const index = entry.elements.indexOf(element);
 
 		if (index !== -1) {
@@ -1808,6 +1826,15 @@ export default class Element
 
 			if ((<any>window)[id] === element || (<any>window)[id] === entry.htmlCollection) {
 				delete (<any>window)[id];
+			}
+		}
+
+		// Mirror the removal back onto the global object.
+		if (globalTarget) {
+			if ((<any>window)[id] !== undefined) {
+				(<any>globalTarget)[id] = (<any>window)[id];
+			} else {
+				delete (<any>globalTarget)[id];
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

When a window is registered globally via `@happy-dom/global-registrator`'s `registerGlobals()` (i.e. `GlobalRegistrator.register()`), the **global object does not receive the element-id named properties** that the happy-dom `Window` does.

This means browser-style test code like:

```js
GlobalRegistrator.register();
document.body.innerHTML = `<button id="foo"></button><div id="baz"></div>`;

// In a real browser this refers to the <button id="foo"> element.
foo.onclick = () => {
  baz.append(Object.assign(document.createElement('div'), { id: 'qux' }));
  console.log(typeof qux); // expected "object"
};
```

fails because `foo` / `window.foo` / `qux` resolve to `undefined` / throw `ReferenceError`.

### Root cause

happy-dom implements named access for elements in `Element.ts`:

- `[PropertySymbol.addIdentifierToWindow](id)` → `window[id] = element`
- `[PropertySymbol.removeIdentifierFromWindow](id)` → `delete window[id]`

These write to the **actual `Window` object** (`this[PropertySymbol.window]`).

`GlobalRegistrator.register()` copies the window's static properties to `globalThis` once, but the named element properties are **created dynamically** as elements are added. So they never land on `globalThis`. Additionally, the registrator aliases `window` / `document.defaultView` to `globalThis`, which makes the real Window object that received the named properties effectively unreachable through `window.foo`.

### Fix

Mirror the named properties onto the **global object** too, but only when the `Window` is the active global (detected by `<any>window.window === globalThis`, which the `GlobalRegistrator` sets up). Detached windows created with `new Window()` keep their existing behaviour and are **not** polluted.

Changes in `packages/happy-dom/src/nodes/element/Element.ts`:

- In `[PropertySymbol.addIdentifierToWindow]`, after writing `window[id]`, also write `globalThis[id]` when the window is the active global.
- In `[PropertySymbol.removeIdentifierFromWindow]`, mirror the removal (or update) back onto `globalThis`.

### Verification

- `Element.test.ts`: **193 passed** (no regression).
- `@happy-dom/global-registrator` `test:node`: new regression test **"Exposes named element properties on the global object"** passes. The remaining Angular failure is a pre-existing environment issue and is unrelated to this change (reproduced without this patch).

### Test added

`packages/@happy-dom/global-registrator/test/node/GlobalRegistrator.test.ts` — verifies that after `register()`, `globalThis.foo` / `globalThis.baz` resolve to the elements, and that removing an element drops the named property from the global object.
