### PR TITLE
fix: [#2355] Strip leading BOM when decoding Blob text

### DIFF
--- a/packages/happy-dom/src/file/Blob.ts
+++ b/packages/happy-dom/src/file/Blob.ts
@@ -134,7 +134,7 @@ export default class Blob {
 	 * @returns Text.
 	 */
 	public async text(): Promise<string> {
-		return this[PropertySymbol.buffer].toString();
+		return new TextDecoder().decode(this[PropertySymbol.buffer]);
 	}
 
 	/**

--- a/packages/happy-dom/test/file/Blob.test.ts
+++ b/packages/happy-dom/test/file/Blob.test.ts
@@ -56,6 +56,18 @@ describe('Blob', () => {
 		});
 	});
 
+	describe('text()', () => {
+		it('Returns the text content of the blob.', async () => {
+			const blob = new Blob(['TEST']);
+			expect(await blob.text()).toBe('TEST');
+		});
+
+		it('Strips a leading BOM.', async () => {
+			const blob = new Blob(['\uFEFFState,Name']);
+			expect(await blob.text()).toBe('State,Name');
+		});
+	});
+
 	describe('toString()', () => {
 		it('Returns "[object Blob]".', () => {
 			const blob = new Blob(['TEST']);


### PR DESCRIPTION
Per the File API spec, `Blob.text()` runs UTF-8 decode, which removes a leading byte order mark. happy-dom used `Buffer.toString()`, which keeps the BOM, so a string round-tripped through a Blob came back one character longer than in browsers, jsdom or Node's own `Blob`.

Switched `text()` to `TextDecoder` (already used by `FileReader.readAsText()`), which strips the BOM. Added a regression test.

Closes #2355