### PR TITLE
fix: [#2407] End comments at the first comment end tag when it overlaps a comment start tag

### DIFF
--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -292,6 +292,9 @@ export default class HTMLParser {
 
 					if (match[4]) {
 						this.parseComment(html.substring(this.startTagIndex, match.index));
+					} else if (match[3]) {
+						// The "--" can be part of the end tag (e.g. "<!-->").
+						this.markupRegExp.lastIndex -= 2;
 					}
 					break;
 				case MarkupReadStateEnum.documentType:

--- a/packages/happy-dom/test/html-parser/HTMLParser.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.test.ts
@@ -123,6 +123,42 @@ describe('HTMLParser', () => {
 			expect((<HTMLElement>result.childNodes[0]).id).toBe('æøåÆØÅ');
 		});
 
+		it('Parses comments containing "<!--" in their data.', () => {
+			const result = new HTMLParser(window).parse(
+				'<!--[if !mso]><!--><div>hello</div><!--<![endif]-->'
+			);
+
+			expect(result.childNodes.length).toBe(3);
+			expect(result.childNodes[0].nodeType).toBe(NodeTypeEnum.commentNode);
+			expect(result.childNodes[0].textContent).toBe('[if !mso]><!');
+			expect((<HTMLElement>result.childNodes[1]).tagName).toBe('DIV');
+			expect(result.childNodes[1].textContent).toBe('hello');
+			expect(result.childNodes[2].nodeType).toBe(NodeTypeEnum.commentNode);
+			expect(result.childNodes[2].textContent).toBe('<![endif]');
+
+			expect(new HTMLSerializer().serializeToString(result)).toBe(
+				'<!--[if !mso]><!--><div>hello</div><!--<![endif]-->'
+			);
+		});
+
+		it('Ends comments at the first comment close sequence.', () => {
+			const result = new HTMLParser(window).parse('<!--a<!--b-->c');
+
+			expect(result.childNodes.length).toBe(2);
+			expect(result.childNodes[0].nodeType).toBe(NodeTypeEnum.commentNode);
+			expect(result.childNodes[0].textContent).toBe('a<!--b');
+			expect(result.childNodes[1].textContent).toBe('c');
+		});
+
+		it('Ends comments at "--!>" when it overlaps a comment start tag.', () => {
+			const result = new HTMLParser(window).parse('<!--a<!--!>b');
+
+			expect(result.childNodes.length).toBe(2);
+			expect(result.childNodes[0].nodeType).toBe(NodeTypeEnum.commentNode);
+			expect(result.childNodes[0].textContent).toBe('a<!');
+			expect(result.childNodes[1].textContent).toBe('b');
+		});
+
 		it('Parses an entire HTML page.', () => {
 			const html = `
 	<!DOCTYPE html>


### PR DESCRIPTION
### Description

Comments were never terminated when the comment end tag overlapped a comment start tag (as in the downlevel-revealed conditional comments used in HTML email markup), which silently dropped the rest of the document. The markup regexp matched the inner comment start tag while in the comment read state, moving the scan position past the two hyphens that belonged to the end tag. The parser now resumes the scan at those hyphens, so the end tag is detected and the comment is terminated where a browser terminates it.

Tests cover the conditional comment case from the issue, the alternative end tag, and that comments still end at the first end tag when a comment start tag appears earlier in the data.

AI disclosure: I used Claude Code to help validate the fix and the tests. I have reviewed the changes and verified the behavior against the HTML specification and a real browser.

Resolves #2407

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.