### PR TITLE
fix: [#2227] Treat an out of range index in HTMLSelectElement.add() a…

### DIFF
--- a/packages/happy-dom/src/nodes/html-select-element/HTMLSelectElement.ts
+++ b/packages/happy-dom/src/nodes/html-select-element/HTMLSelectElement.ts
@@ -573,46 +573,36 @@ export default class HTMLSelectElement extends HTMLElement {
 	/**
 	 * Adds new option to options collection.
 	 *
+	 * @see https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-add
 	 * @param element HTMLOptionElement to add.
 	 * @param before HTMLOptionElement or index number.
 	 */
 	public add(element: HTMLOptionElement, before?: number | HTMLOptionElement): void {
 		const options = QuerySelector.querySelectorAll(this, 'option')[PropertySymbol.items];
-
-		if (!before && before !== 0) {
-			const childNodes = this[PropertySymbol.nodeArray];
-
-			while (childNodes.length) {
-				this[PropertySymbol.removeChild](childNodes[0]);
-			}
-
-			for (const option of options) {
-				this[PropertySymbol.appendChild](option);
-			}
-
-			this[PropertySymbol.appendChild](element);
-
-			return;
-		}
-
 		const window = this[PropertySymbol.window];
 
-		if (typeof before !== 'number') {
-			if (!(before instanceof HTMLOptionElement)) {
-				throw new window.DOMException(
-					"Failed to execute 'add' on 'HTMLFormElement': The node before which the new node is to be inserted before is not an 'HTMLOptionElement'."
-				);
+		// An index of -1 means that the element should be appended at the end.
+		let referenceIndex = -1;
+
+		if (before || before === 0) {
+			if (typeof before !== 'number') {
+				if (!(before instanceof HTMLOptionElement)) {
+					throw new window.DOMException(
+						"Failed to execute 'add' on 'HTMLFormElement': The node before which the new node is to be inserted before is not an 'HTMLOptionElement'."
+					);
+				}
+
+				referenceIndex = options.indexOf(<HTMLOptionElement>before);
+
+				if (referenceIndex === -1) {
+					throw new window.DOMException(
+						"Failed to execute 'add' on 'HTMLFormElement': The node before which the new node is to be inserted before is not a child of this node."
+					);
+				}
+			} else if (options[before]) {
+				// An index that doesn't match an option is treated as "null", which appends the element.
+				referenceIndex = before;
 			}
-
-			before = options.indexOf(<HTMLOptionElement>before);
-		}
-
-		const optionsElement = options[before];
-
-		if (!optionsElement) {
-			throw new window.DOMException(
-				"Failed to execute 'add' on 'HTMLFormElement': The node before which the new node is to be inserted before is not a child of this node."
-			);
 		}
 
 		const childNodes = this[PropertySymbol.nodeArray];
@@ -622,10 +612,14 @@ export default class HTMLSelectElement extends HTMLElement {
 		}
 
 		for (let i = 0, max = options.length; i < max; i++) {
-			if (i === before) {
+			if (i === referenceIndex) {
 				this[PropertySymbol.appendChild](element);
 			}
 			this[PropertySymbol.appendChild](options[i]);
+		}
+
+		if (referenceIndex === -1) {
+			this[PropertySymbol.appendChild](element);
 		}
 	}
 

--- a/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-select-element/HTMLSelectElement.test.ts
@@ -518,6 +518,54 @@ describe('HTMLSelectElement', () => {
 			expect(element.options[1] === option3).toBe(true);
 			expect(element.options[2] === option2).toBe(true);
 		});
+
+		it('Appends the option when the index is out of range.', () => {
+			const option1 = <HTMLOptionElement>document.createElement('option');
+			const option2 = <HTMLOptionElement>document.createElement('option');
+
+			element.add(option1);
+			element.add(option2, 2);
+
+			expect(element.length).toBe(2);
+			expect(element.children.length).toBe(2);
+			expect(element.options.length).toBe(2);
+			expect(element[0] === option1).toBe(true);
+			expect(element[1] === option2).toBe(true);
+			expect(element.children[0] === option1).toBe(true);
+			expect(element.children[1] === option2).toBe(true);
+			expect(element.options[0] === option1).toBe(true);
+			expect(element.options[1] === option2).toBe(true);
+		});
+
+		it('Appends the option when the index is negative.', () => {
+			const option1 = <HTMLOptionElement>document.createElement('option');
+			const option2 = <HTMLOptionElement>document.createElement('option');
+
+			element.add(option1);
+			element.add(option2, -1);
+
+			expect(element.options.length).toBe(2);
+			expect(element.options[0] === option1).toBe(true);
+			expect(element.options[1] === option2).toBe(true);
+		});
+
+		it('Appends the option when the index is out of range and the select is empty.', () => {
+			const option1 = <HTMLOptionElement>document.createElement('option');
+
+			element.add(option1, 0);
+
+			expect(element.options.length).toBe(1);
+			expect(element.options[0] === option1).toBe(true);
+		});
+
+		it('Throws an exception when the option element to insert before is not a child of the select element.', () => {
+			const option1 = <HTMLOptionElement>document.createElement('option');
+			const option2 = <HTMLOptionElement>document.createElement('option');
+
+			expect(() => element.add(option1, option2)).toThrow(
+				"Failed to execute 'add' on 'HTMLFormElement': The node before which the new node is to be inserted before is not a child of this node."
+			);
+		});
 	});
 
 	describe(`item()`, () => {


### PR DESCRIPTION
### Description

`HTMLSelectElement.add(element, before)` threw a `DOMException` when `before` was a number that did not match any option in the select:

```js
document.body.innerHTML = '<select><option>A</option></select>';
const select = document.querySelector('select');

select.add(document.createElement('option'), 2); // index 2 does not exist
// Before: throws DOMException
// After:  appended
```

Per the [HTML specification](https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmloptionscollection-add), when `before` is an integer and there is no item with that index in the collection, the reference node becomes `null`, which appends the element. Browsers and jsdom append in this case.

The element is now appended when `before` is an index that is out of range or negative. Passing an `HTMLOptionElement` that is not a child of the select still throws, as before — the specification only makes the *integer* form fall back to `null`, and a non-descendant element node is still an error.

Resolves #2227

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

Four tests were added to the `add()` describe block, covering an out of range index, a negative index, an out of range index on an empty select, and the existing throw for an option element that is not a child. Three of them fail on `master` and pass with this change.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

Claude Code was used to assist with this change. I reviewed the specification behaviour, ran the test suite locally, and verified that the added tests fail on `master` before submitting.
