### PR TITLE
fix: [#2344] Resolve every var() in a value, not only the first one

### DIFF
--- a/packages/happy-dom/src/css/declaration/property-manager/utilities/CSSVariableFormatter.ts
+++ b/packages/happy-dom/src/css/declaration/property-manager/utilities/CSSVariableFormatter.ts
@@ -66,7 +66,8 @@ export default class CSSVariableFormatter {
 			if (variable && variable.parentheses === parentheses) {
 				const fallbackValue = value.substring(variable.fallbackIndex, match.index).trim();
 				const variableValue = cssVariables[variable.name];
-				return `${value.substring(0, variable.index)}${this.resolveVariables(variableValue || fallbackValue, cssVariables)}${value.substring(match.index! + match[0].length)}`;
+				// The rest of the value may hold further var() references (e.g. "calc(var(--a) + var(--b))").
+				return `${value.substring(0, variable.index)}${this.resolveVariables(variableValue || fallbackValue, cssVariables)}${this.resolveVariables(value.substring(match.index! + match[0].length), cssVariables)}`;
 			}
 		}
 

--- a/packages/happy-dom/test/css/declaration/computed-style/CSSComputedStyle.test.ts
+++ b/packages/happy-dom/test/css/declaration/computed-style/CSSComputedStyle.test.ts
@@ -98,6 +98,32 @@ describe('CSSComputedStyle', () => {
 			expect(propertyManager.get('background-color')?.value).toBe('rgb(255, 219, 0)');
 		});
 
+		it('Resolves every var() in a value, not only the first one.', () => {
+			document.body.appendChild(element);
+			element.setAttribute(
+				'style',
+				`--box: 20px; --gap: 2px; width: calc(5 * var(--box) + 6 * var(--gap)); height: calc(var(--gap) + var(--gap));`
+			);
+
+			const computedStyle = new CSSComputedStyle(element);
+			const propertyManager = computedStyle.getComputedStyle();
+
+			expect(propertyManager.get('width')?.value).toBe('calc(5 * 20px + 6 * 2px)');
+			expect(propertyManager.get('height')?.value).toBe('calc(2px + 2px)');
+		});
+
+		it('Resolves var() with fallback after an earlier var() in a shorthand value.', () => {
+			document.body.appendChild(element);
+			element.setAttribute('style', `--x: 16px; margin: var(--x) var(--x, 4px) var(--y, 8px);`);
+
+			const computedStyle = new CSSComputedStyle(element);
+			const propertyManager = computedStyle.getComputedStyle();
+
+			expect(propertyManager.get('margin-top')?.value).toBe('16px');
+			expect(propertyManager.get('margin-right')?.value).toBe('16px');
+			expect(propertyManager.get('margin-bottom')?.value).toBe('8px');
+		});
+
 		it('Ignores invalid CSS variable fallback value.', () => {
 			document.body.appendChild(element);
 			element.setAttribute('style', `width: var(--my-width, invalid);`);


### PR DESCRIPTION
### Description

Since v20.12.1 `CSSVariableFormatter.resolveVariables()` substitutes the first `var()` it finds and returns, leaving the rest of the value untouched. `calc(5 * var(--box) + 6 * var(--gap))` computes to `calc(5 * 20px + 6 * var(--gap))`, and a shorthand such as `padding: calc(0.375 * var(--x)) calc(0.75 * var(--x))` fails validation and is dropped from `getComputedStyle()` together with its longhands.

The remainder of the value is now passed through `resolveVariables()` as well, so every `var()` is substituted; nested fallbacks are unchanged. Browsers substitute all occurrences at computed-value time (Chromium returns the resolved length, as noted in #2351).

Resolves #2344
Resolves #2351

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] References issues discussed ahead of time (#2344, #2351).
- [x] Allow edits by maintainers.

### Tests

- [x] Two tests in `CSSComputedStyle.test.ts`: a `calc()` with two variables (and the same variable twice), and a shorthand with `var()` fallbacks after an earlier `var()`. Both fail on master and pass with the fix.
- [x] `npm test` run locally; the only failures are pre-existing Windows-environment tests (virtual server, module loader, timers, file cache) that fail identically on master.

### AI tools

- [x] Written with Claude Code (Anthropic), reviewed and verified by the submitter.