### PR TITLE
fix: respect step bases when validating number and range inputs

### DIFF
--- a/packages/happy-dom/src/validity-state/ValidityState.ts
+++ b/packages/happy-dom/src/validity-state/ValidityState.ts
@@ -8,6 +8,8 @@ import type ShadowRoot from '../nodes/shadow-root/ShadowRoot.js';
 import type HTMLObjectElement from '../nodes/html-object-element/HTMLObjectElement.js';
 import type HTMLOutputElement from '../nodes/html-output-element/HTMLOutputElement.js';
 
+// Match the entire attribute, including rejecting trailing line breaks.
+const FLOATING_POINT_NUMBER_REGEXP = /^-?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?(?![\s\S])/;
 const EMAIL_REGEXP =
 	/^([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x22([^\x0d\x22\x5c\x80-\xff]|\x5c[\x00-\x7f])*\x22)(\x2e([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x22([^\x0d\x22\x5c\x80-\xff]|\x5c[\x00-\x7f])*\x22))*\x40([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x5b([^\x0d\x5b-\x5d\x80-\xff]|\x5c[\x00-\x7f])*\x5d)(\x2e([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x5b([^\x0d\x5b-\x5d\x80-\xff]|\x5c[\x00-\x7f])*\x5d))*$/;
 const URL_REGEXP =
@@ -118,22 +120,49 @@ export default class ValidityState {
 	}
 
 	/**
-	 * Returns validity.
+	 * Checks number and range increments when {@link HTMLInputElement} validates a field.
 	 *
-	 * @returns "true" if valid.
+	 * @see https://html.spec.whatwg.org/multipage/input.html#concept-input-step-base
+	 * @returns Whether the value is outside the permitted step increments.
+	 * @example input.min = '0.2'; input.value = '1.2'; input.validity.stepMismatch; // false
 	 */
 	public get stepMismatch(): boolean {
-		return (
-			this.element[PropertySymbol.localName] === 'input' &&
-			(this.element.type === 'number' || this.element.type === 'range') &&
-			((this.element.hasAttribute('step') &&
-				this.element.getAttribute('step') !== 'any' &&
-				Number((<HTMLInputElement>this.element).value) %
-					Number(this.element.getAttribute('step')) !==
-					0) ||
-				(!this.element.hasAttribute('step') &&
-					Number((<HTMLInputElement>this.element).value) % 1 !== 0))
-		);
+		if (
+			this.element[PropertySymbol.localName] !== 'input' ||
+			(this.element.type !== 'number' && this.element.type !== 'range')
+		) {
+			return false;
+		}
+
+		const input = <HTMLInputElement>this.element;
+		const stepAttribute = input.step;
+		const value = Number(input.value);
+
+		if (input.value === '' || !Number.isFinite(value) || stepAttribute.toLowerCase() === 'any') {
+			return false;
+		}
+
+		const minimum = FLOATING_POINT_NUMBER_REGEXP.test(input.min) ? Number(input.min) : NaN;
+		const valueAttribute = input.getAttribute('value') || '';
+		const defaultValue = FLOATING_POINT_NUMBER_REGEXP.test(valueAttribute)
+			? Number(valueAttribute)
+			: NaN;
+		const parsedStep = FLOATING_POINT_NUMBER_REGEXP.test(stepAttribute)
+			? Number(stepAttribute)
+			: NaN;
+		const step = Number.isFinite(parsedStep) && parsedStep > 0 ? parsedStep : 1;
+
+		// A valid min takes precedence over the initial value, including when min is zero.
+		const stepBase = Number.isFinite(minimum)
+			? minimum
+			: Number.isFinite(defaultValue)
+				? defaultValue
+				: 0;
+		const nearestValue = stepBase + Math.round((value - stepBase) / step) * step;
+
+		// Allow floating-point rounding when comparing with the nearest permitted value.
+		const tolerance = Number.EPSILON * Math.max(Math.abs(value), Math.abs(stepBase), step);
+		return Math.abs(value - nearestValue) > tolerance;
 	}
 
 	/**

--- a/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
@@ -16,7 +16,7 @@ import type File from '../../../src/file/File.js';
 import type HTMLElement from '../../../src/nodes/html-element/HTMLElement.js';
 import type HTMLIFrameElement from '../../../src/nodes/html-iframe-element/HTMLIFrameElement.js';
 import type BrowserWindow from '../../../src/window/BrowserWindow.js';
-import { beforeEach, describe, it, test, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import type THTMLFormControlElement from '../../../src/nodes/html-form-element/THTMLFormControlElement.js';
 import type HTMLOutputElement from '../../../src/nodes/html-output-element/HTMLOutputElement.js';
 import * as PropertySymbol from '../../../src/PropertySymbol.js';
@@ -1034,7 +1034,7 @@ describe('HTMLFormElement', () => {
 	});
 
 	describe('requestSubmit()', () => {
-		test('Submits a decimal number after its value attribute is synchronized with an edit.', () => {
+		it('Submits a decimal number after its value attribute is synchronized with an edit.', () => {
 			// Arrange
 			const input = document.createElement('input');
 			input.type = 'number';

--- a/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
+++ b/packages/happy-dom/test/nodes/html-form-element/HTMLFormElement.test.ts
@@ -16,7 +16,7 @@ import type File from '../../../src/file/File.js';
 import type HTMLElement from '../../../src/nodes/html-element/HTMLElement.js';
 import type HTMLIFrameElement from '../../../src/nodes/html-iframe-element/HTMLIFrameElement.js';
 import type BrowserWindow from '../../../src/window/BrowserWindow.js';
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, test, expect, vi } from 'vitest';
 import type THTMLFormControlElement from '../../../src/nodes/html-form-element/THTMLFormControlElement.js';
 import type HTMLOutputElement from '../../../src/nodes/html-output-element/HTMLOutputElement.js';
 import * as PropertySymbol from '../../../src/PropertySymbol.js';
@@ -1034,6 +1034,27 @@ describe('HTMLFormElement', () => {
 	});
 
 	describe('requestSubmit()', () => {
+		test('Submits a decimal number after its value attribute is synchronized with an edit.', () => {
+			// Arrange
+			const input = document.createElement('input');
+			input.type = 'number';
+			input.defaultValue = '1';
+			input.name = 'quantity';
+			element.appendChild(input);
+			document.body.appendChild(element);
+			const submitListener = vi.fn((event: Event) => event.preventDefault());
+			element.addEventListener('submit', submitListener);
+
+			// Act
+			input.value = '1.01';
+			input.defaultValue = input.value;
+			element.requestSubmit();
+
+			// Assert
+			expect(submitListener).toHaveBeenCalledTimes(1);
+			expect(new window.FormData(element).get('quantity')).toBe('1.01');
+		});
+
 		it('Validates form and triggers a "submit" event when valid.', () => {
 			element.innerHTML = `
                 <div>

--- a/packages/happy-dom/test/validity-state/ValidityState.test.ts
+++ b/packages/happy-dom/test/validity-state/ValidityState.test.ts
@@ -1,7 +1,7 @@
 import Window from '../../src/window/Window.js';
 import type Document from '../../src/nodes/document/Document.js';
 import type HTMLInputElement from '../../src/nodes/html-input-element/HTMLInputElement.js';
-import { beforeEach, describe, it, test, expect } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 
 describe('ValidityState', () => {
 	let window: Window;
@@ -143,7 +143,7 @@ describe('ValidityState', () => {
 
 	describe('get stepMismatch()', () => {
 		describe.each(['number', 'range'])('"%s" input step bases', (type) => {
-			test.each([
+			it.each([
 				['the value attribute', '', '1.01', '', '1.01'],
 				['increments from the value attribute', '', '1.01', '', '2.01'],
 				['increments from min', '1', '', '2', '3'],
@@ -168,7 +168,7 @@ describe('ValidityState', () => {
 			});
 		});
 
-		test.each(['', 'invalid', '+1', ' 1', '1\n', '1\r', '1.', '0x1', 'Infinity', '1e309'])(
+		it.each(['', 'invalid', '+1', ' 1', '1\n', '1\r', '1.', '0x1', 'Infinity', '1e309'])(
 			'Falls back to the value attribute when min="%s" is not a valid number.',
 			(min) => {
 				// Arrange
@@ -185,7 +185,7 @@ describe('ValidityState', () => {
 			}
 		);
 
-		test.each(['', 'invalid', '+1', ' 1', '1\n', '1\r', '1.', '0x1', 'Infinity', '1e309'])(
+		it.each(['', 'invalid', '+1', ' 1', '1\n', '1\r', '1.', '0x1', 'Infinity', '1e309'])(
 			'Uses a zero base when value="%s" is not a valid number.',
 			(defaultValue) => {
 				// Arrange
@@ -202,7 +202,7 @@ describe('ValidityState', () => {
 			}
 		);
 
-		test.each(['', '0', '-2', 'invalid', '2x', ' 2', '2\n', '2\r', '0x2'])(
+		it.each(['', '0', '-2', 'invalid', '2x', ' 2', '2\n', '2\r', '0x2'])(
 			'Uses the default step when step="%s" does not specify a positive number.',
 			(step) => {
 				// Arrange
@@ -218,7 +218,7 @@ describe('ValidityState', () => {
 			}
 		);
 
-		test.each(['any', 'ANY', 'Any'])('Allows fractional values with step="%s".', (step) => {
+		it.each(['any', 'ANY', 'Any'])('Allows fractional values with step="%s".', (step) => {
 			// Arrange
 			const input = document.createElement('input');
 			input.type = 'number';
@@ -231,7 +231,7 @@ describe('ValidityState', () => {
 			expect(input.validity.stepMismatch).toBe(false);
 		});
 
-		test('Does not apply a fractional step base to an empty number input.', () => {
+		it('Does not apply a fractional step base to an empty number input.', () => {
 			// Arrange
 			const input = document.createElement('input');
 			input.type = 'number';
@@ -244,7 +244,7 @@ describe('ValidityState', () => {
 			expect(input.validity.stepMismatch).toBe(false);
 		});
 
-		test.each(['0.11', '0.30001'])(
+		it.each(['0.11', '0.30001'])(
 			'Rejects %s when it is not aligned with the fractional value-attribute base.',
 			(value) => {
 				// Arrange

--- a/packages/happy-dom/test/validity-state/ValidityState.test.ts
+++ b/packages/happy-dom/test/validity-state/ValidityState.test.ts
@@ -1,7 +1,7 @@
 import Window from '../../src/window/Window.js';
 import type Document from '../../src/nodes/document/Document.js';
 import type HTMLInputElement from '../../src/nodes/html-input-element/HTMLInputElement.js';
-import { beforeEach, describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, test, expect } from 'vitest';
 
 describe('ValidityState', () => {
 	let window: Window;
@@ -142,6 +142,125 @@ describe('ValidityState', () => {
 	});
 
 	describe('get stepMismatch()', () => {
+		describe.each(['number', 'range'])('"%s" input step bases', (type) => {
+			test.each([
+				['the value attribute', '', '1.01', '', '1.01'],
+				['increments from the value attribute', '', '1.01', '', '2.01'],
+				['increments from min', '1', '', '2', '3'],
+				['min before the value attribute', '1', '0', '2', '3'],
+				['a zero min before the value attribute', '0', '1', '2', '2'],
+				['fractional increments from min', '1', '', '0.1', '1.1'],
+				['fractional increments from the value attribute', '', '0.1', '0.2', '0.3'],
+				['a scientific-notation base', '', '1e-2', '0.1', '0.11']
+			])('Accepts values aligned with %s.', (_description, min, defaultValue, step, value) => {
+				// Arrange
+				const input = document.createElement('input');
+				input.type = type;
+				input.min = min;
+				input.defaultValue = defaultValue;
+				input.step = step;
+
+				// Act
+				input.value = value;
+
+				// Assert
+				expect(input.validity.stepMismatch).toBe(false);
+			});
+		});
+
+		test.each(['', 'invalid', '+1', ' 1', '1\n', '1\r', '1.', '0x1', 'Infinity', '1e309'])(
+			'Falls back to the value attribute when min="%s" is not a valid number.',
+			(min) => {
+				// Arrange
+				const input = document.createElement('input');
+				input.type = 'number';
+				input.min = min;
+				input.defaultValue = '1.5';
+
+				// Act
+				input.value = '2.5';
+
+				// Assert
+				expect(input.validity.stepMismatch).toBe(false);
+			}
+		);
+
+		test.each(['', 'invalid', '+1', ' 1', '1\n', '1\r', '1.', '0x1', 'Infinity', '1e309'])(
+			'Uses a zero base when value="%s" is not a valid number.',
+			(defaultValue) => {
+				// Arrange
+				const input = document.createElement('input');
+				input.type = 'number';
+				input.defaultValue = defaultValue;
+				input.step = '2';
+
+				// Act
+				input.value = '2';
+
+				// Assert
+				expect(input.validity.stepMismatch).toBe(false);
+			}
+		);
+
+		test.each(['', '0', '-2', 'invalid', '2x', ' 2', '2\n', '2\r', '0x2'])(
+			'Uses the default step when step="%s" does not specify a positive number.',
+			(step) => {
+				// Arrange
+				const input = document.createElement('input');
+				input.type = 'number';
+				input.step = step;
+
+				// Act
+				input.value = '3';
+
+				// Assert
+				expect(input.validity.stepMismatch).toBe(false);
+			}
+		);
+
+		test.each(['any', 'ANY', 'Any'])('Allows fractional values with step="%s".', (step) => {
+			// Arrange
+			const input = document.createElement('input');
+			input.type = 'number';
+			input.step = step;
+
+			// Act
+			input.value = '1.01';
+
+			// Assert
+			expect(input.validity.stepMismatch).toBe(false);
+		});
+
+		test('Does not apply a fractional step base to an empty number input.', () => {
+			// Arrange
+			const input = document.createElement('input');
+			input.type = 'number';
+			input.min = '0.5';
+
+			// Act
+			input.value = '';
+
+			// Assert
+			expect(input.validity.stepMismatch).toBe(false);
+		});
+
+		test.each(['0.11', '0.30001'])(
+			'Rejects %s when it is not aligned with the fractional value-attribute base.',
+			(value) => {
+				// Arrange
+				const input = document.createElement('input');
+				input.type = 'number';
+				input.defaultValue = '0.1';
+				input.step = '0.2';
+
+				// Act
+				input.value = value;
+
+				// Assert
+				expect(input.validity.stepMismatch).toBe(true);
+			}
+		);
+
 		it('Returns "true" if a "number" input field has "step" set to a non-steppable value.', () => {
 			const input = <HTMLInputElement>document.createElement('input');
 


### PR DESCRIPTION
### Description

Valid decimal number inputs can incorrectly fail constraint validation and prevent `form.requestSubmit()` from firing a `submit` event. When the current value and the `value` attribute are both `1.01`, the default step of `1` is valid relative to the step base of `1.01`. The current implementation instead checks `1.01 % 1` and reports a step mismatch.

This also affects controlled number inputs that synchronize the `value` attribute after an edit. The form regression test reproduces that sequence using the DOM API, without a framework dependency:

```js
const form = document.createElement('form');
const input = document.createElement('input');
input.type = 'number';
input.defaultValue = '1';
form.appendChild(input);
document.body.appendChild(form);

let submissions = 0;
form.addEventListener('submit', event => {
  event.preventDefault();
  submissions++;
});

input.value = '1.01';
input.defaultValue = input.value;
form.requestSubmit();

console.log(input.validity.stepMismatch, submissions);
// Chrome: false, 1
// Happy DOM before this fix: true, 0
```

The fix applies the [HTML step-base rules](https://html.spec.whatwg.org/multipage/input.html#concept-input-step-base) to number and range inputs: valid `min`, then a valid `value` attribute, then zero. It also handles invalid/non-positive steps, case-insensitive `any`, empty values, and floating-point rounding when checking fractional increments.

Added 52 regression cases across validity and form submission tests. They cover attribute precedence, fractional and scientific-notation bases, malformed attributes, and values that must still be rejected. Of the 134 tests in the two affected files, 36 fail against the unmodified implementation.

Validation on Node.js 24.20.0 / macOS:

- `npm run compile`: passed.
- `npm test --workspace happy-dom`: 302 test files / 7,771 tests passed.
- ESLint with the repository's `.eslintrc.cjs`: passed with zero warnings. Command: `ESLINT_USE_FLAT_CONFIG=false npm run lint -- --no-eslintrc --config .eslintrc.cjs --no-cache` (to isolate this checkout from a parent directory's ESLint config).
- `npm exec -- turbo run test:circular-dependencies`: passed.
- All added scenarios were checked against Chrome 152 using Playwright: 53 assertions passed, including the submit event and submitted decimal value.
- Root `npm test` was also run. The global-registrator, jest-environment, and server-renderer tests pass. The canvas-adapter suite has 9 image snapshot failures on this machine; the identical 9 tests also fail when built from unmodified upstream `eac5a38026b0569f2d52b609b2bb4cbaa94d9644`. No snapshot changes are included.

Upstream CI: [the latest run](https://github.com/capricorn86/happy-dom/actions/runs/33994884065) for commit `723c8c5420cfc4401c42cee6a878d4880141dce7` passes all jobs on Node.js 20, 22, and 24, including compile, lint, the complete test suites, and circular-dependency checks. All canvas-adapter tests pass in this Linux CI environment.

No existing issue is linked; the reproduction and investigation are included here.

AI assistance: OpenAI Codex was used to investigate the bug, implement the fix, run validation, and prepare this PR at the request of @ryota-murakami.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [ ] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR. (Run; the pre-existing canvas snapshot failures are documented above.)

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.

