### PR TITLE
fix: [#2409] Preserve character references in comment data

### DIFF
--- a/packages/happy-dom/src/html-parser/HTMLParser.ts
+++ b/packages/happy-dom/src/html-parser/HTMLParser.ts
@@ -690,9 +690,7 @@ export default class HTMLParser {
 	 * @param comment Comment.
 	 */
 	private parseComment(comment: string): void {
-		const commentNode = this.rootDocument!.createComment(
-			XMLEncodeUtility.decodeHTMLEntities(comment)
-		);
+		const commentNode = this.rootDocument!.createComment(comment);
 
 		if (this.documentStructure) {
 			const level = this.documentStructure.level;

--- a/packages/happy-dom/test/html-parser/HTMLParser.test.ts
+++ b/packages/happy-dom/test/html-parser/HTMLParser.test.ts
@@ -2294,5 +2294,16 @@ describe('HTMLParser', () => {
 			const result5 = new HTMLParser(window).parse(`<div data-foo="&apos;"></div>`);
 			expect(new HTMLSerializer().serializeToString(result5)).toBe(`<div data-foo="'"></div>`);
 		});
+
+		it('Does not decode character references in comment data.', () => {
+			const result = new HTMLParser(window).parse('<div><!--&lt;3 &#60;3 &#x3C;3 --&gt; --></div>');
+			const comment = result.childNodes[0].childNodes[0];
+
+			expect(comment.nodeType).toBe(NodeTypeEnum.commentNode);
+			expect(comment.textContent).toBe('&lt;3 &#60;3 &#x3C;3 --&gt; ');
+			expect(new HTMLSerializer().serializeToString(result)).toBe(
+				'<div><!--&lt;3 &#60;3 &#x3C;3 --&gt; --></div>'
+			);
+		});
 	});
 });


### PR DESCRIPTION
### Description

Comment data was run through entity decoding when parsing, while serialization outputs comment data verbatim. Since comment data is raw text per the HTML specification, parsing and serializing a document changed its markup, and an escaped comment end tag inside a comment became a real one in the output. The parser now stores comment data as written.

AI disclosure: I used Claude Code to help validate the fix and the tests. I have reviewed the changes and verified the behavior against the HTML specification and a real browser.

Resolves #2409

### Before submitting the PR, please make sure you do the following:

- [x] Read the [contributing guidelines](https://github.com/capricorn86/happy-dom/blob/master/CONTRIBUTING.md).
- [x] It's really useful if your PR references an issue where it is discussed ahead of time.
- [x] Please check [Allow edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to make review process faster. Note that this option is not available for repositories that are owned by Github organizations.

### Tests

- [x] Make sure to add tests for your changes. Run your test in a real browser to make sure that the test tests what a real browser would do (e.g. by running the code in the browser console).
- [x] Run the tests with `npm test` locally to make sure that all tests pass before submitting the PR.

### AI tools

- [x] Please disclose in the PR description that you used AI tools to generate code. This is important for transparency and to ensure that the generated code meets the quality standards of the project.