### PR TITLE
fix: [#2306] Return an ArrayBuffer as XMLHttpRequest response for res…

### DIFF
--- a/packages/happy-dom/src/xml-http-request/XMLHttpRequestResponseDataParser.ts
+++ b/packages/happy-dom/src/xml-http-request/XMLHttpRequestResponseDataParser.ts
@@ -33,7 +33,7 @@ export default class XMLHttpRequestResponseDataParser {
 				const newAB = new ArrayBuffer(options.data.length);
 				const view = new Uint8Array(newAB);
 				view.set(options.data);
-				return view;
+				return newAB;
 			case XMLHttpResponseTypeEnum.blob:
 				try {
 					return new options.window.Blob([new Uint8Array(options.data)], {

--- a/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
+++ b/packages/happy-dom/test/xml-http-request/XMLHttpRequest.test.ts
@@ -161,6 +161,7 @@ describe('XMLHttpRequest', () => {
 				request.open('GET', REQUEST_URL, true);
 
 				request.addEventListener('load', () => {
+					expect(request.response instanceof ArrayBuffer).toBe(true);
 					expect(responseText).toBe(new TextDecoder().decode(<ArrayBuffer>request.response));
 					resolve(null);
 				});


### PR DESCRIPTION
### Description

`XMLHttpRequestResponseDataParser.parse()` allocated an `ArrayBuffer`, copied the response data into a `Uint8Array` view of it, and then returned the view instead of the buffer:

```js
const request = new XMLHttpRequest();
request.responseType = 'arraybuffer';
request.open('GET', '/some/path', true);
request.addEventListener('load', () => {
  request.response instanceof ArrayBuffer; // false, was a Uint8Array
});
request.send();
```

As a result, `XMLHttpRequest.response` was a `Uint8Array` when `responseType` was set to `"arraybuffer"`. This broke code that checks `response instanceof ArrayBuffer` or passes the response to APIs expecting an `ArrayBuffer`.

Note that `parse()` already declared `ArrayBuffer` in its return type, so the implementation contradicted its own signature. TypeScript did not catch this because `Uint8Array` is assignable to the `object` member of that union.

The buffer is now returned, as defined by the [XMLHttpRequest specification](https://xhr.spec.whatwg.org/#the-response-attribute) and as implemented in browsers.

Resolves #2306

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

Rather than adding a new test, the existing one was strengthened. It was already named "Returns ArrayBuffer when `responseType` is set to `arrayBuffer`", but never asserted the type — `TextDecoder.decode()` accepts both an `ArrayBuffer` and a `Uint8Array`, so it passed either way. It now asserts the response type, fails on `master`, and passes with this change.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

Claude Code was used to assist with this change. I reviewed the specification behaviour, ran the test suite locally, and verified that the strengthened test fails on `master` before submitting.
