### PR TITLE
fix: [#2366] Invalidate the computed style cache for the whole subtree

### DIFF
--- a/packages/happy-dom/src/css/declaration/computed-style/CSSComputedStyle.ts
+++ b/packages/happy-dom/src/css/declaration/computed-style/CSSComputedStyle.ts
@@ -24,6 +24,7 @@ import type CSSStyleSheet from '../../CSSStyleSheet.js';
 import CSSVariableFormatter from '../property-manager/utilities/CSSVariableFormatter.js';
 import type HTMLElement from '../../../nodes/html-element/HTMLElement.js';
 import type Node from '../../../nodes/node/Node.js';
+import type ICachedComputedStyleResult from '../../../nodes/node/ICachedComputedStyleResult.js';
 
 const CSS_MEASUREMENT_REGEXP = /[0-9.]+(px|rem|em|vw|vh|%|vmin|vmax|cm|mm|in|pt|pc|Q)/g;
 
@@ -275,8 +276,11 @@ export default class CSSComputedStyle {
 					}
 				}
 
-				const cachedResult = {
-					result: new WeakRef(propertyManager)
+				const cachedResult: ICachedComputedStyleResult = {
+					result: new WeakRef(propertyManager),
+					parent: previousParent
+						? previousParent.element![PropertySymbol.cache].computedStyle
+						: null
 				};
 				parentElement.element![PropertySymbol.cache].computedStyle = cachedResult;
 				parentElement.element![PropertySymbol.ownerDocument][
@@ -492,6 +496,24 @@ export default class CSSComputedStyle {
 		if (!node) {
 			return null;
 		}
-		return node[PropertySymbol.cache].computedStyle?.result?.deref() || null;
+
+		const cachedResult = node[PropertySymbol.cache].computedStyle;
+
+		if (!cachedResult?.result) {
+			return null;
+		}
+
+		// A computed style contains the inherited properties of every ancestor it was computed from,
+		// so it goes stale as soon as any of those ancestors is invalidated.
+		let ancestor = cachedResult.parent;
+
+		while (ancestor) {
+			if (!ancestor.result) {
+				return null;
+			}
+			ancestor = ancestor.parent;
+		}
+
+		return cachedResult.result.deref() || null;
 	}
 }

--- a/packages/happy-dom/src/css/declaration/computed-style/CSSComputedStyle.ts
+++ b/packages/happy-dom/src/css/declaration/computed-style/CSSComputedStyle.ts
@@ -24,7 +24,6 @@ import type CSSStyleSheet from '../../CSSStyleSheet.js';
 import CSSVariableFormatter from '../property-manager/utilities/CSSVariableFormatter.js';
 import type HTMLElement from '../../../nodes/html-element/HTMLElement.js';
 import type Node from '../../../nodes/node/Node.js';
-import type ICachedComputedStyleResult from '../../../nodes/node/ICachedComputedStyleResult.js';
 
 const CSS_MEASUREMENT_REGEXP = /[0-9.]+(px|rem|em|vw|vh|%|vmin|vmax|cm|mm|in|pt|pc|Q)/g;
 
@@ -175,9 +174,9 @@ export default class CSSComputedStyle {
 		const cssVariables: { [k: string]: string } = {};
 		let rootFontSize: string | number = 16;
 		let parentFontSize: string | number = 16;
-		let previousParent: IStyleAndElement | null = null;
 
-		for (const parentElement of parentElements) {
+		for (let i = 0, max = parentElements.length; i < max; i++) {
+			const parentElement = parentElements[i];
 			if (parentElement.propertyManager) {
 				if (parentElement.element === this.element) {
 					return parentElement.propertyManager;
@@ -276,28 +275,30 @@ export default class CSSComputedStyle {
 					}
 				}
 
-				const cachedResult: ICachedComputedStyleResult = {
-					result: new WeakRef(propertyManager),
-					parent: previousParent
-						? previousParent.element![PropertySymbol.cache].computedStyle
-						: null
+				const cachedResult = {
+					result: new WeakRef(propertyManager)
 				};
 				parentElement.element![PropertySymbol.cache].computedStyle = cachedResult;
 				parentElement.element![PropertySymbol.ownerDocument][
 					PropertySymbol.affectsComputedStyleCache
 				].push(cachedResult);
-				previousParent?.element![PropertySymbol.affectsCache].push(cachedResult);
-				if ((<Element>previousParent?.element)?.shadowRoot) {
-					(<Element>previousParent!.element).shadowRoot![PropertySymbol.affectsCache].push(
-						cachedResult
-					);
+
+				// All parents of current element affects cache
+				for (let a = 0; a < i; a++) {
+					const previousParent = parentElements[a];
+					previousParent.element![PropertySymbol.affectsCache].push(cachedResult);
+					if ((<Element>previousParent.element)?.shadowRoot) {
+						(<Element>previousParent!.element).shadowRoot![PropertySymbol.affectsCache].push(
+							cachedResult
+						);
+					}
 				}
+
 				if (parentElement.element === this.element) {
 					return propertyManager;
 				}
 			}
 
-			previousParent = parentElement;
 			propertyManager = inheritedPropertyManager.clone();
 		}
 
@@ -496,24 +497,6 @@ export default class CSSComputedStyle {
 		if (!node) {
 			return null;
 		}
-
-		const cachedResult = node[PropertySymbol.cache].computedStyle;
-
-		if (!cachedResult?.result) {
-			return null;
-		}
-
-		// A computed style contains the inherited properties of every ancestor it was computed from,
-		// so it goes stale as soon as any of those ancestors is invalidated.
-		let ancestor = cachedResult.parent;
-
-		while (ancestor) {
-			if (!ancestor.result) {
-				return null;
-			}
-			ancestor = ancestor.parent;
-		}
-
-		return cachedResult.result.deref() || null;
+		return node[PropertySymbol.cache].computedStyle?.result?.deref() || null;
 	}
 }

--- a/packages/happy-dom/src/nodes/node/ICachedComputedStyleResult.ts
+++ b/packages/happy-dom/src/nodes/node/ICachedComputedStyleResult.ts
@@ -3,4 +3,5 @@ import type ICachedResult from './ICachedResult.js';
 
 export default interface ICachedComputedStyleResult extends ICachedResult {
 	result: WeakRef<CSSPropertyManager> | null;
+	parent: ICachedComputedStyleResult | null;
 }

--- a/packages/happy-dom/src/nodes/node/ICachedComputedStyleResult.ts
+++ b/packages/happy-dom/src/nodes/node/ICachedComputedStyleResult.ts
@@ -3,5 +3,4 @@ import type ICachedResult from './ICachedResult.js';
 
 export default interface ICachedComputedStyleResult extends ICachedResult {
 	result: WeakRef<CSSPropertyManager> | null;
-	parent: ICachedComputedStyleResult | null;
 }

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -716,7 +716,7 @@ describe('BrowserWindow', () => {
 
 			const ids = ['d0', 'd1', 'd2', 'd3', 'd4'];
 			const color = (id: string): string =>
-				window.getComputedStyle(<Element>document.getElementById(id)).color;
+				window.getComputedStyle(document.getElementById(id)!).color;
 
 			expect(ids.map(color)).toEqual([
 				'rgb(255, 0, 0)',
@@ -726,7 +726,7 @@ describe('BrowserWindow', () => {
 				'rgb(255, 0, 0)'
 			]);
 
-			(<Element>document.getElementById('d0')).classList.remove('red');
+			document.getElementById('d0')!.classList.remove('red');
 
 			expect(ids.map(color)).toEqual(['', '', '', '', '']);
 

--- a/packages/happy-dom/test/window/BrowserWindow.test.ts
+++ b/packages/happy-dom/test/window/BrowserWindow.test.ts
@@ -709,6 +709,38 @@ describe('BrowserWindow', () => {
 			expect(computedStyle.color).toBe('green');
 		});
 
+		it('Updates inherited values in the whole subtree when an ancestor is changed.', () => {
+			document.head.innerHTML = '<style>.red { color: rgb(255, 0, 0); }</style>';
+			document.body.innerHTML =
+				'<div id="d0" class="red"><div id="d1"><div id="d2"><div id="d3"><span id="d4">Test</span></div></div></div></div>';
+
+			const ids = ['d0', 'd1', 'd2', 'd3', 'd4'];
+			const color = (id: string): string =>
+				window.getComputedStyle(<Element>document.getElementById(id)).color;
+
+			expect(ids.map(color)).toEqual([
+				'rgb(255, 0, 0)',
+				'rgb(255, 0, 0)',
+				'rgb(255, 0, 0)',
+				'rgb(255, 0, 0)',
+				'rgb(255, 0, 0)'
+			]);
+
+			(<Element>document.getElementById('d0')).classList.remove('red');
+
+			expect(ids.map(color)).toEqual(['', '', '', '', '']);
+
+			(<HTMLElement>document.getElementById('d2')).style.color = 'rgb(0, 128, 0)';
+
+			expect(ids.map(color)).toEqual([
+				'',
+				'',
+				'rgb(0, 128, 0)',
+				'rgb(0, 128, 0)',
+				'rgb(0, 128, 0)'
+			]);
+		});
+
 		it('Returns a CSSStyleDeclaration object with computed styles from style sheets.', () => {
 			const parent = document.createElement('div');
 			const element = document.createElement('span');


### PR DESCRIPTION
### Description

A cached computed style holds the inherited properties of every ancestor it was computed from, but since #2358 only the mutated element and its direct children are invalidated, so anything deeper keeps stale inherited values.

`CSSComputedStyle` registers each element's cached result on its direct parent's `affectsCache`, and `Node[PropertySymbol.clearCache]()` clears the node's own `cache.computedStyle` plus that `affectsCache`. Between them, invalidation reaches exactly one level down.

Each cached result now records the ancestor result it inherited from:

```ts
export default interface ICachedComputedStyleResult extends ICachedResult {
	result: WeakRef<CSSPropertyManager> | null;
	parent: ICachedComputedStyleResult | null;
}
```

and `getCachedPropertyManager()` walks that chain, refusing a cached result if any ancestor result it was derived from has been invalidated. Nothing is added to the invalidation path, so there is no subtree walk on mutation; the extra cost is following a few pointers on a cache read.

Resolves #2366

The change and its test were written with Claude Code, and reviewed and verified by me before submitting.

<!-- PLEASE DON*T DELETE THIS CHECKLIST -->

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### Title

- [x] The title of the pull request should be in the format of "type: [#issue] description". The type can be `feat`, `fix`, `chore` or `BREAKING CHANGE`. The issue is optional and can be omitted if the pull request does not relate to an issue.
- [x] The title should be concise and descriptive. The title will be used when generating release notes. Make sure that the title is easily understood by users of the library.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.
