### PR TITLE
fix: [#2356] Ignore null and undefined when setting input.files

### DIFF
--- a/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
+++ b/packages/happy-dom/src/nodes/html-input-element/HTMLInputElement.ts
@@ -145,6 +145,9 @@ export default class HTMLInputElement extends HTMLElement {
 	 * @param files Files.
 	 */
 	public set files(files: FileList) {
+		if (files === null || files === undefined || this.type !== 'file') {
+			return;
+		}
 		this[PropertySymbol.files] = files;
 	}
 

--- a/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-input-element/HTMLInputElement.test.ts
@@ -3,6 +3,7 @@ import type Document from '../../../src/nodes/document/Document.js';
 import type HTMLInputElement from '../../../src/nodes/html-input-element/HTMLInputElement.js';
 import DOMException from '../../../src/exception/DOMException.js';
 import File from '../../../src/file/File.js';
+import FileList from '../../../src/nodes/html-input-element/FileList.js';
 import Event from '../../../src/event/Event.js';
 import HTMLInputElementSelectionModeEnum from '../../../src/nodes/html-input-element/HTMLInputElementSelectionModeEnum.js';
 import HTMLInputElementSelectionDirectionEnum from '../../../src/nodes/html-input-element/HTMLInputElementSelectionDirectionEnum.js';
@@ -93,6 +94,31 @@ describe('HTMLInputElement', () => {
 			element.type = 'file';
 			element.files.push(file);
 			expect(element.value).toBe('/fake/path/filename.jpg');
+		});
+	});
+
+	describe('set files()', () => {
+		it('Ignores null.', () => {
+			element.type = 'file';
+			element.files = <FileList>(<unknown>null);
+			expect(element.files.length).toBe(0);
+			expect(element.value).toBe('');
+		});
+
+		it('Ignores undefined.', () => {
+			element.type = 'file';
+			element.files = <FileList>(<unknown>undefined);
+			expect(element.files.length).toBe(0);
+			expect(element.value).toBe('');
+		});
+
+		it('Ignores setting files when type is not "file".', () => {
+			const file = new File(['TEST'], 'filename.jpg');
+			element.type = 'file';
+			element.files.push(file);
+			element.type = 'text';
+			element.files = <FileList>(<unknown>new FileList());
+			expect(element.files.length).toBe(1);
 		});
 	});
 


### PR DESCRIPTION
Setting `input.files = null` (or `undefined`) on a file input is stored as-is, so reading `.value` afterwards throws. Per spec these assignments are no-ops, and browsers keep the existing `FileList` — this also matches jsdom, which ignores the write when the input isn't a file type.

The setter now returns early for null/undefined and for non-file inputs. Added tests covering both cases.

Closes #2356